### PR TITLE
Implement governed Analyst data and UI handoff

### DIFF
--- a/docs/ANALYST-SAFE-LANGUAGE.md
+++ b/docs/ANALYST-SAFE-LANGUAGE.md
@@ -100,6 +100,18 @@ Approved wording for log-derived evidence:
 
 Do not return unrestricted raw logs, secret-bearing logs, full deploy/destroy transcripts, or arbitrary KQL results. If a requested log query does not match an approved template, fail closed and ask the operator to use an approved log view or Azure SRE Agent portal workflow.
 
+### Governed AKS-derived evidence
+
+Local Analyst may use AKS state only through governed query names approved by [Local Analyst Governance](LOCAL-ANALYST-GOVERNANCE.md). These queries are read-only, allowlisted, timeout-bounded, and citation-producing. They expose Kubernetes state observations for the `energy` namespace; they do not grant write, exec, port-forward, secret, remediation, deploy, destroy, patch, restart, or scale access.
+
+Approved wording for AKS-derived evidence:
+
+> Source: governed AKS query `{queryName}` scoped to the `energy` namespace, collected at `{collectedAt}`. Local Analyst can summarize observed Kubernetes state, but it cannot claim root cause or remediation certainty without Azure SRE Agent or operator evidence.
+
+For `node-capacity`, include the scope caveat:
+
+> Source: governed AKS query `node-capacity`, collected at `{collectedAt}`. This query includes cluster-level node capacity only to interpret `energy` namespace pod allocation. It does not grant write, exec, secret, or remediation access, and Local Analyst cannot infer root cause or remediation certainty from capacity data alone.
+
 ## Approved and prohibited phrases
 
 ### Approved phrases

--- a/docs/LOCAL-ANALYST-GOVERNANCE.md
+++ b/docs/LOCAL-ANALYST-GOVERNANCE.md
@@ -65,6 +65,23 @@ Every future governed-read tool must be:
 
 The governed-read layer still must not expose arbitrary shell, unrestricted `az`, unrestricted `kubectl`, filesystem reads, secret access, arbitrary KQL, write/remediation operations, or direct Azure SRE Agent Preview API automation.
 
+### Implemented governed-read endpoints
+
+Mission Control backend exposes the following Local Analyst read endpoints. They are designed as evidence-producing data APIs for Analyst summaries, not remediation APIs.
+
+| Endpoint | Allowlist | Scope | Failure behavior |
+|----------|-----------|-------|------------------|
+| `GET /api/analyst/aks/:queryName` | `pod-resources`, `node-capacity`, `deployment-replicas`, `namespace-events`, `service-endpoints-health` | `energy` namespace; `node-capacity` also reads cluster nodes to summarize capacity for `energy` pod allocation | Unknown query names fail closed with `400`; kubectl errors return unavailable metadata and no inferred state |
+| `GET /api/analyst/logs/:templateName` | `pod-restarts-lifecycle`, `service-log-excerpts`, `application-exceptions-errors` | Configured Log Analytics workspace; `energy` namespace where Kubernetes tables include namespace fields | Unknown/freeform KQL and unknown parameters fail closed with `400`; timeout returns unavailable rather than partial guesses |
+
+The Log Analytics layer only builds canned KQL from validated parameters:
+
+- `pod-restarts-lifecycle`: recent restart and non-running lifecycle signals from `KubePodInventory`.
+- `service-log-excerpts`: bounded, redacted `ContainerLogV2` excerpts for a validated service or pod over a bounded time window.
+- `application-exceptions-errors`: bounded exception/error signals from workspace-backed Application Insights tables where present; requires a validated service filter to avoid broad workspace reads.
+
+Each successful response includes source, collection timestamp, limitations, confidence, workspace or namespace citation, time range where applicable, row count where applicable, and explicit partial-result behavior.
+
 ### Denied tool categories
 
 | Category | Examples | Required behavior |

--- a/mission-control/backend/.env.example
+++ b/mission-control/backend/.env.example
@@ -9,5 +9,8 @@ LOG_LEVEL=info
 # Kubernetes
 KUBE_NAMESPACE=energy
 
+# Governed Log Analytics / Application Insights read templates
+# LOG_ANALYTICS_WORKSPACE_ID=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<workspace>
+
 # Repo root (auto-detected if not set)
 # REPO_ROOT=/path/to/azure-sre-agent-energy-grid

--- a/mission-control/backend/package.json
+++ b/mission-control/backend/package.json
@@ -7,7 +7,8 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "node --test --import tsx \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@fastify/cors": "^10.0.0",

--- a/mission-control/backend/src/routes/analyst.ts
+++ b/mission-control/backend/src/routes/analyst.ts
@@ -1,0 +1,132 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { ALLOWED_AKS_ANALYST_QUERIES, AnalystKubeQueryService } from '../services/AnalystKubeQueryService.js';
+import { configuredWorkspaceId, LogAnalyticsQueryError, LogAnalyticsQueryService, normalizeLogAnalyticsRequest } from '../services/LogAnalyticsQueryService.js';
+import { KubeClientError, KubeInputError } from '../services/KubeClient.js';
+
+const aksQueries = new AnalystKubeQueryService();
+const logAnalytics = new LogAnalyticsQueryService();
+const ENERGY_NAMESPACE = 'energy' as const;
+const DEFAULT_LOG_ANALYTICS_MINUTES = 30;
+const DEFAULT_LOG_ANALYTICS_TIMEOUT_MS = 15_000;
+const LOG_SOURCE = 'Azure Monitor Log Analytics query via governed canned template';
+const AKS_SOURCE = `kubectl get (read-only) against namespace '${ENERGY_NAMESPACE}'`;
+
+export function registerAnalystRoutes(app: FastifyInstance): void {
+  app.get<{ Params: { queryName: string } }>('/api/analyst/aks/:queryName', async (req, reply) => {
+    try {
+      return reply.send(await aksQueries.execute(req.params.queryName));
+    } catch (err) {
+      return sendAksAnalystError(reply, req.params.queryName, err);
+    }
+  });
+
+  app.get<{ Params: { templateName: string }; Querystring: Record<string, unknown> }>('/api/analyst/logs/:templateName', async (req, reply) => {
+    try {
+      return reply.send(await logAnalytics.execute(req.params.templateName, req.query));
+    } catch (err) {
+      return sendLogAnalystError(reply, req.params.templateName, req.query, err);
+    }
+  });
+}
+
+function sendAksAnalystError(reply: FastifyReply, queryName: string, err: unknown) {
+  if (err instanceof KubeInputError) {
+    return reply.status(400).send(buildAksErrorResponse(queryName, err.message, 'denied'));
+  }
+
+  if (err instanceof KubeClientError) {
+    return reply.status(err.statusCode).send(buildAksErrorResponse(queryName, err.message, 'unavailable'));
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  return reply.status(500).send(buildAksErrorResponse(queryName, message, 'unavailable'));
+}
+
+function sendLogAnalystError(
+  reply: FastifyReply,
+  templateName: string,
+  query: Record<string, unknown>,
+  err: unknown,
+) {
+  if (err instanceof KubeInputError) {
+    return reply.status(400).send(buildLogAnalyticsErrorResponse(templateName, query, err.message, 'denied'));
+  }
+
+  if (err instanceof LogAnalyticsQueryError) {
+    return reply.status(err.statusCode).send(buildLogAnalyticsErrorResponse(templateName, query, err.message, 'unavailable'));
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  return reply.status(500).send(buildLogAnalyticsErrorResponse(templateName, query, message, 'unavailable'));
+}
+
+export function buildAksErrorResponse(queryName: string, error: string, status: 'denied' | 'unavailable') {
+  const limitations = status === 'denied'
+    ? ['Local Analyst uses an explicit AKS query allowlist and rejects unknown, broad, secret, or write-like requests.']
+    : ['No inference is made from missing, timed-out, or unavailable governed AKS data.'];
+
+  return {
+    error,
+    queryName,
+    namespace: ENERGY_NAMESPACE,
+    status,
+    data: [],
+    metadata: {
+      source: AKS_SOURCE,
+      collectedAt: new Date().toISOString(),
+      limitations,
+      confidence: 'none',
+      status,
+      allowedVerb: 'get',
+      allowlist: [...ALLOWED_AKS_ANALYST_QUERIES],
+    },
+  };
+}
+
+export function buildLogAnalyticsErrorResponse(
+  templateName: string,
+  query: Record<string, unknown>,
+  error: string,
+  status: 'denied' | 'unavailable',
+) {
+  const normalized = tryNormalizeLogAnalyticsRequest(templateName, query);
+  const now = new Date();
+  const minutes = normalized?.minutes ?? DEFAULT_LOG_ANALYTICS_MINUTES;
+  const timeoutMs = normalized?.timeoutMs ?? DEFAULT_LOG_ANALYTICS_TIMEOUT_MS;
+  const from = new Date(now.getTime() - minutes * 60_000);
+  const limitations = status === 'denied'
+    ? ['Local Analyst uses canned Log Analytics templates only; unknown templates, freeform KQL, workspace overrides, and invalid parameters are rejected.']
+    : ['No inference is made from missing, timed-out, or unavailable governed Log Analytics data.'];
+
+  return {
+    error,
+    templateName,
+    workspace: configuredWorkspaceId() ?? 'not configured',
+    status,
+    timeRange: {
+      from: from.toISOString(),
+      to: now.toISOString(),
+      minutes,
+    },
+    rowCount: 0,
+    rows: [],
+    metadata: {
+      source: LOG_SOURCE,
+      collectedAt: new Date().toISOString(),
+      limitations,
+      confidence: 'none',
+      status,
+      partial: false,
+      timeoutMs,
+      partialBehavior: 'Partial or timed-out query results are not accepted as complete evidence; Local Analyst must treat this response as unavailable or denied.',
+    },
+  };
+}
+
+function tryNormalizeLogAnalyticsRequest(templateName: string, query: Record<string, unknown>) {
+  try {
+    return normalizeLogAnalyticsRequest(templateName, query);
+  } catch {
+    return undefined;
+  }
+}

--- a/mission-control/backend/src/server.ts
+++ b/mission-control/backend/src/server.ts
@@ -14,6 +14,7 @@ import { registerPodRoutes } from './routes/pods.js';
 import { registerScenarioRoutes } from './routes/scenarios.js';
 import { registerAssistantRoutes } from './routes/assistant.js';
 import { registerPortalValidationRoutes } from './routes/portal-validations.js';
+import { registerAnalystRoutes } from './routes/analyst.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = 3333;
@@ -79,6 +80,7 @@ async function start() {
   registerScenarioRoutes(app);
   registerAssistantRoutes(app, jobManager);
   registerPortalValidationRoutes(app);
+  registerAnalystRoutes(app);
 
   // SPA fallback — must be after API routes
   if (existsSync(frontendDist)) {

--- a/mission-control/backend/src/services/AnalystKubeQueryService.test.ts
+++ b/mission-control/backend/src/services/AnalystKubeQueryService.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AnalystKubeQueryService, assertAllowedAksQuery, assertReadOnlyKubectlArgs, parseCpuMillicores, parseMemoryBytes } from './AnalystKubeQueryService.js';
+import { KubeInputError } from './KubeClient.js';
+import type { AnalystPodResourceState } from '../types/index.js';
+import { buildAksErrorResponse } from '../routes/analyst.js';
+
+test('AKS analyst query allowlist fails closed for unknown query names', () => {
+  assert.throws(() => assertAllowedAksQuery('delete-pods'), KubeInputError);
+});
+
+test('AKS analyst kubectl guard allows get and rejects write verbs', () => {
+  assert.doesNotThrow(() => assertReadOnlyKubectlArgs(['get', 'pods', '-n', 'energy', '-o', 'json']));
+  assert.throws(() => assertReadOnlyKubectlArgs(['delete', 'pods', '-n', 'energy']), KubeInputError);
+  assert.throws(() => assertReadOnlyKubectlArgs(['get', 'secrets', '-n', 'energy']), KubeInputError);
+});
+
+test('AKS quantity parsing maps CPU and memory into comparable units', () => {
+  assert.equal(parseCpuMillicores('250m'), 250);
+  assert.equal(parseCpuMillicores('2'), 2000);
+  assert.equal(parseMemoryBytes('128Mi'), 134217728);
+  assert.equal(parseMemoryBytes('1G'), 1000000000);
+});
+
+test('AKS pod resource query maps success response with metadata', async () => {
+  const service = new AnalystKubeQueryService(async () => ({
+    stderr: '',
+    stdout: JSON.stringify({
+      items: [{
+        metadata: { name: 'api-1', labels: { app: 'api' } },
+        spec: { nodeName: 'node-a', containers: [{ name: 'api', resources: { requests: { cpu: '100m', memory: '64Mi' }, limits: { cpu: '500m', memory: '128Mi' } } }] },
+        status: { phase: 'Running', startTime: '2026-01-01T00:00:00Z', containerStatuses: [{ name: 'api', ready: true, restartCount: 0, state: { running: {} } }] },
+      }],
+    }),
+  }));
+
+  const response = await service.execute('pod-resources');
+  assert.equal(response.queryName, 'pod-resources');
+  assert.equal(response.namespace, 'energy');
+  assert.equal(response.metadata.allowedVerb, 'get');
+  assert.equal(response.metadata.status, 'complete');
+  assert.equal((response.data as AnalystPodResourceState[])[0]?.name, 'api-1');
+});
+
+test('AKS denied response keeps evidence metadata shape', () => {
+  const response = buildAksErrorResponse('delete-pods', 'AKS analyst query is not allowlisted.', 'denied');
+
+  assert.equal(response.status, 'denied');
+  assert.equal(response.queryName, 'delete-pods');
+  assert.equal(response.namespace, 'energy');
+  assert.deepEqual(response.data, []);
+  assert.equal(response.metadata.confidence, 'none');
+  assert.equal(response.metadata.status, 'denied');
+  assert.equal(response.metadata.allowedVerb, 'get');
+});
+
+test('AKS unavailable response keeps empty data and no-confidence metadata', () => {
+  const response = buildAksErrorResponse('pod-resources', 'kubectl timed out.', 'unavailable');
+
+  assert.equal(response.status, 'unavailable');
+  assert.equal(response.queryName, 'pod-resources');
+  assert.deepEqual(response.data, []);
+  assert.equal(response.metadata.confidence, 'none');
+  assert.equal(response.metadata.status, 'unavailable');
+});

--- a/mission-control/backend/src/services/AnalystKubeQueryService.ts
+++ b/mission-control/backend/src/services/AnalystKubeQueryService.ts
@@ -1,0 +1,416 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type {
+  AnalystAksQueryName,
+  AnalystAksQueryResponse,
+  AnalystDeploymentReplicaState,
+  AnalystNodeAllocationSummary,
+  AnalystPodContainerResources,
+  AnalystPodResourceState,
+  AnalystServiceEndpointsHealth,
+  KubeEvent,
+  KubernetesResourceList,
+  ServicePort,
+} from '../types/index.js';
+import { KubeClientError, KubeInputError } from './KubeClient.js';
+
+const exec = promisify(execFile);
+const ENERGY_NAMESPACE = 'energy' as const;
+const KUBECTL_TIMEOUT_MS = 15_000;
+
+export const ALLOWED_AKS_ANALYST_QUERIES = [
+  'pod-resources',
+  'node-capacity',
+  'deployment-replicas',
+  'namespace-events',
+  'service-endpoints-health',
+] as const satisfies readonly AnalystAksQueryName[];
+
+type KubectlExecutor = (args: string[], timeoutMs: number) => Promise<{ stdout: string; stderr: string }>;
+
+export class AnalystKubeQueryService {
+  constructor(private readonly executor: KubectlExecutor = execKubectl) {}
+
+  async execute(queryName: string): Promise<AnalystAksQueryResponse> {
+    assertAllowedAksQuery(queryName);
+
+    const collectedAt = new Date().toISOString();
+    const data = await this.collect(queryName);
+
+    return {
+      queryName,
+      namespace: ENERGY_NAMESPACE,
+      metadata: {
+        source: `kubectl get (read-only) against namespace '${ENERGY_NAMESPACE}'`,
+        collectedAt,
+        limitations: [
+          'Point-in-time Kubernetes API read; no watches, exec, logs, secrets, or remediation verbs are used.',
+          'Data is scoped to the energy namespace except node capacity, which is cluster-level capacity needed to interpret energy pod allocation.',
+          'Confidence describes observation completeness, not root cause or remediation certainty.',
+        ],
+        confidence: data.length > 0 ? 'medium' : 'none',
+        status: 'complete',
+        allowedVerb: 'get',
+        allowlist: [...ALLOWED_AKS_ANALYST_QUERIES],
+      },
+      data,
+    };
+  }
+
+  private async collect(queryName: AnalystAksQueryName): Promise<AnalystAksQueryResponse['data']> {
+    switch (queryName) {
+      case 'pod-resources':
+        return this.getPodResources();
+      case 'node-capacity':
+        return this.getNodeCapacity();
+      case 'deployment-replicas':
+        return this.getDeploymentReplicas();
+      case 'namespace-events':
+        return this.getNamespaceEvents();
+      case 'service-endpoints-health':
+        return this.getServiceEndpointHealth();
+      default:
+        return assertNever(queryName);
+    }
+  }
+
+  private async getPodResources(): Promise<AnalystPodResourceState[]> {
+    const pods = await this.kubectlJson(['get', 'pods', '-n', ENERGY_NAMESPACE, '-o', 'json']);
+    return (pods.items ?? []).map(toPodResourceState);
+  }
+
+  private async getNodeCapacity(): Promise<AnalystNodeAllocationSummary[]> {
+    const [nodes, pods] = await Promise.all([
+      this.kubectlJson(['get', 'nodes', '-o', 'json']),
+      this.kubectlJson(['get', 'pods', '-n', ENERGY_NAMESPACE, '-o', 'json']),
+    ]);
+
+    const allocatedByNode = new Map<string, { requested: KubernetesResourceList; limited: KubernetesResourceList; podCount: number }>();
+    for (const pod of pods.items ?? []) {
+      const nodeName = pod.spec?.nodeName;
+      if (!nodeName) continue;
+
+      const current = allocatedByNode.get(nodeName) ?? { requested: {}, limited: {}, podCount: 0 };
+      current.podCount += 1;
+      for (const container of pod.spec?.containers ?? []) {
+        addResources(current.requested, toResourceList(container.resources?.requests));
+        addResources(current.limited, toResourceList(container.resources?.limits));
+      }
+      allocatedByNode.set(nodeName, current);
+    }
+
+    return (nodes.items ?? []).map((node: any) => {
+      const allocated = allocatedByNode.get(node.metadata?.name) ?? { requested: {}, limited: {}, podCount: 0 };
+      return {
+        name: node.metadata?.name ?? '',
+        capacity: toResourceList(node.status?.capacity),
+        allocatable: toResourceList(node.status?.allocatable),
+        requested: allocated.requested,
+        limited: allocated.limited,
+        podCount: allocated.podCount,
+        conditions: (node.status?.conditions ?? []).map((condition: any) => ({
+          type: condition.type ?? '',
+          status: condition.status ?? '',
+          reason: condition.reason,
+          lastTransitionTime: condition.lastTransitionTime,
+        })),
+      } satisfies AnalystNodeAllocationSummary;
+    });
+  }
+
+  private async getDeploymentReplicas(): Promise<AnalystDeploymentReplicaState[]> {
+    const deployments = await this.kubectlJson(['get', 'deployments', '-n', ENERGY_NAMESPACE, '-o', 'json']);
+    return (deployments.items ?? []).map((deployment: any) => {
+      const desiredReplicas = deployment.spec?.replicas ?? 1;
+      return {
+        name: deployment.metadata?.name ?? '',
+        namespace: ENERGY_NAMESPACE,
+        desiredReplicas,
+        readyReplicas: deployment.status?.readyReplicas ?? 0,
+        updatedReplicas: deployment.status?.updatedReplicas ?? 0,
+        availableReplicas: deployment.status?.availableReplicas ?? 0,
+        observedGeneration: deployment.status?.observedGeneration,
+        conditions: (deployment.status?.conditions ?? []).map((condition: any) => ({
+          type: condition.type ?? '',
+          status: condition.status ?? '',
+          reason: condition.reason,
+          message: redactSensitiveText(condition.message ?? ''),
+          lastUpdateTime: condition.lastUpdateTime,
+          lastTransitionTime: condition.lastTransitionTime,
+        })),
+      } satisfies AnalystDeploymentReplicaState;
+    });
+  }
+
+  private async getNamespaceEvents(): Promise<KubeEvent[]> {
+    const events = await this.kubectlJson(['get', 'events', '-n', ENERGY_NAMESPACE, '-o', 'json']);
+    return (events.items ?? [])
+      .map(toKubeEvent)
+      .sort((a: KubeEvent, b: KubeEvent) => timestampMillis(b.timestamp) - timestampMillis(a.timestamp))
+      .slice(0, 50);
+  }
+
+  private async getServiceEndpointHealth(): Promise<AnalystServiceEndpointsHealth[]> {
+    const [services, endpoints, pods] = await Promise.all([
+      this.kubectlJson(['get', 'services', '-n', ENERGY_NAMESPACE, '-o', 'json']),
+      this.kubectlJson(['get', 'endpoints', '-n', ENERGY_NAMESPACE, '-o', 'json']),
+      this.kubectlJson(['get', 'pods', '-n', ENERGY_NAMESPACE, '-o', 'json']),
+    ]);
+
+    const endpointCounts = new Map<string, { ready: number; notReady: number; total: number }>();
+    for (const endpoint of endpoints.items ?? []) {
+      let ready = 0;
+      let notReady = 0;
+      for (const subset of endpoint.subsets ?? []) {
+        ready += (subset.addresses ?? []).length;
+        notReady += (subset.notReadyAddresses ?? []).length;
+      }
+      endpointCounts.set(endpoint.metadata?.name ?? '', { ready, notReady, total: ready + notReady });
+    }
+
+    return (services.items ?? []).map((service: any) => {
+      const selector = service.spec?.selector ?? {};
+      const counts = endpointCounts.get(service.metadata?.name) ?? { ready: 0, notReady: 0, total: 0 };
+      const matchingPods = (pods.items ?? []).filter((pod: any) => selectorMatches(pod.metadata?.labels ?? {}, selector)).length;
+      return {
+        serviceName: service.metadata?.name ?? '',
+        namespace: ENERGY_NAMESPACE,
+        type: service.spec?.type ?? 'ClusterIP',
+        selector,
+        readyEndpoints: counts.ready,
+        notReadyEndpoints: counts.notReady,
+        totalEndpoints: counts.total,
+        matchingPods,
+        ports: (service.spec?.ports ?? []).map(toServicePort),
+      } satisfies AnalystServiceEndpointsHealth;
+    });
+  }
+
+  private async kubectlJson(args: string[]): Promise<any> {
+    assertReadOnlyKubectlArgs(args);
+    const { stdout } = await this.executor(args, KUBECTL_TIMEOUT_MS);
+    try {
+      return JSON.parse(stdout);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new KubeClientError(`kubectl returned invalid JSON for analyst query: ${message}`, 502);
+    }
+  }
+}
+
+export function assertAllowedAksQuery(queryName: string): asserts queryName is AnalystAksQueryName {
+  if (!ALLOWED_AKS_ANALYST_QUERIES.includes(queryName as AnalystAksQueryName)) {
+    throw new KubeInputError(`AKS analyst query '${queryName}' is not allowlisted.`);
+  }
+}
+
+export function assertReadOnlyKubectlArgs(args: string[]): void {
+  const [verb] = args;
+  const resource = args[1];
+  const denied = ['apply', 'create', 'delete', 'edit', 'exec', 'patch', 'replace', 'rollout', 'run', 'scale', 'set', 'cordon', 'drain', 'taint', 'label', 'annotate', 'port-forward', 'cp'];
+
+  if (verb !== 'get' || denied.includes(verb) || resource === 'secrets' || resource === 'secret') {
+    throw new KubeInputError('Analyst Kubernetes access is read-only and fail-closed to allowlisted kubectl get queries.');
+  }
+}
+
+async function execKubectl(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await exec('kubectl', args, { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 });
+  } catch (err) {
+    if (isNodeError(err) && err.code === 'ENOENT') {
+      throw new KubeClientError('kubectl is unavailable on PATH. Analyst AKS queries are unavailable.', 503);
+    }
+    const stderr = isExecError(err) ? err.stderr?.trim() : undefined;
+    const stdout = isExecError(err) ? err.stdout?.trim() : undefined;
+    const detail = stderr || stdout || (err instanceof Error ? err.message : String(err));
+    throw new KubeClientError(`kubectl analyst query failed: ${redactSensitiveText(detail)}`, 503);
+  }
+}
+
+function toPodResourceState(item: any): AnalystPodResourceState {
+  const containerStatuses = item.status?.containerStatuses ?? [];
+  const containers = (item.spec?.containers ?? []).map((container: any) => toContainerResources(container, containerStatuses));
+  const totalCount = containers.length;
+  const readyCount = containerStatuses.filter((container: any) => container.ready).length;
+
+  return {
+    name: item.metadata?.name ?? '',
+    namespace: ENERGY_NAMESPACE,
+    phase: item.status?.phase ?? 'Unknown',
+    status: getPodStatus(item, containerStatuses),
+    ready: totalCount > 0 && readyCount === totalCount,
+    nodeName: item.spec?.nodeName,
+    startTime: item.status?.startTime,
+    labels: item.metadata?.labels ?? {},
+    requests: sumContainerResources(containers, 'requests'),
+    limits: sumContainerResources(containers, 'limits'),
+    containers,
+  };
+}
+
+function toContainerResources(container: any, statuses: any[]): AnalystPodContainerResources {
+  const status = statuses.find((candidate: any) => candidate.name === container.name);
+  return {
+    name: container.name ?? '',
+    ready: Boolean(status?.ready),
+    restartCount: status?.restartCount ?? 0,
+    state: getContainerState(status ?? {}),
+    reason: getContainerReason(status ?? {}),
+    requests: toResourceList(container.resources?.requests),
+    limits: toResourceList(container.resources?.limits),
+  };
+}
+
+function toResourceList(raw: any): KubernetesResourceList {
+  return {
+    cpuMillicores: parseCpuMillicores(raw?.cpu),
+    memoryBytes: parseMemoryBytes(raw?.memory),
+  };
+}
+
+function sumContainerResources(
+  containers: AnalystPodContainerResources[],
+  field: 'requests' | 'limits',
+): KubernetesResourceList {
+  const result: KubernetesResourceList = {};
+  for (const container of containers) {
+    addResources(result, container[field]);
+  }
+  return result;
+}
+
+function addResources(target: KubernetesResourceList, source: KubernetesResourceList): void {
+  target.cpuMillicores = (target.cpuMillicores ?? 0) + (source.cpuMillicores ?? 0);
+  target.memoryBytes = (target.memoryBytes ?? 0) + (source.memoryBytes ?? 0);
+}
+
+export function parseCpuMillicores(value: unknown): number | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined;
+  const trimmed = value.trim();
+  if (trimmed.endsWith('m')) return parseFiniteNumber(trimmed.slice(0, -1));
+  const cores = parseFiniteNumber(trimmed);
+  return cores === undefined ? undefined : Math.round(cores * 1000);
+}
+
+export function parseMemoryBytes(value: unknown): number | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined;
+  const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)?$/);
+  if (!match) return undefined;
+
+  const number = parseFiniteNumber(match[1]);
+  if (number === undefined) return undefined;
+
+  const suffix = match[2] ?? '';
+  const multipliers: Record<string, number> = {
+    Ki: 1024,
+    Mi: 1024 ** 2,
+    Gi: 1024 ** 3,
+    Ti: 1024 ** 4,
+    Pi: 1024 ** 5,
+    Ei: 1024 ** 6,
+    K: 1000,
+    M: 1000 ** 2,
+    G: 1000 ** 3,
+    T: 1000 ** 4,
+    P: 1000 ** 5,
+    E: 1000 ** 6,
+    '': 1,
+  };
+  return Math.round(number * multipliers[suffix]);
+}
+
+function parseFiniteNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function getPodStatus(item: any, containers: any[]): string {
+  const waiting = containers.find((container: any) => container.state?.waiting?.reason);
+  if (waiting) return waiting.state.waiting.reason;
+  const terminated = containers.find((container: any) => container.state?.terminated?.reason);
+  if (terminated) return terminated.state.terminated.reason;
+  return item.status?.phase ?? 'Unknown';
+}
+
+function getContainerState(container: any): string {
+  if (container.state?.waiting) return 'waiting';
+  if (container.state?.terminated) return 'terminated';
+  if (container.state?.running) return 'running';
+  return 'unknown';
+}
+
+function getContainerReason(container: any): string | undefined {
+  return container.state?.waiting?.reason
+    ?? container.state?.terminated?.reason
+    ?? container.lastState?.terminated?.reason;
+}
+
+function toKubeEvent(item: any): KubeEvent {
+  const lastTimestamp = item.lastTimestamp
+    ?? item.eventTime
+    ?? item.series?.lastObservedTime
+    ?? item.metadata?.creationTimestamp
+    ?? '';
+  const firstTimestamp = item.firstTimestamp ?? item.metadata?.creationTimestamp ?? lastTimestamp;
+
+  return {
+    type: item.type ?? 'Normal',
+    reason: item.reason ?? '',
+    message: redactSensitiveText(item.message ?? ''),
+    source: item.reportingController ?? item.source?.component ?? '',
+    timestamp: lastTimestamp,
+    involvedObject: item.involvedObject ? {
+      kind: item.involvedObject.kind ?? '',
+      name: item.involvedObject.name ?? '',
+      namespace: item.involvedObject.namespace,
+      fieldPath: item.involvedObject.fieldPath,
+      apiVersion: item.involvedObject.apiVersion,
+    } : undefined,
+    count: item.count ?? item.series?.count ?? 1,
+    firstTimestamp,
+    lastTimestamp,
+  };
+}
+
+function toServicePort(port: any): ServicePort {
+  return {
+    name: port.name,
+    port: port.port,
+    targetPort: port.targetPort,
+    nodePort: port.nodePort,
+    protocol: port.protocol ?? 'TCP',
+    appProtocol: port.appProtocol,
+  };
+}
+
+function selectorMatches(labels: Record<string, string>, selector: Record<string, string>): boolean {
+  const entries = Object.entries(selector);
+  if (entries.length === 0) return false;
+  return entries.every(([key, value]) => labels[key] === value);
+}
+
+function timestampMillis(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function redactSensitiveText(text: string): string {
+  return text
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._~+/=-]+/gi, '$1 [REDACTED]')
+    .replace(/\b(password|passwd|pwd|token|secret|api[_-]?key|client[_-]?secret|authorization)(\s*[:=]\s*)(["']?)[^\s"',;]+/gi, '$1$2$3[REDACTED]');
+}
+
+function assertNever(value: never): never {
+  throw new KubeInputError(`Unhandled AKS analyst query '${String(value)}'.`);
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return typeof err === 'object' && err !== null && 'code' in err;
+}
+
+function isExecError(err: unknown): err is Error & { stderr?: string; stdout?: string } {
+  return typeof err === 'object' && err !== null;
+}

--- a/mission-control/backend/src/services/AssistantService.ts
+++ b/mission-control/backend/src/services/AssistantService.ts
@@ -4,7 +4,16 @@ import type { JobManager } from './JobManager.js';
 import { collectMissionState } from './MissionStateService.js';
 import { getRepoRoot } from '../utils/paths.js';
 import { logger } from '../utils/logger.js';
-import type { AssistantAskResponse, AssistantClientContext, AssistantConversationMessage } from '../types/index.js';
+import type {
+  AssistantAskResponse,
+  AssistantCitation,
+  AssistantClientContext,
+  AssistantConfidence,
+  AssistantConversationMessage,
+  AssistantEscalationLink,
+  AssistantResponseStatus,
+  MissionState,
+} from '../types/index.js';
 
 const ASSISTANT_MODEL = 'gpt-4.1';
 const ASSISTANT_TIMEOUT_MS = 60_000;
@@ -25,6 +34,12 @@ const STATE_LIMITATIONS = [
   'Client screen context is untrusted supplemental UX state and never authoritative for live cluster status',
   'Explains and triages Mission Control state; Azure SRE Agent remains the cloud diagnostic/remediation agent',
 ];
+const SRE_AGENT_HANDOFF_LINK: AssistantEscalationLink = {
+  label: 'Open Azure SRE Agent portal',
+  href: 'https://sre.azure.com',
+  kind: 'sre-agent',
+  description: 'Handoff only: ask Azure SRE Agent in the portal for cloud-side diagnosis and remediation guidance.',
+};
 
 const SYSTEM_MESSAGE = `You are Ask Copilot inside Mission Control: a local explainer and triage assistant for the Azure SRE Agent Energy Grid demo.
 You are not Azure SRE Agent, not an autonomous SRE agent, and not a replacement for Azure SRE Agent.
@@ -112,6 +127,43 @@ ${transcript}
 ${latestQuestion}`;
 }
 
+function buildCitations(missionState: MissionState): AssistantCitation[] {
+  const timestamp = missionState.collectedAt;
+
+  return [
+    {
+      label: 'Mission Control state snapshot',
+      detail: `Collected local preflight, energy namespace Kubernetes resources, scenario status, and job status at ${timestamp}.`,
+      timestamp,
+    },
+    {
+      label: 'Read-only Local Analyst boundary',
+      detail: 'Local Analyst cannot read secrets, raw deploy/destroy logs, arbitrary files, or perform remediation.',
+      timestamp,
+    },
+  ];
+}
+
+function responseStatus(missionState: MissionState, toolsUsed: Set<string>): AssistantResponseStatus {
+  if (missionState.cluster.errors && missionState.cluster.errors.length > 0) return 'partial';
+  if (!toolsUsed.has('get_mission_control_state')) return 'partial';
+  return 'ok';
+}
+
+function responseConfidence(status: AssistantResponseStatus, missionState: MissionState): AssistantConfidence {
+  if (status === 'partial') return 'low';
+  if (missionState.cluster.pods.length === 0 && missionState.cluster.deployments.length === 0) return 'medium';
+  return 'high';
+}
+
+function responseLimitations(missionState: MissionState): string[] {
+  const limitations = [...STATE_LIMITATIONS];
+  if (missionState.cluster.errors && missionState.cluster.errors.length > 0) {
+    limitations.push(...missionState.cluster.errors);
+  }
+  return limitations;
+}
+
 export async function askMissionControlAssistant(
   question: string,
   jobManager: JobManager,
@@ -157,15 +209,21 @@ export async function askMissionControlAssistant(
     const response = await session.sendAndWait({ prompt }, ASSISTANT_TIMEOUT_MS);
     const answer = response?.data.content?.trim();
 
+    const status = responseStatus(missionState, toolsUsed);
+
     return {
       answer: answer || 'Copilot completed without returning a text answer. Try asking a narrower state question.',
       metadata: {
         model: ASSISTANT_MODEL,
-        status: 'ok',
+        status,
+        uiState: status,
+        confidence: responseConfidence(status, missionState),
         toolsUsed: Array.from(toolsUsed),
         stateSnapshotTimestamp: missionState.collectedAt,
         sources: STATE_SOURCES,
-        limitations: STATE_LIMITATIONS,
+        citations: buildCitations(missionState),
+        limitations: responseLimitations(missionState),
+        escalationLinks: [SRE_AGENT_HANDOFF_LINK],
         timestamp: new Date().toISOString(),
       },
     };

--- a/mission-control/backend/src/services/LogAnalyticsQueryService.test.ts
+++ b/mission-control/backend/src/services/LogAnalyticsQueryService.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LogAnalyticsQueryError,
+  LogAnalyticsQueryService,
+  buildKqlTemplate,
+  configuredWorkspaceId,
+  mapAzureQueryRows,
+  normalizeAzureMonitorError,
+  normalizeLogAnalyticsRequest,
+} from './LogAnalyticsQueryService.js';
+import { KubeInputError } from './KubeClient.js';
+import { buildLogAnalyticsErrorResponse } from '../routes/analyst.js';
+
+test('Log Analytics rejects unknown templates and freeform KQL parameters', () => {
+  assert.throws(() => normalizeLogAnalyticsRequest('freeform', {}), KubeInputError);
+  assert.throws(() => normalizeLogAnalyticsRequest('pod-restarts-lifecycle', { kql: 'ContainerLogV2 | take 1' }), KubeInputError);
+  assert.throws(() => normalizeLogAnalyticsRequest('pod-restarts-lifecycle', { workspaceId: '/subscriptions/override' }), KubeInputError);
+  assert.throws(() => normalizeLogAnalyticsRequest('service-log-excerpts', { service: 'api; drop', minutes: '30' }), KubeInputError);
+  assert.throws(() => normalizeLogAnalyticsRequest('application-exceptions-errors', { minutes: '30' }), KubeInputError);
+});
+
+test('Log Analytics validates bounded template parameters', () => {
+  const request = normalizeLogAnalyticsRequest('service-log-excerpts', { service: 'meter-api', minutes: '15', limit: '25', timeoutMs: '2000' });
+  assert.equal(request.templateName, 'service-log-excerpts');
+  assert.equal(request.namespace, 'energy');
+  assert.equal(request.minutes, 15);
+  assert.equal(request.limit, 25);
+  assert.match(buildKqlTemplate(request, new Date('2026-01-01T00:00:00Z'), new Date('2026-01-01T00:15:00Z')), /ContainerLogV2/);
+});
+
+test('Log Analytics timeout normalization is explicit', () => {
+  const error = normalizeAzureMonitorError(new Error('Command timed out after 15000ms'));
+  assert.equal(error.statusCode, 504);
+  assert.match(error.message, /timed out/);
+});
+
+test('Log Analytics maps Azure table JSON into row objects', () => {
+  const rows = mapAzureQueryRows(JSON.stringify({
+    tables: [{
+      columns: [{ name: 'TimeGenerated' }, { name: 'Message' }],
+      rows: [['2026-01-01T00:00:00Z', 'failed once']],
+    }],
+  }));
+  assert.deepEqual(rows, [{ TimeGenerated: '2026-01-01T00:00:00Z', Message: 'failed once' }]);
+});
+
+test('Log Analytics service maps success response and redacts returned rows', async () => {
+  const originalWorkspace = process.env.LOG_ANALYTICS_WORKSPACE_ID;
+  process.env.LOG_ANALYTICS_WORKSPACE_ID = '/subscriptions/000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/configured-demo';
+  const service = new LogAnalyticsQueryService(async () => ({
+    stderr: '',
+    stdout: JSON.stringify([{ Message: 'token=abc123 failed', PodName: 'meter-api-1' }]),
+  }));
+  try {
+    const response = await service.execute('service-log-excerpts', {
+      service: 'meter-api',
+    });
+
+    assert.equal(configuredWorkspaceId(), '/subscriptions/000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/configured-demo');
+    assert.equal(response.templateName, 'service-log-excerpts');
+    assert.equal(response.workspace, '/subscriptions/000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/configured-demo');
+    assert.equal(response.rowCount, 1);
+    assert.equal(response.metadata.partial, false);
+    assert.equal(response.rows[0]?.Message, 'token=[REDACTED] failed');
+  } finally {
+    if (originalWorkspace === undefined) {
+      delete process.env.LOG_ANALYTICS_WORKSPACE_ID;
+    } else {
+      process.env.LOG_ANALYTICS_WORKSPACE_ID = originalWorkspace;
+    }
+  }
+});
+
+test('Log Analytics invalid JSON maps to service error', () => {
+  assert.throws(() => mapAzureQueryRows('not-json'), LogAnalyticsQueryError);
+});
+
+test('Log Analytics denied response keeps evidence metadata shape', () => {
+  const response = buildLogAnalyticsErrorResponse(
+    'freeform',
+    { kql: 'ContainerLogV2 | take 1' },
+    'Log Analytics template is not allowlisted.',
+    'denied',
+  );
+
+  assert.equal(response.status, 'denied');
+  assert.equal(response.templateName, 'freeform');
+  assert.equal(response.rowCount, 0);
+  assert.deepEqual(response.rows, []);
+  assert.equal(response.metadata.confidence, 'none');
+  assert.equal(response.metadata.status, 'denied');
+  assert.equal(response.metadata.partial, false);
+});
+
+test('Log Analytics unavailable response keeps validated time and empty rows', () => {
+  const response = buildLogAnalyticsErrorResponse(
+    'service-log-excerpts',
+    { service: 'meter-api', minutes: '15', timeoutMs: '2000' },
+    'Azure Monitor query timed out.',
+    'unavailable',
+  );
+
+  assert.equal(response.status, 'unavailable');
+  assert.equal(response.timeRange.minutes, 15);
+  assert.equal(response.metadata.timeoutMs, 2000);
+  assert.equal(response.rowCount, 0);
+  assert.deepEqual(response.rows, []);
+});

--- a/mission-control/backend/src/services/LogAnalyticsQueryService.ts
+++ b/mission-control/backend/src/services/LogAnalyticsQueryService.ts
@@ -1,0 +1,287 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type {
+  LogAnalyticsQueryRequest,
+  LogAnalyticsQueryResponse,
+  LogAnalyticsTemplateName,
+} from '../types/index.js';
+import { KubeInputError } from './KubeClient.js';
+
+const exec = promisify(execFile);
+const ENERGY_NAMESPACE = 'energy' as const;
+const DEFAULT_MINUTES = 30;
+const MAX_MINUTES = 24 * 60;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_TIMEOUT_MS = 30_000;
+const DNS_LABEL_PATTERN = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+const POD_NAME_PATTERN = /^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$/;
+
+export const LOG_ANALYTICS_TEMPLATES = [
+  'pod-restarts-lifecycle',
+  'service-log-excerpts',
+  'application-exceptions-errors',
+] as const satisfies readonly LogAnalyticsTemplateName[];
+
+type AzureMonitorExecutor = (args: string[], timeoutMs: number) => Promise<{ stdout: string; stderr: string }>;
+
+export class LogAnalyticsQueryError extends Error {
+  constructor(message: string, public readonly statusCode = 503) {
+    super(message);
+    this.name = 'LogAnalyticsQueryError';
+  }
+}
+
+export class LogAnalyticsQueryService {
+  constructor(private readonly executor: AzureMonitorExecutor = execAzureMonitorQuery) {}
+
+  async execute(templateName: string, rawParams: Record<string, unknown>): Promise<LogAnalyticsQueryResponse> {
+    const request = normalizeLogAnalyticsRequest(templateName, rawParams);
+    const workspace = configuredWorkspaceId();
+    if (!workspace) {
+      throw new LogAnalyticsQueryError('Log Analytics workspace is not configured. Set LOG_ANALYTICS_WORKSPACE_ID or AZURE_LOG_ANALYTICS_WORKSPACE_ID.', 503);
+    }
+
+    const now = new Date();
+    const from = new Date(now.getTime() - request.minutes * 60_000);
+    const kql = buildKqlTemplate(request, from, now);
+    const result = await this.executor([
+      'monitor', 'log-analytics', 'query',
+      '--workspace', workspace,
+      '--analytics-query', kql,
+      '--timespan', `PT${request.minutes}M`,
+      '--output', 'json',
+    ], request.timeoutMs);
+
+    const rows = mapAzureQueryRows(result.stdout).slice(0, request.limit).map(redactRow);
+
+    return {
+      templateName: request.templateName,
+      workspace,
+      timeRange: {
+        from: from.toISOString(),
+        to: now.toISOString(),
+        minutes: request.minutes,
+      },
+      rowCount: rows.length,
+      rows,
+      metadata: {
+        source: 'Azure Monitor Log Analytics query via governed canned template',
+        collectedAt: new Date().toISOString(),
+        limitations: [
+          'Only canned parameterized templates are supported; arbitrary KQL is rejected.',
+          'Rows are bounded, redacted, and time-window limited before returning to Local Analyst.',
+          'Timeout or command failure is treated as unavailable; Local Analyst must not infer missing results.',
+        ],
+        confidence: rows.length > 0 ? 'medium' : 'low',
+        status: 'complete',
+        partial: false,
+        timeoutMs: request.timeoutMs,
+        partialBehavior: 'Partial or timed-out query results are not accepted as complete evidence; the route returns an unavailable error instead of guessed rows.',
+      },
+    };
+  }
+}
+
+export function normalizeLogAnalyticsRequest(
+  templateName: string,
+  rawParams: Record<string, unknown>,
+): LogAnalyticsQueryRequest {
+  assertAllowedTemplate(templateName);
+  rejectUnknownParams(templateName, rawParams);
+
+  const minutes = parseBoundedInteger(rawParams.minutes, DEFAULT_MINUTES, 1, MAX_MINUTES, 'minutes');
+  const limit = parseBoundedInteger(rawParams.limit, DEFAULT_LIMIT, 1, MAX_LIMIT, 'limit');
+  const timeoutMs = parseBoundedInteger(rawParams.timeoutMs, DEFAULT_TIMEOUT_MS, 1_000, MAX_TIMEOUT_MS, 'timeoutMs');
+  const service = optionalString(rawParams.service, 63);
+  const pod = optionalString(rawParams.pod, 253);
+
+  if (service && !DNS_LABEL_PATTERN.test(service)) {
+    throw new KubeInputError('service must be a valid Kubernetes DNS label.');
+  }
+  if (pod && !POD_NAME_PATTERN.test(pod)) {
+    throw new KubeInputError('pod must be a valid Kubernetes pod name.');
+  }
+
+  if (templateName === 'service-log-excerpts' && !service && !pod) {
+    throw new KubeInputError('service-log-excerpts requires service or pod.');
+  }
+  if (templateName === 'application-exceptions-errors' && !service) {
+    throw new KubeInputError('application-exceptions-errors requires a service filter to avoid broad workspace reads.');
+  }
+
+  return {
+    templateName,
+    minutes,
+    limit,
+    service,
+    pod,
+    namespace: ENERGY_NAMESPACE,
+    timeoutMs,
+  };
+}
+
+export function buildKqlTemplate(request: LogAnalyticsQueryRequest, from: Date, to: Date): string {
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
+  const namespace = kqlString(ENERGY_NAMESPACE);
+  const limit = request.limit;
+
+  switch (request.templateName) {
+    case 'pod-restarts-lifecycle':
+      return [
+        'KubePodInventory',
+        `| where TimeGenerated between (datetime(${fromIso}) .. datetime(${toIso}))`,
+        `| where Namespace == ${namespace}`,
+        '| summarize RestartCount=max(ContainerRestartCount), LastStatus=max(ContainerStatus), LastSeen=max(TimeGenerated) by PodName, ContainerName',
+        '| where RestartCount > 0 or LastStatus !in ("running", "completed")',
+        '| order by LastSeen desc',
+        `| take ${limit}`,
+      ].join('\n');
+    case 'service-log-excerpts': {
+      const filters = [`TimeGenerated between (datetime(${fromIso}) .. datetime(${toIso}))`, `Namespace == ${namespace}`];
+      if (request.pod) filters.push(`PodName == ${kqlString(request.pod)}`);
+      if (request.service) filters.push(`PodName has ${kqlString(request.service)}`);
+      return [
+        'ContainerLogV2',
+        `| where ${filters.join(' and ')}`,
+        '| project TimeGenerated, PodName, ContainerName, LogLevel, LogMessage',
+        '| order by TimeGenerated desc',
+        `| take ${limit}`,
+      ].join('\n');
+    }
+    case 'application-exceptions-errors':
+      return [
+        'union isfuzzy=true AppExceptions, AppTraces, exceptions, traces',
+        `| where TimeGenerated between (datetime(${fromIso}) .. datetime(${toIso}))`,
+        `| extend RoleName=tostring(coalesce(cloud_RoleName, appName, cloud_RoleInstance, AppRoleName))`,
+        `| where RoleName has ${kqlString(requiredServiceFilter(request))}`,
+        '| where SeverityLevel >= 3 or tostring(type) != "" or message has_any ("error", "exception", "failed")',
+        '| project TimeGenerated, ProblemId=coalesce(problemId, problemId_s, type), SeverityLevel, Message=coalesce(message, innermostMessage, outerMessage), OperationName=operation_Name, CloudRoleName=RoleName',
+        '| order by TimeGenerated desc',
+        `| take ${limit}`,
+      ].join('\n');
+    default:
+      throw new KubeInputError(`Log Analytics template '${String(request.templateName)}' is not allowlisted.`);
+  }
+}
+
+function requiredServiceFilter(request: LogAnalyticsQueryRequest): string {
+  if (!request.service) {
+    throw new KubeInputError('application-exceptions-errors requires a service filter to avoid broad workspace reads.');
+  }
+  return request.service;
+}
+
+export function mapAzureQueryRows(stdout: string): Record<string, unknown>[] {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new LogAnalyticsQueryError(`Azure Monitor returned invalid JSON: ${message}`, 502);
+  }
+
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed?.value)) return parsed.value;
+  const table = parsed?.tables?.[0];
+  if (!table) return [];
+  const columns = (table.columns ?? []).map((column: any) => column.name);
+  return (table.rows ?? []).map((row: unknown[]) => Object.fromEntries(columns.map((column: string, index: number) => [column, row[index]])));
+}
+
+export function normalizeAzureMonitorError(err: unknown): LogAnalyticsQueryError {
+  if (isNodeError(err) && err.code === 'ENOENT') {
+    return new LogAnalyticsQueryError('Azure CLI is unavailable on PATH. Log Analytics templates are unavailable.', 503);
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const isTimeout = /timed out|timeout/i.test(message);
+  const stderr = isExecError(err) ? err.stderr?.trim() : undefined;
+  const stdout = isExecError(err) ? err.stdout?.trim() : undefined;
+  const detail = redactSensitiveText(stderr || stdout || message);
+  return new LogAnalyticsQueryError(`Azure Monitor Log Analytics query ${isTimeout ? 'timed out' : 'failed'}: ${detail}`, isTimeout ? 504 : 503);
+}
+
+async function execAzureMonitorQuery(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await exec('az', args, { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 });
+  } catch (err) {
+    throw normalizeAzureMonitorError(err);
+  }
+}
+
+function assertAllowedTemplate(templateName: string): asserts templateName is LogAnalyticsTemplateName {
+  if (!LOG_ANALYTICS_TEMPLATES.includes(templateName as LogAnalyticsTemplateName)) {
+    throw new KubeInputError(`Log Analytics template '${templateName}' is not allowlisted.`);
+  }
+}
+
+function rejectUnknownParams(templateName: LogAnalyticsTemplateName, rawParams: Record<string, unknown>): void {
+  const base = new Set(['minutes', 'limit', 'timeoutMs']);
+  const allowedByTemplate: Record<LogAnalyticsTemplateName, Set<string>> = {
+    'pod-restarts-lifecycle': base,
+    'service-log-excerpts': new Set([...base, 'service', 'pod']),
+    'application-exceptions-errors': new Set([...base, 'service']),
+  };
+  for (const key of Object.keys(rawParams)) {
+    if (!allowedByTemplate[templateName].has(key)) {
+      throw new KubeInputError(`Parameter '${key}' is not allowed for template '${templateName}'.`);
+    }
+  }
+}
+
+function parseBoundedInteger(value: unknown, fallback: number, min: number, max: number, name: string): number {
+  if (value === undefined) return fallback;
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (typeof raw !== 'string' && typeof raw !== 'number') throw new KubeInputError(`${name} must be an integer.`);
+  if (!/^\d+$/.test(String(raw))) throw new KubeInputError(`${name} must be an integer.`);
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+    throw new KubeInputError(`${name} must be between ${min} and ${max}.`);
+  }
+  return parsed;
+}
+
+function optionalString(value: unknown, maxLength: number): string | undefined {
+  if (value === undefined) return undefined;
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (typeof raw !== 'string') throw new KubeInputError('String parameter has invalid type.');
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length > maxLength) throw new KubeInputError('String parameter is too long.');
+  return trimmed;
+}
+
+export function configuredWorkspaceId(): string | undefined {
+  return process.env.LOG_ANALYTICS_WORKSPACE_ID
+    ?? process.env.AZURE_LOG_ANALYTICS_WORKSPACE_ID
+    ?? process.env.APPLICATIONINSIGHTS_WORKSPACE_ID;
+}
+
+function kqlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function redactRow(row: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(row).map(([key, value]) => [
+    key,
+    typeof value === 'string' ? redactSensitiveText(value) : value,
+  ]));
+}
+
+function redactSensitiveText(text: string): string {
+  return text
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._~+/=-]+/gi, '$1 [REDACTED]')
+    .replace(/\b(password|passwd|pwd|token|secret|api[_-]?key|client[_-]?secret|authorization)(\s*[:=]\s*)(["']?)[^\s"',;]+/gi, '$1$2$3[REDACTED]')
+    .replace(/\b(AccountKey=)[^;\s]+/gi, '$1[REDACTED]');
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return typeof err === 'object' && err !== null && 'code' in err;
+}
+
+function isExecError(err: unknown): err is Error & { stderr?: string; stdout?: string } {
+  return typeof err === 'object' && err !== null;
+}

--- a/mission-control/backend/src/types/index.ts
+++ b/mission-control/backend/src/types/index.ts
@@ -165,6 +165,145 @@ export interface PodLogsResponse {
   updatedAt: string;
 }
 
+export type AnalystConfidence = 'high' | 'medium' | 'low' | 'none';
+export type AnalystQueryStatus = 'complete' | 'partial' | 'unavailable' | 'denied';
+
+export interface AnalystEvidenceMetadata {
+  source: string;
+  collectedAt: string;
+  limitations: string[];
+  confidence: AnalystConfidence;
+  status: AnalystQueryStatus;
+}
+
+export type AnalystAksQueryName =
+  | 'pod-resources'
+  | 'node-capacity'
+  | 'deployment-replicas'
+  | 'namespace-events'
+  | 'service-endpoints-health';
+
+export interface KubernetesResourceList {
+  cpuMillicores?: number;
+  memoryBytes?: number;
+}
+
+export interface AnalystPodContainerResources {
+  name: string;
+  ready: boolean;
+  restartCount: number;
+  state: string;
+  reason?: string;
+  requests: KubernetesResourceList;
+  limits: KubernetesResourceList;
+}
+
+export interface AnalystPodResourceState {
+  name: string;
+  namespace: 'energy';
+  phase: string;
+  status: string;
+  ready: boolean;
+  nodeName?: string;
+  startTime?: string;
+  labels: Record<string, string>;
+  requests: KubernetesResourceList;
+  limits: KubernetesResourceList;
+  containers: AnalystPodContainerResources[];
+}
+
+export interface AnalystNodeAllocationSummary {
+  name: string;
+  capacity: KubernetesResourceList;
+  allocatable: KubernetesResourceList;
+  requested: KubernetesResourceList;
+  limited: KubernetesResourceList;
+  podCount: number;
+  conditions: Array<{
+    type: string;
+    status: string;
+    reason?: string;
+    lastTransitionTime?: string;
+  }>;
+}
+
+export interface AnalystDeploymentReplicaState {
+  name: string;
+  namespace: 'energy';
+  desiredReplicas: number;
+  readyReplicas: number;
+  updatedReplicas: number;
+  availableReplicas: number;
+  observedGeneration?: number;
+  conditions: Array<{
+    type: string;
+    status: string;
+    reason?: string;
+    message?: string;
+    lastUpdateTime?: string;
+    lastTransitionTime?: string;
+  }>;
+}
+
+export interface AnalystServiceEndpointsHealth {
+  serviceName: string;
+  namespace: 'energy';
+  type: string;
+  selector: Record<string, string>;
+  readyEndpoints: number;
+  notReadyEndpoints: number;
+  totalEndpoints: number;
+  matchingPods: number;
+  ports: ServicePort[];
+}
+
+export interface AnalystAksQueryResponse {
+  queryName: AnalystAksQueryName;
+  namespace: 'energy';
+  metadata: AnalystEvidenceMetadata & {
+    allowedVerb: 'get';
+    allowlist: AnalystAksQueryName[];
+  };
+  data:
+    | AnalystPodResourceState[]
+    | AnalystNodeAllocationSummary[]
+    | AnalystDeploymentReplicaState[]
+    | KubeEvent[]
+    | AnalystServiceEndpointsHealth[];
+}
+
+export type LogAnalyticsTemplateName =
+  | 'pod-restarts-lifecycle'
+  | 'service-log-excerpts'
+  | 'application-exceptions-errors';
+
+export interface LogAnalyticsQueryRequest {
+  templateName: LogAnalyticsTemplateName;
+  minutes: number;
+  limit: number;
+  service?: string;
+  pod?: string;
+  namespace: 'energy';
+  timeoutMs: number;
+}
+
+export interface LogAnalyticsQueryResponse {
+  templateName: LogAnalyticsTemplateName;
+  workspace: string;
+  timeRange: {
+    from: string;
+    to: string;
+    minutes: number;
+  };
+  rowCount: number;
+  rows: Record<string, unknown>[];
+  metadata: AnalystEvidenceMetadata & {
+    partial: boolean;
+    timeoutMs: number;
+    partialBehavior: string;
+  };
+}
+
 export interface Scenario {
   name: string;
   file: string;
@@ -327,15 +466,35 @@ export interface AssistantAskRequest {
   screenContext?: AssistantClientContext;
 }
 
+export type AssistantResponseStatus = 'ok' | 'partial' | 'error' | 'timeout' | 'escalation';
+export type AssistantConfidence = 'high' | 'medium' | 'low' | 'none';
+
+export interface AssistantCitation {
+  label: string;
+  detail?: string;
+  timestamp?: string;
+}
+
+export interface AssistantEscalationLink {
+  label: string;
+  href: string;
+  kind: 'sre-agent' | 'azure-portal' | 'log-analytics' | 'app-insights' | 'grafana';
+  description: string;
+}
+
 export interface AssistantAskResponse {
   answer: string;
   metadata: {
     model: string;
-    status: 'ok';
+    status: AssistantResponseStatus;
+    uiState?: AssistantResponseStatus;
+    confidence?: AssistantConfidence;
     toolsUsed: string[];
     stateSnapshotTimestamp: string;
     sources: string[];
+    citations?: AssistantCitation[];
     limitations: string[];
+    escalationLinks?: AssistantEscalationLink[];
     timestamp: string;
   };
 }

--- a/mission-control/backend/tsconfig.json
+++ b/mission-control/backend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/mission-control/frontend/env.d.ts
+++ b/mission-control/frontend/env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_AZURE_SRE_AGENT_PORTAL_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue';
   const component: DefineComponent<object, object, unknown>;

--- a/mission-control/frontend/src/components/AssistantPanel.vue
+++ b/mission-control/frontend/src/components/AssistantPanel.vue
@@ -63,39 +63,117 @@
       </div>
     </div>
 
-    <div v-if="loading" class="card card--status loading text-sm text-center mt-4">
+    <div v-if="loading" class="card card--status loading text-sm text-center mt-4" role="status" aria-live="polite">
       Inspecting Mission Control state…
     </div>
 
-    <div v-if="error" class="card mt-4 text-sm" style="border-color: var(--red); color: var(--red);">
-      {{ error }}
+    <div v-if="error" class="card assistant-error mt-4 text-sm" role="alert">
+      <strong>Local Analyst unavailable.</strong>
+      <p>{{ error }}</p>
+      <p class="assistant-error__limit">
+        No confidence: Local Analyst cannot safely infer an answer without the read-only Mission Control snapshot. Refresh Mission Control, verify preflight checks, and retry.
+      </p>
     </div>
 
-    <div v-if="answer" class="card card--output assistant-answer mt-4">
+    <div
+      v-if="answer"
+      class="card card--output assistant-answer mt-4"
+      role="region"
+      aria-labelledby="assistant-answer-heading"
+      aria-live="polite"
+    >
       <div class="assistant-answer__heading">
-        <span class="status-strip__title">
-          <span class="dot dot-green"></span>
+        <span id="assistant-answer-heading" class="status-strip__title">
+          <span class="dot" :class="answerDotClass" aria-hidden="true"></span>
           Local analyst answer
         </span>
-        <span class="badge badge-info">{{ modelLabel }}</span>
+        <div class="assistant-answer__badges" aria-label="Analyst response state">
+          <span class="badge" :class="statusBadgeClass">{{ statusLabel }}</span>
+          <span class="badge" :class="confidenceBadgeClass">{{ confidenceLabel }}</span>
+          <span class="badge badge-info">{{ sourceCountLabel }}</span>
+        </div>
       </div>
-      <div class="assistant-metadata">
-        <span>Snapshot: {{ snapshotLabel }}</span>
-        <span>Tools: {{ toolsLabel }}</span>
-        <span>Sources: {{ sourcesLabel }}</span>
+      <div
+        ref="answerScrollRef"
+        class="assistant-answer__scroll"
+        tabindex="0"
+        role="document"
+        aria-label="Local Analyst response history, sources, limitations, and portal handoff. Long content scrolls inside this region."
+      >
+        <div class="assistant-answer__text">{{ answer }}</div>
+        <details class="assistant-details">
+          <summary>Sources, confidence, and limitations</summary>
+          <div class="assistant-details__grid">
+            <div>
+              <span class="assistant-details__label">Snapshot</span>
+              <p>{{ snapshotLabel }}</p>
+            </div>
+            <div>
+              <span class="assistant-details__label">Tools</span>
+              <p>{{ toolsLabel }}</p>
+            </div>
+            <div>
+              <span class="assistant-details__label">Confidence</span>
+              <p>{{ confidenceLabel }} — Local Analyst observes the Mission Control snapshot only.</p>
+            </div>
+          </div>
+          <div v-if="citations.length" class="assistant-citations" aria-label="Local Analyst sources and citations">
+            <h3>Citations</h3>
+            <ul>
+              <li v-for="citation in citations" :key="`${citation.label}-${citation.timestamp ?? ''}`">
+                <strong>{{ citation.label }}</strong>
+                <span v-if="citation.timestamp"> — {{ formatTimestamp(citation.timestamp) }}</span>
+                <span v-if="citation.detail">: {{ citation.detail }}</span>
+              </li>
+            </ul>
+          </div>
+          <div v-if="metadata?.limitations.length" class="assistant-limitations assistant-limitations--answer">
+            <strong>Limitations:</strong> {{ metadata.limitations.join(' · ') }}
+          </div>
+        </details>
+        <div v-if="escalationLinks.length" class="assistant-escalation" aria-label="Azure SRE Agent and portal handoff">
+          <div>
+            <span class="panel-eyebrow">Portal handoff</span>
+            <p>
+              Local Analyst observed this local snapshot only. It did not invoke Azure SRE Agent. Open the portal for diagnosis/remediation recommendations and capture portal evidence before making Azure SRE Agent claims.
+            </p>
+            <p class="assistant-escalation__unavailable">
+              Resource-specific deep links are unavailable unless a safe portal URL is configured.
+            </p>
+          </div>
+          <div class="assistant-escalation__actions">
+            <a
+              v-for="link in escalationLinks"
+              :key="`${link.kind}-${link.href}`"
+              class="command-button command-button--neutral assistant-escalation__link"
+              :href="link.href"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {{ link.label }}
+            </a>
+            <button class="command-button command-button--neutral assistant-escalation__link" type="button" @click="copyHandoffPrompt">
+              {{ copyLabel }}
+            </button>
+          </div>
+        </div>
       </div>
-      <p>{{ answer }}</p>
-      <div v-if="metadata?.limitations.length" class="assistant-limitations assistant-limitations--answer">
-        Limits: {{ metadata.limitations.join(' · ') }}
-      </div>
+      <div class="sr-only" aria-live="polite" aria-atomic="true">{{ copyStatus }}</div>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { useApi } from '@/composables/useApi';
-import type { AssistantAskResponse } from '@/types/api';
+import type {
+  AssistantAskResponse,
+  AssistantCitation,
+  AssistantConfidence,
+  AssistantEscalationLink,
+  AssistantResponseStatus,
+} from '@/types/api';
+import { visibleEscalationLinks } from '@/utils/portalLinks';
 
 const { askAssistant } = useApi();
 
@@ -109,13 +187,12 @@ const question = ref('');
 const loading = ref(false);
 const answer = ref('');
 const error = ref('');
+const copyStatus = ref('');
+const copySucceeded = ref(false);
 const metadata = ref<AssistantAskResponse['metadata'] | null>(null);
+const answerScrollRef = ref<HTMLElement | null>(null);
 
 const canAsk = computed(() => question.value.trim().length > 0);
-const modelLabel = computed(() => {
-  if (!metadata.value) return 'No metadata';
-  return metadata.value.model;
-});
 const toolsLabel = computed(() => {
   if (!metadata.value || metadata.value.toolsUsed.length === 0) return 'none reported';
   return metadata.value.toolsUsed.join(', ');
@@ -126,8 +203,106 @@ const sourcesLabel = computed(() => {
 });
 const snapshotLabel = computed(() => {
   if (!metadata.value) return 'not collected';
-  return new Date(metadata.value.stateSnapshotTimestamp).toLocaleString();
+  return formatTimestamp(metadata.value.stateSnapshotTimestamp);
 });
+const sourceCountLabel = computed(() => {
+  const count = metadata.value?.sources.length ?? citations.value.length;
+  return `${count} source${count === 1 ? '' : 's'}`;
+});
+const responseStatus = computed<AssistantResponseStatus>(() => metadata.value?.uiState ?? metadata.value?.status ?? 'ok');
+const responseConfidence = computed<AssistantConfidence>(() => metadata.value?.confidence ?? 'medium');
+const statusLabel = computed(() => {
+  switch (responseStatus.value) {
+    case 'partial':
+      return 'Partial evidence';
+    case 'error':
+      return 'Error';
+    case 'timeout':
+      return 'Timed out';
+    case 'escalation':
+      return 'Portal handoff';
+    default:
+      return 'Success';
+  }
+});
+const confidenceLabel = computed(() => `${responseConfidence.value === 'none' ? 'No' : responseConfidence.value} confidence`);
+const statusBadgeClass = computed(() => {
+  switch (responseStatus.value) {
+    case 'partial':
+    case 'timeout':
+    case 'escalation':
+      return 'badge-warning';
+    case 'error':
+      return 'badge-offline';
+    default:
+      return 'badge-online';
+  }
+});
+const confidenceBadgeClass = computed(() => {
+  switch (responseConfidence.value) {
+    case 'high':
+      return 'badge-online';
+    case 'medium':
+      return 'badge-info';
+    case 'low':
+      return 'badge-warning';
+    default:
+      return 'badge-neutral';
+  }
+});
+const answerDotClass = computed(() => {
+  switch (responseStatus.value) {
+    case 'partial':
+    case 'timeout':
+    case 'escalation':
+      return 'dot-amber';
+    case 'error':
+      return 'dot-red';
+    default:
+      return 'dot-green';
+  }
+});
+const citations = computed<AssistantCitation[]>(() => {
+  if (metadata.value?.citations?.length) return metadata.value.citations;
+  if (!metadata.value) return [];
+
+  return [
+    {
+      label: 'Mission Control state snapshot',
+      detail: `Included data sources: ${sourcesLabel.value}.`,
+      timestamp: metadata.value.stateSnapshotTimestamp,
+    },
+  ];
+});
+const escalationLinks = computed<AssistantEscalationLink[]>(() => visibleEscalationLinks(metadata.value?.escalationLinks));
+const handoffPrompt = computed(() => {
+  const snapshot = metadata.value?.stateSnapshotTimestamp ? formatTimestamp(metadata.value.stateSnapshotTimestamp) : 'the current Mission Control snapshot';
+  return [
+    'Please investigate this Azure SRE Agent Energy Grid demo state.',
+    `Local Analyst observed a read-only Mission Control snapshot collected at ${snapshot}.`,
+    `User question: ${question.value.trim()}`,
+    `Local Analyst observation: ${answer.value}`,
+    'Use Azure SRE Agent portal evidence for diagnosis/remediation recommendations; Local Analyst did not invoke Azure SRE Agent.',
+  ].join('\n\n');
+});
+const copyLabel = computed(() => copySucceeded.value ? 'Prompt copied' : 'Copy prompt');
+
+function formatTimestamp(value: string) {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.valueOf()) ? value : parsed.toLocaleString();
+}
+
+async function copyHandoffPrompt() {
+  copyStatus.value = '';
+  copySucceeded.value = false;
+  try {
+    await navigator.clipboard.writeText(handoffPrompt.value);
+    copySucceeded.value = true;
+    copyStatus.value = 'Azure SRE Agent portal handoff prompt copied.';
+  } catch {
+    copyStatus.value = 'Copy failed. Select the Local Analyst answer and copy it manually.';
+  }
+}
 
 async function ask() {
   const prompt = question.value.trim();
@@ -136,12 +311,16 @@ async function ask() {
   loading.value = true;
   answer.value = '';
   error.value = '';
+  copyStatus.value = '';
+  copySucceeded.value = false;
   metadata.value = null;
 
   try {
     const response = await askAssistant(prompt);
     answer.value = response.answer;
     metadata.value = response.metadata;
+    await nextTick();
+    answerScrollRef.value?.focus({ preventScroll: true });
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err);
   } finally {

--- a/mission-control/frontend/src/components/MissionWallboard.vue
+++ b/mission-control/frontend/src/components/MissionWallboard.vue
@@ -1898,6 +1898,8 @@ defineExpose({
   border-radius: var(--radius-sm);
   background: rgb(2 6 23 / 0.5);
   padding: 0.75rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .analyst-empty {

--- a/mission-control/frontend/src/styles/theme.css
+++ b/mission-control/frontend/src/styles/theme.css
@@ -631,10 +631,12 @@ button:disabled {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
   gap: 1rem;
+  min-height: 0;
 }
 
 .assistant-card {
   min-height: 100%;
+  min-width: 0;
 }
 
 .assistant-input {
@@ -660,6 +662,13 @@ button:disabled {
   gap: 0.75rem;
 }
 
+.assistant-answer__badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
 .assistant-footer {
   margin-top: 0.75rem;
   color: var(--subtle);
@@ -681,25 +690,165 @@ button:disabled {
 }
 
 .assistant-answer {
-  white-space: pre-wrap;
+  display: flex;
+  flex-direction: column;
+  max-height: min(34rem, 62vh);
+  min-height: 0;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-.assistant-metadata {
-  display: grid;
-  gap: 0.35rem;
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid rgb(148 163 184 / 0.12);
-  color: var(--muted);
-  font-size: 0.75rem;
-  line-height: 1.45;
-}
-
-.assistant-answer p {
+.assistant-answer__scroll {
   margin-top: 0.8rem;
+  flex: 1 1 auto;
+  min-height: 8rem;
+  max-height: clamp(16rem, 44vh, 28rem);
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid rgb(148 163 184 / 0.16);
+  border-radius: var(--radius-sm);
+  background: rgb(2 6 23 / 0.38);
+  padding: 0.85rem;
   color: var(--text);
   font-size: 0.92rem;
   line-height: 1.65;
+}
+
+.assistant-answer__text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.assistant-answer__scroll:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.assistant-error {
+  border-color: var(--danger-border);
+  color: #fecaca;
+}
+
+.assistant-error p {
+  margin-top: 0.45rem;
+  line-height: 1.55;
+}
+
+.assistant-error__limit {
+  color: var(--muted);
+}
+
+.assistant-citations,
+.assistant-details,
+.assistant-escalation {
+  margin-top: 0.85rem;
+  border-top: 1px solid rgb(148 163 184 / 0.12);
+  padding-top: 0.75rem;
+}
+
+.assistant-details {
+  flex: 0 0 auto;
+  color: var(--subtle);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.assistant-details summary {
+  cursor: pointer;
+  color: var(--muted);
+  font-weight: 850;
+}
+
+.assistant-details summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+
+.assistant-details__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin-top: 0.65rem;
+}
+
+.assistant-details__grid p {
+  overflow-wrap: anywhere;
+}
+
+.assistant-details__label {
+  display: block;
+  margin-bottom: 0.2rem;
+  color: var(--text);
+  font-size: 0.65rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.assistant-citations h3 {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.assistant-citations ul {
+  display: grid;
+  gap: 0.4rem;
+  margin-top: 0.45rem;
+  padding-left: 1rem;
+  color: var(--subtle);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.assistant-citations strong {
+  color: var(--text);
+}
+
+.assistant-escalation {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  border: 1px solid rgb(245 158 11 / 0.25);
+  border-radius: var(--radius-md);
+  background: rgb(120 53 15 / 0.12);
+  padding: 0.85rem;
+}
+
+.assistant-escalation p {
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.assistant-escalation__link {
+  flex: 0 0 auto;
+  padding: 0.65rem 0.85rem;
+  text-decoration: none;
+}
+
+.assistant-escalation__unavailable {
+  margin-top: 0.35rem;
+  color: var(--subtle) !important;
+  font-size: 0.72rem !important;
+}
+
+.assistant-escalation__actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 .assistant-limitations {
@@ -735,5 +884,23 @@ button:disabled {
   .danger-zone__gate,
   .assistant-layout {
     grid-template-columns: 1fr;
+  }
+
+  .assistant-answer__heading,
+  .assistant-escalation {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .assistant-details__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .assistant-answer__badges {
+    justify-content: flex-start;
+  }
+
+  .assistant-escalation__actions {
+    justify-content: flex-start;
   }
 }

--- a/mission-control/frontend/src/types/api.ts
+++ b/mission-control/frontend/src/types/api.ts
@@ -345,15 +345,35 @@ export interface AssistantAskRequest {
   screenContext?: AssistantClientContext;
 }
 
+export type AssistantResponseStatus = 'ok' | 'partial' | 'error' | 'timeout' | 'escalation';
+export type AssistantConfidence = 'high' | 'medium' | 'low' | 'none';
+
+export interface AssistantCitation {
+  label: string;
+  detail?: string;
+  timestamp?: string;
+}
+
+export interface AssistantEscalationLink {
+  label: string;
+  href: string;
+  kind: 'sre-agent' | 'azure-portal' | 'log-analytics' | 'app-insights' | 'grafana';
+  description: string;
+}
+
 export interface AssistantAskResponse {
   answer: string;
   metadata: {
     model: string;
-    status: 'ok';
+    status: AssistantResponseStatus;
+    uiState?: AssistantResponseStatus;
+    confidence?: AssistantConfidence;
     toolsUsed: string[];
     stateSnapshotTimestamp: string;
     sources: string[];
+    citations?: AssistantCitation[];
     limitations: string[];
+    escalationLinks?: AssistantEscalationLink[];
     timestamp: string;
   };
 }

--- a/mission-control/frontend/src/utils/portalLinks.ts
+++ b/mission-control/frontend/src/utils/portalLinks.ts
@@ -1,0 +1,35 @@
+import type { AssistantEscalationLink } from '@/types/api';
+
+const GENERIC_SRE_AGENT_HANDOFF = 'https://sre.azure.com';
+
+function isSafeHttpsUrl(value: string | undefined): value is string {
+  if (!value) return false;
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function configuredSreAgentHandoff(): AssistantEscalationLink {
+  const configuredUrl = import.meta.env.VITE_AZURE_SRE_AGENT_PORTAL_URL;
+  const href = isSafeHttpsUrl(configuredUrl) ? configuredUrl : GENERIC_SRE_AGENT_HANDOFF;
+
+  return {
+    label: href === GENERIC_SRE_AGENT_HANDOFF ? 'Open Azure SRE Agent portal' : 'Open configured Azure SRE Agent handoff',
+    href,
+    kind: 'sre-agent',
+    description: 'Handoff only: Local Analyst has not invoked Azure SRE Agent. Use the portal for cloud-side diagnosis and remediation guidance.',
+  };
+}
+
+export function visibleEscalationLinks(links: AssistantEscalationLink[] | undefined): AssistantEscalationLink[] {
+  const configuredFallback = configuredSreAgentHandoff();
+  const safeLinks = (links ?? [])
+    .filter(link => isSafeHttpsUrl(link.href))
+    .filter(link => link.kind !== 'sre-agent' || link.href !== GENERIC_SRE_AGENT_HANDOFF);
+
+  return [...safeLinks, configuredFallback];
+}

--- a/mission-control/frontend/tsconfig.json
+++ b/mission-control/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Adds governed read-only AKS and Log Analytics Analyst endpoints for issues #8 and #9.
- Adds evidence-shaped denied/unavailable responses, blocks request-supplied workspace overrides, and documents AKS-derived safe-language boundaries.
- Adds Local Analyst UI citations/confidence states, bounded scrolling, accessible response history, and safe Azure SRE Agent portal handoff for issues #10, #11, and #14.
- Restores TypeScript compiler options and validates the combined frontend/backend build.

## Validation
- npm run lint -w backend
- npm test -w backend (14/14)
- npm run lint -w frontend
- npm run build

Addresses #8, #9, #10, #11, #14.