### PR TITLE
Define cloud grid map data contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ See [docs/COSTS.md](docs/COSTS.md) for detailed breakdown and optimization tips.
 - [Kubernetes Service Troubleshooting](docs/KUBERNETES-SERVICE-TROUBLESHOOTING.md)
 - [Azure Networking Troubleshooting](docs/TROUBLESHOOTING.md)
 - [Cost Estimation](docs/COSTS.md)
-- [Interactive Grid Map Spec](docs/INTERACTIVE-GRID-MAP-SPEC.md) — design spec for the topology map screen (pending expert review)
+- [Interactive Grid Map Spec](docs/INTERACTIVE-GRID-MAP-SPEC.md) — approved cloud-demo topology map specification
+- [Cloud Grid Map Data Contract](docs/CLOUD-GRID-MAP-DATA-CONTRACT.md) — selected cloud host, V1 health sources, and reusable topology config for the grid map
 
 ## 🤝 Contributing
 

--- a/docs/CLOUD-GRID-MAP-DATA-CONTRACT.md
+++ b/docs/CLOUD-GRID-MAP-DATA-CONTRACT.md
@@ -1,0 +1,75 @@
+# Cloud Grid Map data contract
+
+This document closes the placement and data-contract gate for the Interactive Grid Map. The grid map belongs in the deployed cloud demo, not in local Mission Control.
+
+## Placement decision
+
+| Decision | Value |
+|---|---|
+| Host | `ops-console` |
+| Reason | `ops-console` is already the deployed Grid Operations Console and is the operator-facing cloud demo surface. |
+| Non-host | `grid-dashboard` remains the consumer portal for usage, billing, outage-map, and service-health storytelling. |
+| Not in scope | Local Mission Control UI and local Mission Control APIs are not runtime dependencies for the cloud grid map. |
+
+The selected host is the `ops-console` nginx-served ConfigMap and Service in `k8s/base/application.yaml`.
+
+## V1 data contract
+
+V1 uses existing in-cluster HTTP health proxies exposed by `ops-console`:
+
+| Node | Source | Healthy when | Notes |
+|---|---|---|---|
+| `asset-service` | `GET /api/assets/health` | HTTP 2xx | Proxied by `ops-console` nginx to `asset-service.energy.svc.cluster.local:3002`. |
+| `meter-service` | `GET /api/meter/health` | HTTP 2xx | Proxied by `ops-console` nginx to `meter-service.energy.svc.cluster.local:3000`. |
+| `dispatch-service` | `GET /api/dispatch/health` | HTTP 2xx | Proxied by `ops-console` nginx to `dispatch-service.energy.svc.cluster.local:3001`. |
+| `mongodb` | Static `in-cluster` | Rendered as static/in-cluster in V1 | No browser-safe direct health endpoint exists today. |
+| `rabbitmq` | Static `in-cluster` | Rendered as static/in-cluster in V1 | No browser-safe direct health endpoint exists today. |
+| `grid-dashboard` | Static `in-cluster` | Rendered as static/in-cluster in V1 | Existing LoadBalancer service is separate from the selected host. |
+| `ops-console` | Static `in-cluster` | Rendered as static/in-cluster in V1 | The current page proves the host is serving. |
+| `load-simulator` | Static `in-cluster` | Rendered as static/in-cluster in V1 | No browser-safe health endpoint exists today. |
+| `grid-worker` | Static `disabled` | Rendered as disabled/unknown in V1 | `application.yaml` sets `replicas: 0` because of an AMQP protocol mismatch. |
+| `forecast-service` | Optional absent | Rendered as `unknown` if included | `application.yaml` documents it as optional and it is not deployed today. |
+
+## Severity mapping
+
+| Input | Grid map severity |
+|---|---|
+| HTTP 2xx from a live health endpoint | `healthy` |
+| Timeout or network error from a live health endpoint | `critical` |
+| HTTP 5xx from a live health endpoint | `critical` |
+| HTTP 4xx from a live health endpoint | `warning` |
+| Static in-cluster node without a browser-safe endpoint | `unknown` or neutral static state, as chosen by renderer issue |
+| Optional absent node | `unknown` with explicit optional/absent label |
+
+Edge severity derives from endpoint severity using the approved visual rule `healthy < warning < critical`. `unknown` is separate and non-propagating: if either endpoint is `unknown` and neither endpoint is `warning` or `critical`, render the edge as unknown/gray/dashed. Do not treat `unknown` as worse than `critical` or as causal impact. Edge severity is only a visual impact cue and must not be described as root cause.
+
+## Static topology source
+
+The reusable topology config is `k8s/base/grid-map-topology.json`.
+
+It is reconciled with `k8s/base/application.yaml`:
+
+- Deployments: `rabbitmq`, `mongodb`, `asset-service`, `meter-service`, `dispatch-service`, `grid-dashboard`, `ops-console`, `load-simulator`, `grid-worker`.
+- Optional documented service: `forecast-service`.
+- Services and proxy paths are taken from the `grid-dashboard` and `ops-console` nginx ConfigMaps in `application.yaml`.
+- Runtime dependencies are taken from service URLs and environment variables in `application.yaml`, including `asset-service` to optional `forecast-service`, `load-simulator` to `meter-service`, and disabled `grid-worker` to `dispatch-service`.
+
+If `application.yaml` adds, removes, or renames a service, update `grid-map-topology.json` in the same pull request.
+
+## Explicit exclusions
+
+V1 must not use:
+
+- local Mission Control APIs such as `/api/inventory`, `/api/events`, `/api/pods/:name/logs`, or `/api/services/:name/endpoints`;
+- arbitrary Kubernetes API access from browser JavaScript;
+- pod logs, Kubernetes events, or endpoint details unless a future governed read-only in-cluster status endpoint is added;
+- write, exec, shell, secret, scale, patch, restart, or remediation actions;
+- any direct Azure SRE Agent chat/action API.
+
+## Safe-language requirement
+
+Required disclaimer:
+
+> Demo topology only. This map visualizes Kubernetes service/application health for the Azure SRE Agent demo and is not connected to real grid telemetry, SCADA, GIS, or utility infrastructure.
+
+The map may say that an application health endpoint is unreachable. It must not claim a real power outage, real grid telemetry, autonomous remediation, or Azure SRE Agent diagnosis unless separate portal evidence is captured.

--- a/docs/INTERACTIVE-GRID-MAP-SPEC.md
+++ b/docs/INTERACTIVE-GRID-MAP-SPEC.md
@@ -443,7 +443,7 @@ The grid map must not consume local Mission Control APIs. Issue A must select an
 2. Add a small read-only in-cluster status endpoint or sidecar specifically for demo topology health, with no secret, exec, shell, or remediation access.
 3. Split V1 into a static/topology-only cloud demo map plus explicit follow-up work for richer Kubernetes-derived state.
 
-Do not wire the cloud map to local Mission Control APIs as an implementation shortcut.
+Do not wire the cloud map to local Mission Control APIs as an implementation shortcut. The Issue A decision is captured in [Cloud Grid Map data contract](CLOUD-GRID-MAP-DATA-CONTRACT.md), with reusable topology in `k8s/base/grid-map-topology.json`.
 
 ### 5.4 Source and Citation Fields
 

--- a/k8s/base/grid-map-topology.json
+++ b/k8s/base/grid-map-topology.json
@@ -1,0 +1,170 @@
+{
+  "schemaVersion": "1.0",
+  "host": "ops-console",
+  "namespace": "energy",
+  "disclaimer": "Demo topology only. This map visualizes Kubernetes service/application health for the Azure SRE Agent demo and is not connected to real grid telemetry, SCADA, GIS, or utility infrastructure.",
+  "dataContract": {
+    "version": "cloud-demo-v1",
+    "source": "ops-console nginx proxy and static topology config",
+    "refreshSeconds": 30,
+    "severityOrder": ["healthy", "warning", "critical"],
+    "unknownHandling": "Unknown is a separate non-propagating state. Do not treat unknown as worse than critical.",
+    "liveHealth": {
+      "asset-service": {
+        "method": "GET",
+        "path": "/api/assets/health",
+        "healthyWhen": "HTTP 2xx response"
+      },
+      "meter-service": {
+        "method": "GET",
+        "path": "/api/meter/health",
+        "healthyWhen": "HTTP 2xx response"
+      },
+      "dispatch-service": {
+        "method": "GET",
+        "path": "/api/dispatch/health",
+        "healthyWhen": "HTTP 2xx response"
+      }
+    },
+    "staticHealth": {
+      "mongodb": "in-cluster",
+      "rabbitmq": "in-cluster",
+      "grid-dashboard": "in-cluster",
+      "ops-console": "in-cluster",
+      "load-simulator": "in-cluster",
+      "grid-worker": "disabled-replicas-0",
+      "forecast-service": "optional-absent"
+    },
+    "unsupportedInV1": [
+      "direct local Mission Control API reads",
+      "Kubernetes pod listing from browser JavaScript",
+      "Kubernetes events in the browser",
+      "pod logs in the browser",
+      "write, exec, shell, secret, scale, patch, restart, or remediation actions"
+    ]
+  },
+  "nodes": [
+    {
+      "id": "grid-dashboard",
+      "label": "Consumer Portal",
+      "resourceName": "grid-dashboard",
+      "metaphor": "Customer Energy Portal",
+      "kind": "service",
+      "icon": "dashboard",
+      "position": { "x": 120, "y": 120 },
+      "healthSource": "static"
+    },
+    {
+      "id": "ops-console",
+      "label": "Grid Operations Console",
+      "resourceName": "ops-console",
+      "metaphor": "Control Room",
+      "kind": "service",
+      "icon": "console",
+      "position": { "x": 120, "y": 320 },
+      "healthSource": "static"
+    },
+    {
+      "id": "meter-service",
+      "label": "Meter Service",
+      "resourceName": "meter-service",
+      "metaphor": "Smart Meter Ingestion",
+      "kind": "service",
+      "icon": "meter",
+      "position": { "x": 360, "y": 120 },
+      "healthSource": "live",
+      "healthPath": "/api/meter/health"
+    },
+    {
+      "id": "asset-service",
+      "label": "Asset Service",
+      "resourceName": "asset-service",
+      "metaphor": "Asset Catalog",
+      "kind": "service",
+      "icon": "assets",
+      "position": { "x": 360, "y": 320 },
+      "healthSource": "live",
+      "healthPath": "/api/assets/health"
+    },
+    {
+      "id": "dispatch-service",
+      "label": "Dispatch Service",
+      "resourceName": "dispatch-service",
+      "metaphor": "Energy Dispatch",
+      "kind": "service",
+      "icon": "dispatch",
+      "position": { "x": 600, "y": 220 },
+      "healthSource": "live",
+      "healthPath": "/api/dispatch/health"
+    },
+    {
+      "id": "rabbitmq",
+      "label": "RabbitMQ",
+      "resourceName": "rabbitmq",
+      "metaphor": "Event Bus",
+      "kind": "datastore",
+      "icon": "queue",
+      "position": { "x": 600, "y": 60 },
+      "healthSource": "static"
+    },
+    {
+      "id": "mongodb",
+      "label": "MongoDB",
+      "resourceName": "mongodb",
+      "metaphor": "Meter Data Store",
+      "kind": "datastore",
+      "icon": "database",
+      "position": { "x": 840, "y": 220 },
+      "healthSource": "static"
+    },
+    {
+      "id": "load-simulator",
+      "label": "Load Simulator",
+      "resourceName": "load-simulator",
+      "metaphor": "Consumer Demand Simulator",
+      "kind": "service",
+      "icon": "simulator",
+      "position": { "x": 360, "y": 520 },
+      "healthSource": "static"
+    },
+    {
+      "id": "grid-worker",
+      "label": "Grid Worker",
+      "resourceName": "grid-worker",
+      "metaphor": "Dispatch Worker",
+      "kind": "service",
+      "icon": "worker",
+      "position": { "x": 600, "y": 520 },
+      "healthSource": "static",
+      "replicas": 0,
+      "stateNote": "Disabled in application.yaml with replicas: 0 due to AMQP protocol mismatch"
+    },
+    {
+      "id": "forecast-service",
+      "label": "Forecast Service",
+      "resourceName": "forecast-service",
+      "metaphor": "Demand Forecast",
+      "kind": "service",
+      "icon": "forecast",
+      "position": { "x": 840, "y": 420 },
+      "healthSource": "optional",
+      "optional": true,
+      "absentBehavior": "Render as unknown with label Optional service absent in current deployment"
+    }
+  ],
+  "edges": [
+    { "source": "grid-dashboard", "target": "meter-service", "label": "Usage and billing data", "type": "sync" },
+    { "source": "grid-dashboard", "target": "asset-service", "label": "Asset catalog reads", "type": "sync" },
+    { "source": "ops-console", "target": "dispatch-service", "label": "Operations data", "type": "sync" },
+    { "source": "ops-console", "target": "asset-service", "label": "Asset inventory", "type": "sync" },
+    { "source": "meter-service", "target": "rabbitmq", "label": "Meter events", "type": "async" },
+    { "source": "meter-service", "target": "mongodb", "label": "Meter readings", "type": "sync" },
+    { "source": "rabbitmq", "target": "dispatch-service", "label": "Dispatch commands", "type": "async" },
+    { "source": "dispatch-service", "target": "mongodb", "label": "Grid state writes", "type": "sync" },
+    { "source": "asset-service", "target": "mongodb", "label": "Asset catalog data", "type": "sync" },
+    { "source": "dispatch-service", "target": "asset-service", "label": "Asset lookups", "type": "sync" },
+    { "source": "asset-service", "target": "forecast-service", "label": "Demand forecast", "type": "sync", "optional": true },
+    { "source": "load-simulator", "target": "meter-service", "label": "Simulated meter usage", "type": "sync" },
+    { "source": "grid-worker", "target": "dispatch-service", "label": "Disabled dispatch processing path", "type": "sync", "disabled": true }
+  ]
+}


### PR DESCRIPTION
## Summary
- Selects `ops-console` as the deployed cloud demo host for the Interactive Grid Map.
- Documents the V1 cloud data contract using existing `ops-console` nginx health proxies for asset, meter, and dispatch services.
- Adds `k8s/base/grid-map-topology.json` as the reusable static topology config for follow-on grid-map issues.
- Explicitly excludes local Mission Control APIs, unsafe browser-side Kubernetes access, and write/remediation actions.
- Documents optional/absent `forecast-service`, disabled `grid-worker`, and non-propagating `unknown` severity behavior.

## Validation
- JSON topology parsed successfully.
- All topology edges reference known nodes.
- `git diff --check` passed.
- Workflow Architect re-review approved the contract.

Closes #15.