### PR TITLE
Add cloud grid map selection and keyboard filtering

### DIFF
--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -844,6 +844,25 @@ data:
         .grid-map-svg { display: none; }
         .map-fallback { display: grid; }
       }
+      @media (prefers-reduced-motion: reduce) {
+        .loading { animation: none; }
+        .map-status-dot.healthy, .map-status-dot.warning, .map-status-dot.critical { filter: none; }
+      }
+      .node-ring, .node-focus-ring { fill: none; stroke: none; pointer-events: none; }
+      .map-node.selected .node-ring { stroke: var(--cyan); stroke-width: 3; filter: drop-shadow(0 0 8px rgba(34,211,238,.75)); }
+      .map-node:focus-visible { outline: none; }
+      .map-node:focus-visible .node-focus-ring { stroke: rgba(255,255,255,.88); stroke-width: 2; stroke-dasharray: 6 4; filter: drop-shadow(0 0 6px rgba(255,255,255,.45)); }
+      .map-node.dimmed { opacity: 0.22; }
+      .map-edge.dimmed { opacity: 0.12; }
+      .map-edge.selected { stroke: var(--cyan) !important; stroke-width: 5 !important; opacity: 1 !important; filter: drop-shadow(0 0 8px rgba(34,211,238,.65)); }
+      .map-edge-hit { stroke: transparent; stroke-width: 14; fill: none; cursor: pointer; }
+      .filter-bar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin-bottom: .75rem; }
+      .filter-btn { background: rgba(15,23,42,.8); border: 1px solid #475569; border-radius: 8px; color: var(--muted); padding: .35rem .7rem; cursor: pointer; font: inherit; font-size: .82rem; display: inline-flex; align-items: center; gap: .4rem; }
+      .filter-btn:hover, .filter-btn:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.35); outline-offset: 2px; }
+      .filter-btn[aria-pressed="true"] { background: rgba(34,211,238,.15); border-color: var(--cyan); color: var(--cyan); font-weight: 600; }
+      .filter-btn[data-filter="critical"][aria-pressed="true"] { background: rgba(248,113,113,.15); border-color: var(--red); color: var(--red); }
+      .filter-btn[data-filter="warning"][aria-pressed="true"] { background: rgba(251,191,36,.15); border-color: var(--amber); color: var(--amber); }
+      .filter-badge { display: inline-block; min-width: 1.3em; padding: .1em .35em; background: rgba(255,255,255,.1); border-radius: 999px; font-size: .75em; font-weight: 700; text-align: center; line-height: 1.4; }
     </style>
     </head>
      <body>
@@ -916,6 +935,12 @@ data:
              <button class="map-button" type="button" id="map-reset">Fit / Reset</button>
            </div>
          </div>
+          <div class="filter-bar" role="group" aria-label="Severity filter">
+            <span style="color:var(--muted);font-size:.82rem">Filter:</span>
+            <button class="filter-btn" type="button" data-filter="all" aria-pressed="true">All <span class="filter-badge" id="badge-all">—</span></button>
+            <button class="filter-btn" type="button" data-filter="critical" aria-pressed="false">Critical <span class="filter-badge" id="badge-critical">—</span></button>
+            <button class="filter-btn" type="button" data-filter="warning" aria-pressed="false">Warning <span class="filter-badge" id="badge-warning">—</span></button>
+          </div>
           <div class="map-disclaimer" role="note">
             Demo topology only. This map visualizes Kubernetes service/application health for the Azure SRE Agent demo and is not connected to real grid telemetry, SCADA, GIS, or utility infrastructure.
           </div>
@@ -984,7 +1009,7 @@ data:
       const MAP_HEALTH_POLL_MS = 30000;
       const STALE_AFTER_MS = 60000;
       const SEVERITY_RANK = { healthy: 0, warning: 1, critical: 2 };
-      const mapState = { x: 0, y: 0, k: 1, rendered: false, dragging: false, dragX: 0, dragY: 0, healthById: {}, lastSuccessfulHealthPoll: null, healthPollInFlight: false };
+       const mapState = { x: 0, y: 0, k: 1, rendered: false, dragging: false, dragX: 0, dragY: 0, dragMoved: false, healthById: {}, lastSuccessfulHealthPoll: null, healthPollInFlight: false, selectedNodeId: null, selectedEdgeKey: null, activeFilter: 'all' };
 
     function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
 
@@ -1200,13 +1225,14 @@ data:
               }
             });
           })
-          .finally(() => {
-            mapState.healthPollInFlight = false;
-            renderHealthGrid();
-            updateMapHealthBanner();
-            refreshGridMapAfterHealthChange();
-          });
-      }
+         .finally(() => {
+           mapState.healthPollInFlight = false;
+           renderHealthGrid();
+           updateMapHealthBanner();
+           refreshGridMapAfterHealthChange();
+           updateFilterBadges();
+         });
+       }
 
      function createSvgElement(name, attrs) {
        const el = document.createElementNS(SVG_NS, name);
@@ -1237,6 +1263,85 @@ data:
         return { className: 'unknown', label: 'unknown/static endpoint state' };
       }
 
+     function selectNode(nodeId) {
+       mapState.selectedNodeId = nodeId;
+       mapState.selectedEdgeKey = null;
+       applyNodeSelection();
+       applyEdgeSelection();
+     }
+     function selectEdge(key) {
+       mapState.selectedEdgeKey = key;
+       mapState.selectedNodeId = null;
+       applyNodeSelection();
+       applyEdgeSelection();
+     }
+     function clearSelection() {
+       mapState.selectedNodeId = null;
+       mapState.selectedEdgeKey = null;
+       applyNodeSelection();
+       applyEdgeSelection();
+     }
+     function applyNodeSelection() {
+       document.querySelectorAll('.map-node').forEach(function(group) {
+         var isSelected = group.dataset.nodeId === mapState.selectedNodeId && !!mapState.selectedNodeId;
+         group.classList.toggle('selected', isSelected);
+         group.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+       });
+     }
+     function applyEdgeSelection() {
+       document.querySelectorAll('.map-edge').forEach(function(line) {
+         line.classList.toggle('selected', !!mapState.selectedEdgeKey && line.dataset.edgeKey === mapState.selectedEdgeKey);
+       });
+     }
+     function updateFilterBadges() {
+       var total = GRID_TOPOLOGY.nodes.length;
+       var critical = 0, warning = 0;
+       GRID_TOPOLOGY.nodes.forEach(function(node) {
+         var sev = getMapStatus(node).severity;
+         if (sev === 'critical') critical++;
+         else if (sev === 'warning') warning++;
+       });
+       var badgeAll = document.getElementById('badge-all');
+       var badgeCritical = document.getElementById('badge-critical');
+       var badgeWarning = document.getElementById('badge-warning');
+       if (badgeAll) badgeAll.textContent = total;
+       if (badgeCritical) badgeCritical.textContent = critical;
+       if (badgeWarning) badgeWarning.textContent = warning;
+     }
+     function applySeverityFilter() {
+       var filter = mapState.activeFilter;
+       document.querySelectorAll('[data-filter]').forEach(function(btn) {
+         btn.setAttribute('aria-pressed', btn.dataset.filter === filter ? 'true' : 'false');
+       });
+       document.querySelectorAll('.map-node').forEach(function(group) {
+         var nodeId = group.dataset.nodeId;
+         if (!nodeId || filter === 'all') { group.classList.remove('dimmed'); return; }
+         var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === nodeId; });
+         var severity = node ? getMapStatus(node).severity : 'unknown';
+         group.classList.toggle('dimmed', severity !== filter);
+       });
+       document.querySelectorAll('.map-edge').forEach(function(line) {
+         if (filter === 'all') { line.classList.remove('dimmed'); return; }
+         var key = line.dataset.edgeKey;
+         if (!key) return;
+         var parts = key.split(':');
+         var srcNode = document.querySelector('.map-node[data-node-id="' + parts[0] + '"]');
+         var tgtNode = document.querySelector('.map-node[data-node-id="' + parts[1] + '"]');
+         var srcDimmed = srcNode && srcNode.classList.contains('dimmed');
+         var tgtDimmed = tgtNode && tgtNode.classList.contains('dimmed');
+         line.classList.toggle('dimmed', srcDimmed && tgtDimmed);
+       });
+       updateFilterBadges();
+     }
+     function initSeverityFilter() {
+       document.querySelectorAll('[data-filter]').forEach(function(btn) {
+         btn.addEventListener('click', function() {
+           mapState.activeFilter = btn.dataset.filter;
+           applySeverityFilter();
+         });
+       });
+       updateFilterBadges();
+     }
      function nodeCenter(node) {
        return { x: node.position.x + MAP_NODE.width / 2, y: node.position.y + MAP_NODE.height / 2 };
      }
@@ -1256,7 +1361,9 @@ data:
          class: 'map-node service ' + status.className,
          tabindex: '0',
          role: 'img',
-         'aria-label': node.label + ', ' + node.metaphor + ', ' + status.text
+         'aria-label': node.label + ', ' + node.metaphor + ', ' + status.text,
+         'data-node-id': node.id,
+         'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
        });
         const x = node.position.x;
         const y = node.position.y;
@@ -1274,6 +1381,9 @@ data:
        const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64 });
        state.textContent = status.text;
        group.appendChild(state);
+       group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 18, ry: 18 }));
+       group.appendChild(createSvgElement('rect', { class: 'node-focus-ring', x: x - 7, y: y - 7, width: MAP_NODE.width + 14, height: MAP_NODE.height + 14, rx: 21, ry: 21 }));
+       if (mapState.selectedNodeId === node.id) group.classList.add('selected');
        stage.appendChild(group);
      }
 
@@ -1283,7 +1393,9 @@ data:
          class: 'map-node datastore ' + status.className,
          tabindex: '0',
          role: 'img',
-         'aria-label': node.label + ', data store, ' + node.metaphor + ', ' + status.text
+         'aria-label': node.label + ', data store, ' + node.metaphor + ', ' + status.text,
+         'data-node-id': node.id,
+         'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
        });
        const x = node.position.x;
        const y = node.position.y;
@@ -1303,6 +1415,9 @@ data:
        const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 67 });
        state.textContent = status.text;
        group.appendChild(state);
+       group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 14, ry: 14 }));
+       group.appendChild(createSvgElement('rect', { class: 'node-focus-ring', x: x - 7, y: y - 7, width: MAP_NODE.width + 14, height: MAP_NODE.height + 14, rx: 17, ry: 17 }));
+       if (mapState.selectedNodeId === node.id) group.classList.add('selected');
        stage.appendChild(group);
      }
 
@@ -1326,22 +1441,32 @@ data:
          const source = nodesById[edge.source];
           const target = nodesById[edge.target];
           if (!source || !target) return;
-          const start = edgeAnchor(source, target);
-          const end = edgeAnchor(target, source);
-          const edgeStatus = getEdgeStatus(edge, source, target);
-          const edgeLine = createSvgElement('line', {
-            class: 'map-edge ' + edgeStatus.className,
-            x1: start.x,
-            y1: start.y,
-            x2: end.x,
-            y2: end.y,
-            'marker-end': 'url(#map-arrowhead)',
-            'aria-label': edge.label + ', ' + edgeStatus.label
-          });
-          stage.appendChild(edgeLine);
-          const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle' });
-          label.textContent = edge.label + (edgeStatus.className === 'unknown' ? ' · unknown' : edgeStatus.className === 'critical' ? ' · critical' : edgeStatus.className === 'warning' ? ' · warning' : '');
-          stage.appendChild(label);
+           const start = edgeAnchor(source, target);
+           const end = edgeAnchor(target, source);
+           const edgeStatus = getEdgeStatus(edge, source, target);
+           const edgeKey = edge.source + ':' + edge.target;
+           const edgeLine = createSvgElement('line', {
+             class: 'map-edge ' + edgeStatus.className + (mapState.selectedEdgeKey === edgeKey ? ' selected' : ''),
+             x1: start.x,
+             y1: start.y,
+             x2: end.x,
+             y2: end.y,
+             'marker-end': 'url(#map-arrowhead)',
+             role: 'img',
+             'aria-label': edge.label + ', ' + edgeStatus.label,
+             'data-edge-key': edgeKey
+           });
+           stage.appendChild(edgeLine);
+           const edgeHit = createSvgElement('line', {
+             class: 'map-edge-hit',
+             x1: start.x, y1: start.y, x2: end.x, y2: end.y,
+             'data-edge-key': edgeKey,
+             'aria-hidden': 'true'
+           });
+           stage.appendChild(edgeHit);
+           const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle' });
+           label.textContent = edge.label + (edgeStatus.className === 'unknown' ? ' · unknown' : edgeStatus.className === 'critical' ? ' · critical' : edgeStatus.className === 'warning' ? ' · warning' : '');
+           stage.appendChild(label);
         });
 
        GRID_TOPOLOGY.nodes.forEach(node => {
@@ -1351,6 +1476,9 @@ data:
 
        mapState.rendered = true;
        bindGridMapInteractions();
+       applyNodeSelection();
+       applyEdgeSelection();
+       applySeverityFilter();
        fitGridMap();
      }
 
@@ -1420,14 +1548,18 @@ data:
        svg.addEventListener('pointerdown', event => {
          if (event.button !== 0) return;
          mapState.dragging = true;
+         mapState.dragMoved = false;
          mapState.dragX = event.clientX;
          mapState.dragY = event.clientY;
          svg.setPointerCapture(event.pointerId);
        });
        svg.addEventListener('pointermove', event => {
          if (!mapState.dragging) return;
-         mapState.x += event.clientX - mapState.dragX;
-         mapState.y += event.clientY - mapState.dragY;
+         const dx = event.clientX - mapState.dragX;
+         const dy = event.clientY - mapState.dragY;
+         if (Math.abs(dx) + Math.abs(dy) > 4) mapState.dragMoved = true;
+         mapState.x += dx;
+         mapState.y += dy;
          mapState.dragX = event.clientX;
          mapState.dragY = event.clientY;
          applyMapTransform();
@@ -1436,14 +1568,35 @@ data:
          mapState.dragging = false;
          if (svg.hasPointerCapture(event.pointerId)) svg.releasePointerCapture(event.pointerId);
        });
+       svg.addEventListener('click', event => {
+         if (mapState.dragMoved) { mapState.dragMoved = false; return; }
+         const nodeGroup = event.target.closest ? event.target.closest('.map-node') : null;
+         if (nodeGroup && nodeGroup.dataset.nodeId) {
+           const id = nodeGroup.dataset.nodeId;
+           if (mapState.selectedNodeId === id) clearSelection(); else selectNode(id);
+           return;
+         }
+         const hitLine = event.target.closest ? event.target.closest('.map-edge-hit') : null;
+         if (hitLine && hitLine.dataset.edgeKey) {
+           const key = hitLine.dataset.edgeKey;
+           if (mapState.selectedEdgeKey === key) clearSelection(); else selectEdge(key);
+           return;
+         }
+         clearSelection();
+       });
        svg.addEventListener('keydown', event => {
          const step = 26;
-         if (event.key === '+' || event.key === '=') { zoomGridMap(1.12); event.preventDefault(); }
-         if (event.key === '-' || event.key === '_') { zoomGridMap(0.88); event.preventDefault(); }
-         if (event.key === '0') { fitGridMap(); event.preventDefault(); }
-         if (event.key === 'ArrowLeft') { mapState.x += step; applyMapTransform(); event.preventDefault(); }
-         if (event.key === 'ArrowRight') { mapState.x -= step; applyMapTransform(); event.preventDefault(); }
-         if (event.key === 'ArrowUp') { mapState.y += step; applyMapTransform(); event.preventDefault(); }
+         if (event.key === 'Escape') { clearSelection(); return; }
+         if (event.key === 'Enter') {
+           const nodeGroup = event.target.closest ? event.target.closest('.map-node') : null;
+           if (nodeGroup && nodeGroup.dataset.nodeId) { selectNode(nodeGroup.dataset.nodeId); event.preventDefault(); return; }
+         }
+         if (event.key === '+' || event.key === '=') { zoomGridMap(1.12); event.preventDefault(); return; }
+         if (event.key === '-' || event.key === '_') { zoomGridMap(0.88); event.preventDefault(); return; }
+         if (event.key === '0') { fitGridMap(); event.preventDefault(); return; }
+         if (event.key === 'ArrowLeft') { mapState.x += step; applyMapTransform(); event.preventDefault(); return; }
+         if (event.key === 'ArrowRight') { mapState.x -= step; applyMapTransform(); event.preventDefault(); return; }
+         if (event.key === 'ArrowUp') { mapState.y += step; applyMapTransform(); event.preventDefault(); return; }
          if (event.key === 'ArrowDown') { mapState.y -= step; applyMapTransform(); event.preventDefault(); }
        });
      }
@@ -1474,6 +1627,7 @@ data:
      }
 
      function initViewToggle() {
+       initSeverityFilter();
        document.querySelectorAll('[data-view-target]').forEach(button => {
          button.addEventListener('click', () => setConsoleView(button.dataset.viewTarget, true));
        });

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -852,8 +852,8 @@ data:
       .map-node.selected .node-ring { stroke: var(--cyan); stroke-width: 3; filter: drop-shadow(0 0 8px rgba(34,211,238,.75)); }
       .map-node:focus-visible { outline: none; }
       .map-node:focus-visible .node-focus-ring { stroke: rgba(255,255,255,.88); stroke-width: 2; stroke-dasharray: 6 4; filter: drop-shadow(0 0 6px rgba(255,255,255,.45)); }
-      .map-node.dimmed { opacity: 0.40; }
-      .map-edge.dimmed { opacity: 0.28; }
+      .map-node.dimmed { opacity: 0.52; }
+      .map-edge.dimmed { opacity: 0.45; pointer-events: none; }
       .map-edge.selected { stroke: var(--cyan) !important; stroke-width: 5 !important; opacity: 1 !important; filter: drop-shadow(0 0 8px rgba(34,211,238,.65)); }
       .map-edge-hit { stroke: transparent; stroke-width: 14; fill: none; cursor: pointer; }
       .filter-bar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin-bottom: .75rem; }
@@ -1292,7 +1292,7 @@ data:
        mapState.selectedEdgeKey = null;
        applyNodeSelection();
        applyEdgeSelection();
-       updateSelectionStatus('');
+       updateSelectionStatus('Selection cleared.');
      }
      function applyNodeSelection() {
        document.querySelectorAll('.map-node').forEach(function(group) {
@@ -1335,7 +1335,7 @@ data:
          group.classList.toggle('dimmed', severity !== filter);
        });
        document.querySelectorAll('.map-edge').forEach(function(line) {
-         if (filter === 'all') { line.classList.remove('dimmed'); return; }
+         if (filter === 'all') { line.classList.remove('dimmed'); line.removeAttribute('aria-hidden'); return; }
          var key = line.dataset.edgeKey;
          if (!key) return;
          var parts = key.split(':');
@@ -1343,7 +1343,9 @@ data:
          var tgtNode = document.querySelector('.map-node[data-node-id="' + parts[1] + '"]');
          var srcDimmed = srcNode && srcNode.classList.contains('dimmed');
          var tgtDimmed = tgtNode && tgtNode.classList.contains('dimmed');
-         line.classList.toggle('dimmed', srcDimmed && tgtDimmed);
+         var isDimmed = srcDimmed && tgtDimmed;
+         line.classList.toggle('dimmed', isDimmed);
+         if (isDimmed) { line.setAttribute('aria-hidden', 'true'); } else { line.removeAttribute('aria-hidden'); }
        });
        updateFilterBadges();
      }
@@ -1385,13 +1387,13 @@ data:
         const symbol = createSvgElement('text', { class: 'map-node-symbol', x: x + MAP_NODE.width - 22, y: y + 24, 'text-anchor': 'middle', 'aria-hidden': 'true' });
         symbol.textContent = status.symbol;
         group.appendChild(symbol);
-        const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 23 });
+        const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 23, 'aria-hidden': 'true' });
         title.textContent = node.label;
         group.appendChild(title);
-       const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 46 });
+       const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 46, 'aria-hidden': 'true' });
        subtitle.textContent = node.metaphor;
        group.appendChild(subtitle);
-       const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64 });
+       const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64, 'aria-hidden': 'true' });
        state.textContent = status.text;
        group.appendChild(state);
        group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 18, ry: 18 }));
@@ -1418,13 +1420,13 @@ data:
         const symbol = createSvgElement('text', { class: 'map-node-symbol', x: x + MAP_NODE.width - 22, y: y + 27, 'text-anchor': 'middle', 'aria-hidden': 'true' });
         symbol.textContent = status.symbol;
         group.appendChild(symbol);
-        const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 27 });
+        const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 27, 'aria-hidden': 'true' });
        title.textContent = node.label;
        group.appendChild(title);
-       const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 50 });
+       const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 50, 'aria-hidden': 'true' });
        subtitle.textContent = node.metaphor;
        group.appendChild(subtitle);
-       const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 67 });
+       const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 67, 'aria-hidden': 'true' });
        state.textContent = status.text;
        group.appendChild(state);
        group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 14, ry: 14 }));
@@ -1591,6 +1593,8 @@ data:
          const hitLine = event.target.closest ? event.target.closest('.map-edge-hit') : null;
          if (hitLine && hitLine.dataset.edgeKey) {
            const key = hitLine.dataset.edgeKey;
+           const edgeLine = document.querySelector('.map-edge[data-edge-key="' + key + '"]');
+           if (edgeLine && edgeLine.classList.contains('dimmed')) return;
            if (mapState.selectedEdgeKey === key) clearSelection(); else selectEdge(key);
            return;
          }

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -948,11 +948,11 @@ data:
           <div class="map-health-banner warning" id="map-health-banner" role="status" aria-live="polite">
             Live service health has not been received yet. Static and optional nodes are shown in a safe unknown/static state.
           </div>
-          <p class="sr-only">Interactive topology map. Tab between nodes, Enter to select, Escape to deselect. Use arrow keys to pan, + / &#8722; to zoom, 0 to fit.</p>
+          <p class="sr-only" id="map-instructions">Interactive topology map. Tab between nodes, Enter to select, Escape to deselect. Use arrow keys to pan, + / &#8722; to zoom, 0 to fit.</p>
           <div id="map-selection-status" role="status" aria-live="polite" class="sr-only"></div>
           <div class="card">
            <div class="grid-map-shell" id="grid-map-shell">
-             <svg id="grid-map-svg" class="grid-map-svg" role="application" aria-roledescription="interactive topology map" aria-label="Interactive cloud demo topology map" tabindex="0">
+             <svg id="grid-map-svg" class="grid-map-svg" role="application" aria-roledescription="interactive topology map" aria-label="Interactive cloud demo topology map" aria-describedby="map-instructions" tabindex="0">
                <g id="grid-map-stage"></g>
              </svg>
              <div class="map-fallback" id="map-fallback" hidden>

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -799,7 +799,7 @@ data:
       .map-toolbar { display: flex; gap: .6rem; align-items: center; justify-content: space-between; flex-wrap: wrap; margin-bottom: .8rem; }
       .map-controls { display: flex; gap: .5rem; flex-wrap: wrap; }
       .map-button { background: #0f172a; border: 1px solid #475569; border-radius: 8px; color: var(--text); padding: .45rem .65rem; cursor: pointer; font: inherit; font-size: .85rem; }
-      .map-button:hover, .map-button:focus-visible { border-color: var(--cyan); outline: 2px solid rgba(34,211,238,.35); outline-offset: 2px; }
+      .map-button:hover, .map-button:focus-visible { border-color: var(--cyan); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
       .map-meta { color: var(--muted); font-size: .8rem; }
       .map-disclaimer { border: 1px solid rgba(251,191,36,.35); background: rgba(120,53,15,.18); color: #fde68a; border-radius: 10px; padding: .8rem 1rem; margin-bottom: 1rem; font-size: .86rem; line-height: 1.45; }
       .map-health-banner { border: 1px solid rgba(148,163,184,.38); background: rgba(15,23,42,.82); color: #cbd5e1; border-radius: 10px; padding: .75rem 1rem; margin-bottom: 1rem; font-size: .86rem; line-height: 1.45; }
@@ -852,26 +852,27 @@ data:
       .map-node.selected .node-ring { stroke: var(--cyan); stroke-width: 3; filter: drop-shadow(0 0 8px rgba(34,211,238,.75)); }
       .map-node:focus-visible { outline: none; }
       .map-node:focus-visible .node-focus-ring { stroke: rgba(255,255,255,.88); stroke-width: 2; stroke-dasharray: 6 4; filter: drop-shadow(0 0 6px rgba(255,255,255,.45)); }
-      .map-node.dimmed { opacity: 0.22; }
-      .map-edge.dimmed { opacity: 0.12; }
+      .map-node.dimmed { opacity: 0.40; }
+      .map-edge.dimmed { opacity: 0.28; }
       .map-edge.selected { stroke: var(--cyan) !important; stroke-width: 5 !important; opacity: 1 !important; filter: drop-shadow(0 0 8px rgba(34,211,238,.65)); }
       .map-edge-hit { stroke: transparent; stroke-width: 14; fill: none; cursor: pointer; }
       .filter-bar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin-bottom: .75rem; }
       .filter-btn { background: rgba(15,23,42,.8); border: 1px solid #475569; border-radius: 8px; color: var(--muted); padding: .35rem .7rem; cursor: pointer; font: inherit; font-size: .82rem; display: inline-flex; align-items: center; gap: .4rem; }
-      .filter-btn:hover, .filter-btn:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.35); outline-offset: 2px; }
+      .filter-btn:hover, .filter-btn:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
       .filter-btn[aria-pressed="true"] { background: rgba(34,211,238,.15); border-color: var(--cyan); color: var(--cyan); font-weight: 600; }
       .filter-btn[data-filter="critical"][aria-pressed="true"] { background: rgba(248,113,113,.15); border-color: var(--red); color: var(--red); }
       .filter-btn[data-filter="warning"][aria-pressed="true"] { background: rgba(251,191,36,.15); border-color: var(--amber); color: var(--amber); }
       .filter-badge { display: inline-block; min-width: 1.3em; padding: .1em .35em; background: rgba(255,255,255,.1); border-radius: 999px; font-size: .75em; font-weight: 700; text-align: center; line-height: 1.4; }
+      .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
     </style>
     </head>
      <body>
      <header>
        <div class="header-left">
          <h1>&#9881; Grid Operations Console</h1>
-         <nav class="view-toggle" aria-label="Console views">
-           <button type="button" id="operations-tab" data-view-target="operations" aria-selected="true">Operations</button>
-           <button type="button" id="map-tab" data-view-target="map" aria-selected="false">Grid Map</button>
+         <nav class="view-toggle" role="tablist" aria-label="Console views">
+           <button type="button" id="operations-tab" role="tab" aria-controls="operations-view" data-view-target="operations" aria-selected="true">Operations</button>
+           <button type="button" id="map-tab" role="tab" aria-controls="map-view" data-view-target="map" aria-selected="false">Grid Map</button>
          </nav>
        </div>
        <div class="status-bar">
@@ -880,7 +881,7 @@ data:
        </div>
      </header>
      <main>
-       <section id="operations-view" class="app-view" data-view="operations">
+       <section id="operations-view" class="app-view" role="tabpanel" aria-labelledby="operations-tab" data-view="operations">
          <div class="grid">
            <div class="card">
              <h3>Dispatch Queue Depth</h3>
@@ -923,13 +924,13 @@ data:
          <div class="grid" id="health-grid"></div>
        </section>
 
-       <section id="map-view" class="app-view" data-view="map" hidden>
+       <section id="map-view" class="app-view" role="tabpanel" aria-labelledby="map-tab" data-view="map" hidden>
          <div class="map-toolbar">
            <div>
              <h2 class="section-title" style="margin-top:0">&#128506; Cloud Demo Grid Map</h2>
               <div class="map-meta">Topology and live service health use the approved cloud grid-map data contract. Live checks poll every 30 seconds.</div>
            </div>
-           <div class="map-controls" aria-label="Grid map controls">
+           <div class="map-controls" role="group" aria-label="Grid map controls">
              <button class="map-button" type="button" id="map-zoom-in">Zoom in</button>
              <button class="map-button" type="button" id="map-zoom-out">Zoom out</button>
              <button class="map-button" type="button" id="map-reset">Fit / Reset</button>
@@ -937,9 +938,9 @@ data:
          </div>
           <div class="filter-bar" role="group" aria-label="Severity filter">
             <span style="color:var(--muted);font-size:.82rem">Filter:</span>
-            <button class="filter-btn" type="button" data-filter="all" aria-pressed="true">All <span class="filter-badge" id="badge-all">—</span></button>
-            <button class="filter-btn" type="button" data-filter="critical" aria-pressed="false">Critical <span class="filter-badge" id="badge-critical">—</span></button>
-            <button class="filter-btn" type="button" data-filter="warning" aria-pressed="false">Warning <span class="filter-badge" id="badge-warning">—</span></button>
+            <button class="filter-btn" type="button" data-filter="all" aria-pressed="true">All <span class="filter-badge" id="badge-all" aria-label="loading">—</span></button>
+            <button class="filter-btn" type="button" data-filter="critical" aria-pressed="false">Critical <span class="filter-badge" id="badge-critical" aria-label="loading">—</span></button>
+            <button class="filter-btn" type="button" data-filter="warning" aria-pressed="false">Warning <span class="filter-badge" id="badge-warning" aria-label="loading">—</span></button>
           </div>
           <div class="map-disclaimer" role="note">
             Demo topology only. This map visualizes Kubernetes service/application health for the Azure SRE Agent demo and is not connected to real grid telemetry, SCADA, GIS, or utility infrastructure.
@@ -947,9 +948,11 @@ data:
           <div class="map-health-banner warning" id="map-health-banner" role="status" aria-live="polite">
             Live service health has not been received yet. Static and optional nodes are shown in a safe unknown/static state.
           </div>
+          <p class="sr-only">Interactive topology map. Tab between nodes, Enter to select, Escape to deselect. Use arrow keys to pan, + / &#8722; to zoom, 0 to fit.</p>
+          <div id="map-selection-status" role="status" aria-live="polite" class="sr-only"></div>
           <div class="card">
            <div class="grid-map-shell" id="grid-map-shell">
-             <svg id="grid-map-svg" class="grid-map-svg" role="img" aria-label="Static cloud demo topology graph with service and data-store nodes" tabindex="0">
+             <svg id="grid-map-svg" class="grid-map-svg" role="application" aria-roledescription="interactive topology map" aria-label="Interactive cloud demo topology map" tabindex="0">
                <g id="grid-map-stage"></g>
              </svg>
              <div class="map-fallback" id="map-fallback" hidden>
@@ -1263,29 +1266,40 @@ data:
         return { className: 'unknown', label: 'unknown/static endpoint state' };
       }
 
+     function updateSelectionStatus(text) {
+       var el = document.getElementById('map-selection-status');
+       if (el) el.textContent = text;
+     }
      function selectNode(nodeId) {
        mapState.selectedNodeId = nodeId;
        mapState.selectedEdgeKey = null;
        applyNodeSelection();
        applyEdgeSelection();
+       var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === nodeId; });
+       updateSelectionStatus(node ? node.label + ' selected' : '');
      }
      function selectEdge(key) {
        mapState.selectedEdgeKey = key;
        mapState.selectedNodeId = null;
        applyNodeSelection();
        applyEdgeSelection();
+       var parts = key ? key.split(':') : [];
+       var edge = GRID_TOPOLOGY.edges.find(function(e) { return e.source === parts[0] && e.target === parts[1]; });
+       updateSelectionStatus(edge ? edge.label + ' connection selected' : '');
      }
      function clearSelection() {
        mapState.selectedNodeId = null;
        mapState.selectedEdgeKey = null;
        applyNodeSelection();
        applyEdgeSelection();
+       updateSelectionStatus('');
      }
      function applyNodeSelection() {
        document.querySelectorAll('.map-node').forEach(function(group) {
          var isSelected = group.dataset.nodeId === mapState.selectedNodeId && !!mapState.selectedNodeId;
          group.classList.toggle('selected', isSelected);
-         group.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+         var base = (group.getAttribute('aria-label') || '').replace(', selected', '');
+         group.setAttribute('aria-label', isSelected ? base + ', selected' : base);
        });
      }
      function applyEdgeSelection() {
@@ -1304,9 +1318,9 @@ data:
        var badgeAll = document.getElementById('badge-all');
        var badgeCritical = document.getElementById('badge-critical');
        var badgeWarning = document.getElementById('badge-warning');
-       if (badgeAll) badgeAll.textContent = total;
-       if (badgeCritical) badgeCritical.textContent = critical;
-       if (badgeWarning) badgeWarning.textContent = warning;
+       if (badgeAll) { badgeAll.textContent = total; badgeAll.removeAttribute('aria-label'); }
+       if (badgeCritical) { badgeCritical.textContent = critical; badgeCritical.removeAttribute('aria-label'); }
+       if (badgeWarning) { badgeWarning.textContent = warning; badgeWarning.removeAttribute('aria-label'); }
      }
      function applySeverityFilter() {
        var filter = mapState.activeFilter;
@@ -1362,8 +1376,7 @@ data:
          tabindex: '0',
          role: 'img',
          'aria-label': node.label + ', ' + node.metaphor + ', ' + status.text,
-         'data-node-id': node.id,
-         'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
+         'data-node-id': node.id
        });
         const x = node.position.x;
         const y = node.position.y;
@@ -1394,8 +1407,7 @@ data:
          tabindex: '0',
          role: 'img',
          'aria-label': node.label + ', data store, ' + node.metaphor + ', ' + status.text,
-         'data-node-id': node.id,
-         'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
+         'data-node-id': node.id
        });
        const x = node.position.x;
        const y = node.position.y;
@@ -1464,7 +1476,7 @@ data:
              'aria-hidden': 'true'
            });
            stage.appendChild(edgeHit);
-           const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle' });
+           const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle', 'aria-hidden': 'true' });
            label.textContent = edge.label + (edgeStatus.className === 'unknown' ? ' · unknown' : edgeStatus.className === 'critical' ? ' · critical' : edgeStatus.className === 'warning' ? ' · warning' : '');
            stage.appendChild(label);
         });

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -1201,7 +1201,7 @@ data:
       function refreshGridMapAfterHealthChange() {
         mapState.rendered = false;
         const mapView = document.getElementById('map-view');
-        if (mapView && !mapView.hidden) renderGridMap();
+        if (mapView && !mapView.hidden) renderGridMap({ preserveViewport: true });
       }
 
       function loadHealth() {
@@ -1421,7 +1421,7 @@ data:
        stage.appendChild(group);
      }
 
-     function renderGridMap() {
+     function renderGridMap(opts) {
        const svg = document.getElementById('grid-map-svg');
        const stage = document.getElementById('grid-map-stage');
        if (!svg || !stage || mapState.rendered) return;
@@ -1479,7 +1479,7 @@ data:
        applyNodeSelection();
        applyEdgeSelection();
        applySeverityFilter();
-       fitGridMap();
+       if (!opts || !opts.preserveViewport) fitGridMap();
      }
 
      function getMapBounds() {
@@ -1655,8 +1655,6 @@ data:
     </script>
     </body>
     </html>
-
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -451,7 +451,7 @@ function addLogEntry() {
   function refreshGridMapAfterHealthChange() {
     mapState.rendered = false;
     const mapView = document.getElementById('map-view');
-    if (mapView && !mapView.hidden) renderGridMap();
+    if (mapView && !mapView.hidden) renderGridMap({ preserveViewport: true });
   }
 
   function loadHealth() {
@@ -671,7 +671,7 @@ function addLogEntry() {
    stage.appendChild(group);
  }
 
- function renderGridMap() {
+ function renderGridMap(opts) {
    const svg = document.getElementById('grid-map-svg');
    const stage = document.getElementById('grid-map-stage');
    if (!svg || !stage || mapState.rendered) return;
@@ -729,7 +729,7 @@ function addLogEntry() {
    applyNodeSelection();
    applyEdgeSelection();
    applySeverityFilter();
-   fitGridMap();
+   if (!opts || !opts.preserveViewport) fitGridMap();
  }
 
  function getMapBounds() {

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -8,14 +8,20 @@
   :root { --bg: #0f172a; --card: #1e293b; --accent: #a78bfa; --green: #34d399; --amber: #fbbf24; --red: #f87171; --cyan: #22d3ee; --text: #e2e8f0; --muted: #94a3b8; }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
-  header { background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%); border-bottom: 2px solid var(--accent); padding: 1rem 2rem; display: flex; align-items: center; justify-content: space-between; }
+  header { background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%); border-bottom: 2px solid var(--accent); padding: 1rem 2rem; display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
   header h1 { font-size: 1.4rem; font-weight: 600; display: flex; align-items: center; gap: .6rem; }
+  .header-left { display: flex; align-items: center; gap: 1.25rem; flex-wrap: wrap; }
+  .view-toggle { display: inline-flex; gap: .25rem; padding: .25rem; border: 1px solid rgba(167,139,250,.45); border-radius: 999px; background: rgba(15,23,42,.55); }
+  .view-toggle button { border: 0; border-radius: 999px; padding: .45rem .8rem; color: var(--muted); background: transparent; font: inherit; font-size: .85rem; cursor: pointer; }
+  .view-toggle button:hover, .view-toggle button:focus-visible { color: var(--text); outline: 2px solid rgba(34,211,238,.55); outline-offset: 2px; }
+  .view-toggle button[aria-selected="true"] { color: #0f172a; background: var(--green); box-shadow: 0 0 12px rgba(52,211,153,.35); font-weight: 700; }
   .status-bar { display: flex; gap: 1.5rem; font-size: .85rem; }
   .status-bar .item { display: flex; align-items: center; gap: .4rem; }
   .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
   .dot.green { background: var(--green); box-shadow: 0 0 6px var(--green); }
   .dot.amber { background: var(--amber); box-shadow: 0 0 6px var(--amber); }
   .dot.red { background: var(--red); box-shadow: 0 0 6px var(--red); }
+  .dot.unknown { background: #94a3b8; box-shadow: 0 0 6px rgb(148 163 184 / 0.45); }
   main { padding: 1.5rem 2rem; }
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.2rem; margin-bottom: 1.5rem; }
   .card { background: var(--card); border-radius: 10px; padding: 1.2rem; border: 1px solid #334155; }
@@ -39,66 +45,221 @@
   .log-box .err { color: var(--red); }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .5; } }
   .loading { animation: pulse 1.5s infinite; color: var(--muted); }
+  .app-view[hidden] { display: none; }
+  .map-toolbar { display: flex; gap: .6rem; align-items: center; justify-content: space-between; flex-wrap: wrap; margin-bottom: .8rem; }
+  .map-controls { display: flex; gap: .5rem; flex-wrap: wrap; }
+  .map-button { background: #0f172a; border: 1px solid #475569; border-radius: 8px; color: var(--text); padding: .45rem .65rem; cursor: pointer; font: inherit; font-size: .85rem; }
+  .map-button:hover, .map-button:focus-visible { border-color: var(--cyan); outline: 2px solid rgba(34,211,238,.35); outline-offset: 2px; }
+  .map-meta { color: var(--muted); font-size: .8rem; }
+  .map-disclaimer { border: 1px solid rgba(251,191,36,.35); background: rgba(120,53,15,.18); color: #fde68a; border-radius: 10px; padding: .8rem 1rem; margin-bottom: 1rem; font-size: .86rem; line-height: 1.45; }
+  .map-health-banner { border: 1px solid rgba(148,163,184,.38); background: rgba(15,23,42,.82); color: #cbd5e1; border-radius: 10px; padding: .75rem 1rem; margin-bottom: 1rem; font-size: .86rem; line-height: 1.45; }
+  .map-health-banner.warning { border-color: rgba(251,191,36,.58); background: rgba(120,53,15,.22); color: #fde68a; }
+  .map-health-banner[hidden] { display: none; }
+  .grid-map-shell { position: relative; min-height: 560px; border: 1px solid #334155; border-radius: 12px; overflow: hidden; background: radial-gradient(circle at 50% 0%, rgba(34,211,238,.12), transparent 36%), linear-gradient(180deg, rgba(15,23,42,.96), rgba(2,6,23,.98)); }
+  .grid-map-svg { width: 100%; height: 560px; display: block; touch-action: none; cursor: grab; }
+  .grid-map-svg:active { cursor: grabbing; }
+  .grid-map-svg:focus-visible { outline: 3px solid rgba(34,211,238,.6); outline-offset: -3px; }
+  .map-fallback { position: absolute; inset: 0; display: grid; place-items: center; padding: 2rem; text-align: center; background: rgba(15,23,42,.96); color: var(--muted); line-height: 1.5; }
+  .map-fallback[hidden] { display: none; }
+  .map-edge { stroke: #64748b; stroke-width: 2.4; fill: none; opacity: .82; }
+  .map-edge.healthy { stroke: var(--green); opacity: .86; }
+  .map-edge.warning { stroke: var(--amber); stroke-width: 3; opacity: .9; }
+  .map-edge.critical { stroke: var(--red); stroke-width: 3.4; opacity: .95; filter: drop-shadow(0 0 6px rgba(248,113,113,.45)); }
+  .map-edge.unknown { stroke: #94a3b8; stroke-dasharray: 8 7; opacity: .58; }
+  .map-edge.disabled { stroke: #94a3b8; stroke-dasharray: 3 7; opacity: .5; }
+  .map-edge-label { fill: #cbd5e1; font-size: 11px; paint-order: stroke; stroke: #020617; stroke-width: 4px; stroke-linejoin: round; }
+  .map-node .node-box { fill: #182338; stroke: #475569; stroke-width: 1.5; filter: drop-shadow(0 10px 18px rgba(2,6,23,.45)); }
+  .map-node.service .node-box { stroke: rgba(34,211,238,.65); }
+  .map-node.datastore .node-box, .map-node.datastore .node-cap { fill: #14213a; stroke: rgba(167,139,250,.75); stroke-width: 1.5; }
+  .map-node.healthy .node-box, .map-node.datastore.healthy .node-box, .map-node.datastore.healthy .node-cap { fill: rgba(6,78,59,.92); stroke: var(--green); stroke-width: 2.2; filter: drop-shadow(0 0 14px rgba(52,211,153,.36)); }
+  .map-node.warning .node-box, .map-node.datastore.warning .node-box, .map-node.datastore.warning .node-cap { fill: rgba(120,53,15,.92); stroke: var(--amber); stroke-width: 2.4; filter: drop-shadow(0 0 14px rgba(251,191,36,.34)); }
+  .map-node.critical .node-box, .map-node.datastore.critical .node-box, .map-node.datastore.critical .node-cap { fill: rgba(127,29,29,.92); stroke: var(--red); stroke-width: 2.6; filter: drop-shadow(0 0 16px rgba(248,113,113,.48)); }
+  .map-node.unknown .node-box, .map-node.datastore.unknown .node-box, .map-node.datastore.unknown .node-cap { fill: rgba(30,41,59,.88); stroke: #94a3b8; stroke-dasharray: 7 5; }
+  .map-node.static .node-box, .map-node.datastore.static .node-box, .map-node.datastore.static .node-cap { fill: rgba(30,41,59,.92); stroke: #cbd5e1; stroke-width: 1.8; }
+  .map-node.disabled .node-box { stroke-dasharray: 7 5; opacity: .72; }
+  .map-node text { pointer-events: none; }
+  .map-node-symbol { fill: #f8fafc; font-size: 13px; font-weight: 800; }
+  .map-node-title { fill: var(--text); font-size: 14px; font-weight: 700; }
+  .map-node-subtitle { fill: var(--muted); font-size: 11px; }
+  .map-node-status { fill: #94a3b8; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; }
+  .map-status-dot { fill: #94a3b8; }
+  .map-status-dot.healthy { fill: var(--green); filter: drop-shadow(0 0 5px rgba(52,211,153,.85)); }
+  .map-status-dot.warning { fill: var(--amber); filter: drop-shadow(0 0 5px rgba(251,191,36,.85)); }
+  .map-status-dot.critical { fill: var(--red); filter: drop-shadow(0 0 5px rgba(248,113,113,.85)); }
+  .map-status-dot.static { fill: #cbd5e1; }
+  .map-status-dot.unknown { fill: #94a3b8; }
+  .map-status-dot.disabled { fill: var(--amber); }
+  @media (max-width: 799px), (max-height: 499px) {
+    .grid-map-shell { min-height: 260px; }
+    .grid-map-svg { display: none; }
+    .map-fallback { display: grid; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .loading { animation: none; }
+    .map-status-dot.healthy, .map-status-dot.warning, .map-status-dot.critical { filter: none; }
+  }
+  .node-ring, .node-focus-ring { fill: none; stroke: none; pointer-events: none; }
+  .map-node.selected .node-ring { stroke: var(--cyan); stroke-width: 3; filter: drop-shadow(0 0 8px rgba(34,211,238,.75)); }
+  .map-node:focus-visible { outline: none; }
+  .map-node:focus-visible .node-focus-ring { stroke: rgba(255,255,255,.88); stroke-width: 2; stroke-dasharray: 6 4; filter: drop-shadow(0 0 6px rgba(255,255,255,.45)); }
+  .map-node.dimmed { opacity: 0.22; }
+  .map-edge.dimmed { opacity: 0.12; }
+  .map-edge.selected { stroke: var(--cyan) !important; stroke-width: 5 !important; opacity: 1 !important; filter: drop-shadow(0 0 8px rgba(34,211,238,.65)); }
+  .map-edge-hit { stroke: transparent; stroke-width: 14; fill: none; cursor: pointer; }
+  .filter-bar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin-bottom: .75rem; }
+  .filter-btn { background: rgba(15,23,42,.8); border: 1px solid #475569; border-radius: 8px; color: var(--muted); padding: .35rem .7rem; cursor: pointer; font: inherit; font-size: .82rem; display: inline-flex; align-items: center; gap: .4rem; }
+  .filter-btn:hover, .filter-btn:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.35); outline-offset: 2px; }
+  .filter-btn[aria-pressed="true"] { background: rgba(34,211,238,.15); border-color: var(--cyan); color: var(--cyan); font-weight: 600; }
+  .filter-btn[data-filter="critical"][aria-pressed="true"] { background: rgba(248,113,113,.15); border-color: var(--red); color: var(--red); }
+  .filter-btn[data-filter="warning"][aria-pressed="true"] { background: rgba(251,191,36,.15); border-color: var(--amber); color: var(--amber); }
+  .filter-badge { display: inline-block; min-width: 1.3em; padding: .1em .35em; background: rgba(255,255,255,.1); border-radius: 999px; font-size: .75em; font-weight: 700; text-align: center; line-height: 1.4; }
 </style>
 </head>
-<body>
-<header>
-  <h1>&#9881; Grid Operations Console</h1>
-  <div class="status-bar">
-    <div class="item"><span class="dot green"></span> Operator Mode</div>
-    <div class="item" id="clock"></div>
-  </div>
-</header>
-<main>
-  <div class="grid">
-    <div class="card">
-      <h3>Dispatch Queue Depth</h3>
-      <div class="metric" style="color:var(--accent)" id="queue-depth">--</div>
-    </div>
-    <div class="card">
-      <h3>Active Dispatches</h3>
-      <div class="metric" style="color:var(--cyan)" id="active-dispatches">--</div>
-    </div>
-    <div class="card">
-      <h3>Grid Efficiency</h3>
-      <div class="metric" style="color:var(--green)" id="efficiency">--<sub> %</sub></div>
-    </div>
-    <div class="card">
-      <h3>Alert Count (24h)</h3>
-      <div class="metric" style="color:var(--amber)" id="alert-count">--</div>
-    </div>
-  </div>
+ <body>
+ <header>
+   <div class="header-left">
+     <h1>&#9881; Grid Operations Console</h1>
+     <nav class="view-toggle" aria-label="Console views">
+       <button type="button" id="operations-tab" data-view-target="operations" aria-selected="true">Operations</button>
+       <button type="button" id="map-tab" data-view-target="map" aria-selected="false">Grid Map</button>
+     </nav>
+   </div>
+   <div class="status-bar">
+     <div class="item"><span class="dot green"></span> Operator Mode</div>
+     <div class="item" id="clock"></div>
+   </div>
+ </header>
+ <main>
+   <section id="operations-view" class="app-view" data-view="operations">
+     <div class="grid">
+       <div class="card">
+         <h3>Dispatch Queue Depth</h3>
+         <div class="metric" style="color:var(--accent)" id="queue-depth">--</div>
+       </div>
+       <div class="card">
+         <h3>Active Dispatches</h3>
+         <div class="metric" style="color:var(--cyan)" id="active-dispatches">--</div>
+       </div>
+       <div class="card">
+         <h3>Grid Efficiency</h3>
+         <div class="metric" style="color:var(--green)" id="efficiency">--<sub> %</sub></div>
+       </div>
+       <div class="card">
+         <h3>Alert Count (24h)</h3>
+         <div class="metric" style="color:var(--amber)" id="alert-count">--</div>
+       </div>
+     </div>
 
-  <h2 class="section-title">&#128640; Active Dispatch Orders</h2>
-  <div class="card" style="overflow-x:auto">
-    <table>
-      <thead><tr><th>Dispatch ID</th><th>Type</th><th>Zone</th><th>Priority</th><th>Status</th><th>Assigned</th></tr></thead>
-      <tbody id="dispatch-body"></tbody>
-    </table>
-  </div>
+     <h2 class="section-title">&#128640; Active Dispatch Orders</h2>
+     <div class="card" style="overflow-x:auto">
+       <table>
+         <thead><tr><th>Dispatch ID</th><th>Type</th><th>Zone</th><th>Priority</th><th>Status</th><th>Assigned</th></tr></thead>
+         <tbody id="dispatch-body"></tbody>
+       </table>
+     </div>
 
-  <h2 class="section-title">&#127981; Energy Asset Inventory</h2>
-  <div class="card" style="overflow-x:auto">
-    <table>
-      <thead><tr><th>Asset ID</th><th>Name</th><th>Type</th><th>Output</th><th>Efficiency</th><th>Status</th></tr></thead>
-      <tbody id="assets-body"><tr><td colspan="6" class="loading">Loading assets...</td></tr></tbody>
-    </table>
-  </div>
+     <h2 class="section-title">&#127981; Energy Asset Inventory</h2>
+     <div class="card" style="overflow-x:auto">
+       <table>
+         <thead><tr><th>Asset ID</th><th>Name</th><th>Type</th><th>Output</th><th>Efficiency</th><th>Status</th></tr></thead>
+         <tbody id="assets-body"><tr><td colspan="6" class="loading">Loading assets...</td></tr></tbody>
+       </table>
+     </div>
 
-  <h2 class="section-title">&#128195; Operations Log</h2>
-  <div class="log-box" id="ops-log"></div>
+     <h2 class="section-title">&#128195; Operations Log</h2>
+     <div class="log-box" id="ops-log"></div>
 
-  <h2 class="section-title">&#128506; Platform Health</h2>
-  <div class="grid" id="health-grid"></div>
-</main>
+     <h2 class="section-title">&#128506; Platform Health</h2>
+     <div class="grid" id="health-grid"></div>
+   </section>
+
+   <section id="map-view" class="app-view" data-view="map" hidden>
+     <div class="map-toolbar">
+       <div>
+         <h2 class="section-title" style="margin-top:0">&#128506; Cloud Demo Grid Map</h2>
+          <div class="map-meta">Topology and live service health use the approved cloud grid-map data contract. Live checks poll every 30 seconds.</div>
+       </div>
+       <div class="map-controls" aria-label="Grid map controls">
+         <button class="map-button" type="button" id="map-zoom-in">Zoom in</button>
+         <button class="map-button" type="button" id="map-zoom-out">Zoom out</button>
+         <button class="map-button" type="button" id="map-reset">Fit / Reset</button>
+       </div>
+     </div>
+      <div class="filter-bar" role="group" aria-label="Severity filter">
+        <span style="color:var(--muted);font-size:.82rem">Filter:</span>
+        <button class="filter-btn" type="button" data-filter="all" aria-pressed="true">All <span class="filter-badge" id="badge-all">—</span></button>
+        <button class="filter-btn" type="button" data-filter="critical" aria-pressed="false">Critical <span class="filter-badge" id="badge-critical">—</span></button>
+        <button class="filter-btn" type="button" data-filter="warning" aria-pressed="false">Warning <span class="filter-badge" id="badge-warning">—</span></button>
+      </div>
+      <div class="map-disclaimer" role="note">
+        Demo topology only. This map visualizes Kubernetes service/application health for the Azure SRE Agent demo and is not connected to real grid telemetry, SCADA, GIS, or utility infrastructure.
+      </div>
+      <div class="map-health-banner warning" id="map-health-banner" role="status" aria-live="polite">
+        Live service health has not been received yet. Static and optional nodes are shown in a safe unknown/static state.
+      </div>
+      <div class="card">
+       <div class="grid-map-shell" id="grid-map-shell">
+         <svg id="grid-map-svg" class="grid-map-svg" role="img" aria-label="Static cloud demo topology graph with service and data-store nodes" tabindex="0">
+           <g id="grid-map-stage"></g>
+         </svg>
+         <div class="map-fallback" id="map-fallback" hidden>
+           <div>
+             <strong>Grid map needs at least 800 × 500 pixels.</strong><br>
+             Increase the browser window or use a larger display to view the topology safely.
+           </div>
+         </div>
+       </div>
+     </div>
+   </section>
+ </main>
 <div class="footer">Contoso Energy &mdash; Grid Operations Console &mdash; Azure SRE Agent Demo Lab</div>
 
 <script>
 const ZONES = ['Zone-A North', 'Zone-B Central', 'Zone-C South', 'Zone-D East', 'Zone-E West'];
 const DISPATCH_TYPES = ['Load Balance', 'Frequency Adj', 'Capacity Shift', 'Emergency Shed', 'Reserve Activate', 'Ramp Up', 'Ramp Down'];
-const PRIORITIES = ['Critical', 'High', 'Medium', 'Low'];
-const ASSET_TYPES = ['Solar Farm', 'Wind Array', 'Gas Turbine', 'Hydroelectric', 'Battery Bank', 'Substation'];
-const ASSET_NAMES = ['Ridgeline Solar Alpha', 'Cedar Wind Farm', 'Riverside Gas Unit 3', 'Lakeview Hydro Station', 'Eastport Battery Grid', 'Northgate Substation 7', 'Summit Solar Bravo', 'Pinecrest Wind Array', 'Valley Gas Peaker 1', 'Harbor Hydro Complex'];
+ const PRIORITIES = ['Critical', 'High', 'Medium', 'Low'];
+ const ASSET_TYPES = ['Solar Farm', 'Wind Array', 'Gas Turbine', 'Hydroelectric', 'Battery Bank', 'Substation'];
+ const ASSET_NAMES = ['Ridgeline Solar Alpha', 'Cedar Wind Farm', 'Riverside Gas Unit 3', 'Lakeview Hydro Station', 'Eastport Battery Grid', 'Northgate Substation 7', 'Summit Solar Bravo', 'Pinecrest Wind Array', 'Valley Gas Peaker 1', 'Harbor Hydro Complex'];
+ const GRID_TOPOLOGY = {
+   schemaVersion: '1.0',
+   host: 'ops-console',
+   namespace: 'energy',
+   disclaimer: 'Demo topology only. This map visualizes Kubernetes service/application health for the Azure SRE Agent demo and is not connected to real grid telemetry, SCADA, GIS, or utility infrastructure.',
+   nodes: [
+     { id: 'grid-dashboard', label: 'Consumer Portal', resourceName: 'grid-dashboard', metaphor: 'Customer Energy Portal', kind: 'service', position: { x: 120, y: 120 }, healthSource: 'static' },
+     { id: 'ops-console', label: 'Grid Operations Console', resourceName: 'ops-console', metaphor: 'Control Room', kind: 'service', position: { x: 120, y: 320 }, healthSource: 'static' },
+     { id: 'meter-service', label: 'Meter Service', resourceName: 'meter-service', metaphor: 'Smart Meter Ingestion', kind: 'service', position: { x: 360, y: 120 }, healthSource: 'live', healthPath: '/api/meter/health' },
+     { id: 'asset-service', label: 'Asset Service', resourceName: 'asset-service', metaphor: 'Asset Catalog', kind: 'service', position: { x: 360, y: 320 }, healthSource: 'live', healthPath: '/api/assets/health' },
+     { id: 'dispatch-service', label: 'Dispatch Service', resourceName: 'dispatch-service', metaphor: 'Energy Dispatch', kind: 'service', position: { x: 600, y: 220 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
+     { id: 'rabbitmq', label: 'RabbitMQ', resourceName: 'rabbitmq', metaphor: 'Event Bus', kind: 'datastore', position: { x: 600, y: 60 }, healthSource: 'static' },
+     { id: 'mongodb', label: 'MongoDB', resourceName: 'mongodb', metaphor: 'Meter Data Store', kind: 'datastore', position: { x: 840, y: 220 }, healthSource: 'static' },
+     { id: 'load-simulator', label: 'Load Simulator', resourceName: 'load-simulator', metaphor: 'Consumer Demand Simulator', kind: 'service', position: { x: 360, y: 520 }, healthSource: 'static' },
+     { id: 'grid-worker', label: 'Grid Worker', resourceName: 'grid-worker', metaphor: 'Dispatch Worker', kind: 'service', position: { x: 600, y: 520 }, healthSource: 'static', replicas: 0, stateNote: 'Disabled in application.yaml with replicas: 0 due to AMQP protocol mismatch' },
+     { id: 'forecast-service', label: 'Forecast Service', resourceName: 'forecast-service', metaphor: 'Demand Forecast', kind: 'service', position: { x: 840, y: 420 }, healthSource: 'optional', optional: true, absentBehavior: 'Render as unknown with label Optional service absent in current deployment' }
+   ],
+   edges: [
+     { source: 'grid-dashboard', target: 'meter-service', label: 'Usage and billing data', type: 'sync' },
+     { source: 'grid-dashboard', target: 'asset-service', label: 'Asset catalog reads', type: 'sync' },
+     { source: 'ops-console', target: 'dispatch-service', label: 'Operations data', type: 'sync' },
+     { source: 'ops-console', target: 'asset-service', label: 'Asset inventory', type: 'sync' },
+     { source: 'meter-service', target: 'rabbitmq', label: 'Meter events', type: 'async' },
+     { source: 'meter-service', target: 'mongodb', label: 'Meter readings', type: 'sync' },
+     { source: 'rabbitmq', target: 'dispatch-service', label: 'Dispatch commands', type: 'async' },
+     { source: 'dispatch-service', target: 'mongodb', label: 'Grid state writes', type: 'sync' },
+     { source: 'asset-service', target: 'mongodb', label: 'Asset catalog data', type: 'sync' },
+     { source: 'dispatch-service', target: 'asset-service', label: 'Asset lookups', type: 'sync' },
+     { source: 'asset-service', target: 'forecast-service', label: 'Demand forecast', type: 'sync', optional: true },
+     { source: 'load-simulator', target: 'meter-service', label: 'Simulated meter usage', type: 'sync' },
+     { source: 'grid-worker', target: 'dispatch-service', label: 'Disabled dispatch processing path', type: 'sync', disabled: true }
+   ]
+  };
+  const MAP_NODE = { width: 176, height: 76 };
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const LIVE_HEALTH_TIMEOUT_MS = 3000;
+  const MAP_HEALTH_POLL_MS = 30000;
+  const STALE_AFTER_MS = 60000;
+  const SEVERITY_RANK = { healthy: 0, warning: 1, critical: 2 };
+   const mapState = { x: 0, y: 0, k: 1, rendered: false, dragging: false, dragX: 0, dragY: 0, dragMoved: false, healthById: {}, lastSuccessfulHealthPoll: null, healthPollInFlight: false, selectedNodeId: null, selectedEdgeKey: null, activeFilter: 'all' };
 
 function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
 
@@ -184,39 +345,563 @@ function addLogEntry() {
   if (box.children.length > 50) box.removeChild(box.lastChild);
 }
 
-function loadHealth() {
-  const grid = document.getElementById('health-grid');
-  grid.innerHTML = '';
-  const svcs = [
-    { name: 'Asset Service', url: '/api/assets/health' },
-    { name: 'Meter Service', url: '/api/meter/health' },
-    { name: 'Dispatch Service', url: '/api/dispatch/health' },
-    { name: 'MongoDB', url: null },
-    { name: 'RabbitMQ', url: null },
-  ];
-  svcs.forEach(svc => {
-    const card = document.createElement('div');
-    card.className = 'card';
-    if (svc.url) {
-      card.innerHTML = '<h3>' + svc.name + '</h3><div class="loading">Checking...</div>';
-      fetch(svc.url, { signal: AbortSignal.timeout(3000) })
-        .then(() => { card.innerHTML = '<h3>' + svc.name + '</h3><div style="color:var(--green)"><span class="dot green"></span> Healthy</div>'; })
-        .catch(() => { card.innerHTML = '<h3>' + svc.name + '</h3><div style="color:var(--red)"><span class="dot red"></span> Unreachable</div>'; });
-    } else {
-      card.innerHTML = '<h3>' + svc.name + '</h3><div style="color:var(--muted)"><span class="dot green"></span> In-Cluster</div>';
-    }
-    grid.appendChild(card);
-  });
-}
+  function liveHealthNodes() {
+    return GRID_TOPOLOGY.nodes.filter(node => node.healthSource === 'live' && node.healthPath);
+  }
 
-updateClock(); updateMetrics(); loadDispatches(); loadAssets(); loadHealth();
+  function createTimeoutSignal(timeoutMs) {
+    if (window.AbortSignal && AbortSignal.timeout) return AbortSignal.timeout(timeoutMs);
+    const controller = new AbortController();
+    window.setTimeout(() => controller.abort(), timeoutMs);
+    return controller.signal;
+  }
+
+  function severityForHttpStatus(status) {
+    if (status >= 200 && status < 300) return 'healthy';
+    if (status >= 400 && status < 500) return 'warning';
+    if (status >= 500) return 'critical';
+    return 'warning';
+  }
+
+  function healthTextForResult(result) {
+    if (!result) return 'checking live health';
+    if (result.reason === 'network') return 'critical - endpoint unreachable';
+    if (result.severity === 'healthy') return 'healthy - HTTP ' + result.httpStatus;
+    if (result.severity === 'warning') return 'warning - HTTP ' + result.httpStatus;
+    if (result.severity === 'critical') return 'critical - HTTP ' + result.httpStatus;
+    return 'unknown';
+  }
+
+  function fetchLiveHealth(node) {
+    const checkedAt = Date.now();
+    return fetch(node.healthPath, { method: 'GET', cache: 'no-store', signal: createTimeoutSignal(LIVE_HEALTH_TIMEOUT_MS) })
+      .then(response => ({
+        id: node.id,
+        severity: severityForHttpStatus(response.status),
+        httpStatus: response.status,
+        checkedAt,
+        successAt: checkedAt,
+        reason: 'http'
+      }))
+      .catch(error => ({
+        id: node.id,
+        severity: 'critical',
+        checkedAt,
+        successAt: null,
+        reason: 'network',
+        errorName: error && error.name ? error.name : 'NetworkError'
+      }));
+  }
+
+  function statusDotClass(severity) {
+    if (severity === 'healthy') return 'green';
+    if (severity === 'warning') return 'amber';
+    if (severity === 'critical') return 'red';
+    return 'unknown';
+  }
+
+  function renderHealthGrid() {
+    const grid = document.getElementById('health-grid');
+    if (!grid) return;
+    grid.innerHTML = '';
+    const svcs = [
+      ...liveHealthNodes().map(node => ({ name: node.label, node })),
+      { name: 'MongoDB', staticText: 'Static in-cluster - no browser health endpoint' },
+      { name: 'RabbitMQ', staticText: 'Static in-cluster - no browser health endpoint' },
+    ];
+    svcs.forEach(svc => {
+      const card = document.createElement('div');
+      card.className = 'card';
+      if (svc.node) {
+        const result = mapState.healthById[svc.node.id];
+        const severity = result ? result.severity : 'unknown';
+        const dotClass = statusDotClass(severity);
+        const label = result ? healthTextForResult(result) : 'Checking approved health endpoint...';
+        card.innerHTML = '<h3>' + svc.name + '</h3><div style="color:var(--' + (severity === 'warning' ? 'amber' : severity === 'critical' ? 'red' : severity === 'healthy' ? 'green' : 'muted') + ')"><span class="dot ' + dotClass + '"></span> ' + label + '</div>';
+      } else {
+        card.innerHTML = '<h3>' + svc.name + '</h3><div style="color:var(--muted)"><span class="dot green"></span> ' + svc.staticText + '</div>';
+      }
+      grid.appendChild(card);
+    });
+  }
+
+  function updateMapHealthBanner() {
+    const banner = document.getElementById('map-health-banner');
+    if (!banner) return;
+    const now = Date.now();
+    const last = mapState.lastSuccessfulHealthPoll;
+    if (!last) {
+      banner.hidden = false;
+      banner.className = 'map-health-banner warning';
+      banner.textContent = mapState.healthPollInFlight
+        ? 'Checking approved cloud demo health endpoints. Static and optional nodes remain in safe unknown/static state while live data loads.'
+        : 'Live service health is unavailable. The map is showing safe severity states from the last known cloud demo contract, with endpoint failures marked critical only for application health.';
+      return;
+    }
+    const age = now - last;
+    if (age > STALE_AFTER_MS) {
+      banner.hidden = false;
+      banner.className = 'map-health-banner warning';
+      banner.textContent = 'Live service health data is stale (' + Math.round(age / 1000) + 's since the last successful health response). Static and optional nodes are not treated as causal impact.';
+      return;
+    }
+    banner.hidden = true;
+  }
+
+  function refreshGridMapAfterHealthChange() {
+    mapState.rendered = false;
+    const mapView = document.getElementById('map-view');
+    if (mapView && !mapView.hidden) renderGridMap();
+  }
+
+  function loadHealth() {
+    if (mapState.healthPollInFlight) return;
+    mapState.healthPollInFlight = true;
+    renderHealthGrid();
+    updateMapHealthBanner();
+    Promise.all(liveHealthNodes().map(fetchLiveHealth))
+      .then(results => {
+        let newestSuccess = mapState.lastSuccessfulHealthPoll;
+        results.forEach(result => {
+          mapState.healthById[result.id] = result;
+          if (result.successAt && (!newestSuccess || result.successAt > newestSuccess)) newestSuccess = result.successAt;
+        });
+        mapState.lastSuccessfulHealthPoll = newestSuccess;
+      })
+      .catch(() => {
+        liveHealthNodes().forEach(node => {
+          if (!mapState.healthById[node.id]) {
+            mapState.healthById[node.id] = { id: node.id, severity: 'critical', checkedAt: Date.now(), successAt: null, reason: 'network' };
+          }
+        });
+      })
+     .finally(() => {
+       mapState.healthPollInFlight = false;
+       renderHealthGrid();
+       updateMapHealthBanner();
+       refreshGridMapAfterHealthChange();
+       updateFilterBadges();
+     });
+   }
+
+ function createSvgElement(name, attrs) {
+   const el = document.createElementNS(SVG_NS, name);
+   Object.keys(attrs || {}).forEach(key => el.setAttribute(key, attrs[key]));
+   return el;
+ }
+
+  function getMapStatus(node) {
+    if (node.replicas === 0) return { text: 'disabled - replicas 0', className: 'disabled', severity: 'unknown', symbol: 'Ⅱ' };
+    if (node.optional) return { text: 'optional absent', className: 'unknown', severity: 'unknown', symbol: '?' };
+    if (node.healthSource === 'live') {
+      const result = mapState.healthById[node.id];
+      if (!result) return { text: 'checking live health', className: 'unknown', severity: 'unknown', symbol: '?' };
+      const symbol = result.severity === 'healthy' ? '✓' : result.severity === 'warning' ? '!' : '×';
+      return { text: healthTextForResult(result), className: result.severity, severity: result.severity, symbol };
+    }
+    return { text: 'static in-cluster', className: 'static', severity: 'unknown', symbol: 'S' };
+  }
+
+  function getEdgeStatus(edge, source, target) {
+    if (edge.disabled) return { className: 'disabled', label: 'disabled path' };
+    const sourceStatus = getMapStatus(source);
+    const targetStatus = getMapStatus(target);
+    const known = [sourceStatus.severity, targetStatus.severity].filter(severity => severity in SEVERITY_RANK);
+    if (known.includes('critical')) return { className: 'critical', label: 'visual impact: critical endpoint' };
+    if (known.includes('warning')) return { className: 'warning', label: 'visual impact: warning endpoint' };
+    if (known.length === 2 && known.every(severity => severity === 'healthy')) return { className: 'healthy', label: 'both endpoints healthy' };
+    return { className: 'unknown', label: 'unknown/static endpoint state' };
+  }
+
+ function selectNode(nodeId) {
+   mapState.selectedNodeId = nodeId;
+   mapState.selectedEdgeKey = null;
+   applyNodeSelection();
+   applyEdgeSelection();
+ }
+ function selectEdge(key) {
+   mapState.selectedEdgeKey = key;
+   mapState.selectedNodeId = null;
+   applyNodeSelection();
+   applyEdgeSelection();
+ }
+ function clearSelection() {
+   mapState.selectedNodeId = null;
+   mapState.selectedEdgeKey = null;
+   applyNodeSelection();
+   applyEdgeSelection();
+ }
+ function applyNodeSelection() {
+   document.querySelectorAll('.map-node').forEach(function(group) {
+     var isSelected = group.dataset.nodeId === mapState.selectedNodeId && !!mapState.selectedNodeId;
+     group.classList.toggle('selected', isSelected);
+     group.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+   });
+ }
+ function applyEdgeSelection() {
+   document.querySelectorAll('.map-edge').forEach(function(line) {
+     line.classList.toggle('selected', !!mapState.selectedEdgeKey && line.dataset.edgeKey === mapState.selectedEdgeKey);
+   });
+ }
+ function updateFilterBadges() {
+   var total = GRID_TOPOLOGY.nodes.length;
+   var critical = 0, warning = 0;
+   GRID_TOPOLOGY.nodes.forEach(function(node) {
+     var sev = getMapStatus(node).severity;
+     if (sev === 'critical') critical++;
+     else if (sev === 'warning') warning++;
+   });
+   var badgeAll = document.getElementById('badge-all');
+   var badgeCritical = document.getElementById('badge-critical');
+   var badgeWarning = document.getElementById('badge-warning');
+   if (badgeAll) badgeAll.textContent = total;
+   if (badgeCritical) badgeCritical.textContent = critical;
+   if (badgeWarning) badgeWarning.textContent = warning;
+ }
+ function applySeverityFilter() {
+   var filter = mapState.activeFilter;
+   document.querySelectorAll('[data-filter]').forEach(function(btn) {
+     btn.setAttribute('aria-pressed', btn.dataset.filter === filter ? 'true' : 'false');
+   });
+   document.querySelectorAll('.map-node').forEach(function(group) {
+     var nodeId = group.dataset.nodeId;
+     if (!nodeId || filter === 'all') { group.classList.remove('dimmed'); return; }
+     var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === nodeId; });
+     var severity = node ? getMapStatus(node).severity : 'unknown';
+     group.classList.toggle('dimmed', severity !== filter);
+   });
+   document.querySelectorAll('.map-edge').forEach(function(line) {
+     if (filter === 'all') { line.classList.remove('dimmed'); return; }
+     var key = line.dataset.edgeKey;
+     if (!key) return;
+     var parts = key.split(':');
+     var srcNode = document.querySelector('.map-node[data-node-id="' + parts[0] + '"]');
+     var tgtNode = document.querySelector('.map-node[data-node-id="' + parts[1] + '"]');
+     var srcDimmed = srcNode && srcNode.classList.contains('dimmed');
+     var tgtDimmed = tgtNode && tgtNode.classList.contains('dimmed');
+     line.classList.toggle('dimmed', srcDimmed && tgtDimmed);
+   });
+   updateFilterBadges();
+ }
+ function initSeverityFilter() {
+   document.querySelectorAll('[data-filter]').forEach(function(btn) {
+     btn.addEventListener('click', function() {
+       mapState.activeFilter = btn.dataset.filter;
+       applySeverityFilter();
+     });
+   });
+   updateFilterBadges();
+ }
+ function nodeCenter(node) {
+   return { x: node.position.x + MAP_NODE.width / 2, y: node.position.y + MAP_NODE.height / 2 };
+ }
+
+ function edgeAnchor(from, to) {
+   const a = nodeCenter(from);
+   const b = nodeCenter(to);
+   const dx = b.x - a.x;
+   const dy = b.y - a.y;
+   const scale = Math.max(Math.abs(dx) / (MAP_NODE.width / 2), Math.abs(dy) / (MAP_NODE.height / 2), 1);
+   return { x: a.x + dx / scale, y: a.y + dy / scale };
+ }
+
+ function renderServiceNode(stage, node) {
+   const status = getMapStatus(node);
+   const group = createSvgElement('g', {
+     class: 'map-node service ' + status.className,
+     tabindex: '0',
+     role: 'img',
+     'aria-label': node.label + ', ' + node.metaphor + ', ' + status.text,
+     'data-node-id': node.id,
+     'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
+   });
+    const x = node.position.x;
+    const y = node.position.y;
+    group.appendChild(createSvgElement('rect', { class: 'node-box', x, y, width: MAP_NODE.width, height: MAP_NODE.height, rx: 14, ry: 14 }));
+    group.appendChild(createSvgElement('circle', { class: 'map-status-dot ' + status.className, cx: x + 16, cy: y + 18, r: 5 }));
+    const symbol = createSvgElement('text', { class: 'map-node-symbol', x: x + MAP_NODE.width - 22, y: y + 24, 'text-anchor': 'middle', 'aria-hidden': 'true' });
+    symbol.textContent = status.symbol;
+    group.appendChild(symbol);
+    const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 23 });
+    title.textContent = node.label;
+    group.appendChild(title);
+   const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 46 });
+   subtitle.textContent = node.metaphor;
+   group.appendChild(subtitle);
+   const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64 });
+   state.textContent = status.text;
+   group.appendChild(state);
+   group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 18, ry: 18 }));
+   group.appendChild(createSvgElement('rect', { class: 'node-focus-ring', x: x - 7, y: y - 7, width: MAP_NODE.width + 14, height: MAP_NODE.height + 14, rx: 21, ry: 21 }));
+   if (mapState.selectedNodeId === node.id) group.classList.add('selected');
+   stage.appendChild(group);
+ }
+
+ function renderDataStoreNode(stage, node) {
+   const status = getMapStatus(node);
+   const group = createSvgElement('g', {
+     class: 'map-node datastore ' + status.className,
+     tabindex: '0',
+     role: 'img',
+     'aria-label': node.label + ', data store, ' + node.metaphor + ', ' + status.text,
+     'data-node-id': node.id,
+     'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
+   });
+   const x = node.position.x;
+   const y = node.position.y;
+    group.appendChild(createSvgElement('rect', { class: 'node-box', x, y: y + 12, width: MAP_NODE.width, height: MAP_NODE.height - 24, rx: 6, ry: 6 }));
+    group.appendChild(createSvgElement('ellipse', { class: 'node-cap', cx: x + MAP_NODE.width / 2, cy: y + 13, rx: MAP_NODE.width / 2, ry: 14 }));
+    group.appendChild(createSvgElement('ellipse', { class: 'node-cap', cx: x + MAP_NODE.width / 2, cy: y + MAP_NODE.height - 12, rx: MAP_NODE.width / 2, ry: 14 }));
+    group.appendChild(createSvgElement('circle', { class: 'map-status-dot ' + status.className, cx: x + 16, cy: y + 22, r: 5 }));
+    const symbol = createSvgElement('text', { class: 'map-node-symbol', x: x + MAP_NODE.width - 22, y: y + 27, 'text-anchor': 'middle', 'aria-hidden': 'true' });
+    symbol.textContent = status.symbol;
+    group.appendChild(symbol);
+    const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 27 });
+   title.textContent = node.label;
+   group.appendChild(title);
+   const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 50 });
+   subtitle.textContent = node.metaphor;
+   group.appendChild(subtitle);
+   const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 67 });
+   state.textContent = status.text;
+   group.appendChild(state);
+   group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 14, ry: 14 }));
+   group.appendChild(createSvgElement('rect', { class: 'node-focus-ring', x: x - 7, y: y - 7, width: MAP_NODE.width + 14, height: MAP_NODE.height + 14, rx: 17, ry: 17 }));
+   if (mapState.selectedNodeId === node.id) group.classList.add('selected');
+   stage.appendChild(group);
+ }
+
+ function renderGridMap() {
+   const svg = document.getElementById('grid-map-svg');
+   const stage = document.getElementById('grid-map-stage');
+   if (!svg || !stage || mapState.rendered) return;
+   stage.innerHTML = '';
+   const defs = createSvgElement('defs');
+   const marker = createSvgElement('marker', { id: 'map-arrowhead', viewBox: '0 0 10 10', refX: '9', refY: '5', markerWidth: '7', markerHeight: '7', orient: 'auto-start-reverse' });
+   marker.appendChild(createSvgElement('path', { d: 'M 0 0 L 10 5 L 0 10 z', fill: '#94a3b8' }));
+   defs.appendChild(marker);
+   stage.appendChild(defs);
+
+   const nodesById = GRID_TOPOLOGY.nodes.reduce((acc, node) => {
+     acc[node.id] = node;
+     return acc;
+   }, {});
+
+   GRID_TOPOLOGY.edges.forEach(edge => {
+     const source = nodesById[edge.source];
+      const target = nodesById[edge.target];
+      if (!source || !target) return;
+       const start = edgeAnchor(source, target);
+       const end = edgeAnchor(target, source);
+       const edgeStatus = getEdgeStatus(edge, source, target);
+       const edgeKey = edge.source + ':' + edge.target;
+       const edgeLine = createSvgElement('line', {
+         class: 'map-edge ' + edgeStatus.className + (mapState.selectedEdgeKey === edgeKey ? ' selected' : ''),
+         x1: start.x,
+         y1: start.y,
+         x2: end.x,
+         y2: end.y,
+         'marker-end': 'url(#map-arrowhead)',
+         role: 'img',
+         'aria-label': edge.label + ', ' + edgeStatus.label,
+         'data-edge-key': edgeKey
+       });
+       stage.appendChild(edgeLine);
+       const edgeHit = createSvgElement('line', {
+         class: 'map-edge-hit',
+         x1: start.x, y1: start.y, x2: end.x, y2: end.y,
+         'data-edge-key': edgeKey,
+         'aria-hidden': 'true'
+       });
+       stage.appendChild(edgeHit);
+       const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle' });
+       label.textContent = edge.label + (edgeStatus.className === 'unknown' ? ' · unknown' : edgeStatus.className === 'critical' ? ' · critical' : edgeStatus.className === 'warning' ? ' · warning' : '');
+       stage.appendChild(label);
+    });
+
+   GRID_TOPOLOGY.nodes.forEach(node => {
+     if (node.kind === 'datastore') renderDataStoreNode(stage, node);
+     else renderServiceNode(stage, node);
+   });
+
+   mapState.rendered = true;
+   bindGridMapInteractions();
+   applyNodeSelection();
+   applyEdgeSelection();
+   applySeverityFilter();
+   fitGridMap();
+ }
+
+ function getMapBounds() {
+   const xs = GRID_TOPOLOGY.nodes.map(n => n.position.x);
+   const ys = GRID_TOPOLOGY.nodes.map(n => n.position.y);
+   const minX = Math.min.apply(null, xs);
+   const minY = Math.min.apply(null, ys);
+   const maxX = Math.max.apply(null, xs) + MAP_NODE.width;
+   const maxY = Math.max.apply(null, ys) + MAP_NODE.height;
+   return { minX, minY, width: maxX - minX, height: maxY - minY };
+ }
+
+ function applyMapTransform() {
+   const stage = document.getElementById('grid-map-stage');
+   if (stage) stage.setAttribute('transform', 'translate(' + mapState.x + ' ' + mapState.y + ') scale(' + mapState.k + ')');
+ }
+
+ function fitGridMap() {
+   const svg = document.getElementById('grid-map-svg');
+   const shell = document.getElementById('grid-map-shell');
+   const fallback = document.getElementById('map-fallback');
+   if (!svg || !shell || !fallback) return;
+   const width = shell.clientWidth;
+   const shellHeight = shell.clientHeight;
+   const height = Math.max(560, shellHeight);
+   svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+   if (width < 800 || shellHeight < 500 || window.innerHeight < 500) {
+     fallback.hidden = false;
+     svg.setAttribute('aria-hidden', 'true');
+     return;
+   }
+   fallback.hidden = true;
+   svg.removeAttribute('aria-hidden');
+   const bounds = getMapBounds();
+   const padding = 48;
+   mapState.k = Math.min((width - padding * 2) / bounds.width, (height - padding * 2) / bounds.height);
+   mapState.x = (width - bounds.width * mapState.k) / 2 - bounds.minX * mapState.k;
+   mapState.y = (height - bounds.height * mapState.k) / 2 - bounds.minY * mapState.k;
+   applyMapTransform();
+ }
+
+ function zoomGridMap(factor, clientPoint) {
+   const svg = document.getElementById('grid-map-svg');
+   if (!svg) return;
+   const rect = svg.getBoundingClientRect();
+   const originX = clientPoint ? clientPoint.x - rect.left : rect.width / 2;
+   const originY = clientPoint ? clientPoint.y - rect.top : rect.height / 2;
+   const oldK = mapState.k;
+   const newK = Math.max(0.45, Math.min(2.6, oldK * factor));
+   const worldX = (originX - mapState.x) / oldK;
+   const worldY = (originY - mapState.y) / oldK;
+   mapState.k = newK;
+   mapState.x = originX - worldX * newK;
+   mapState.y = originY - worldY * newK;
+   applyMapTransform();
+ }
+
+ function bindGridMapInteractions() {
+   const svg = document.getElementById('grid-map-svg');
+   if (!svg || svg.dataset.bound === 'true') return;
+   svg.dataset.bound = 'true';
+   svg.addEventListener('wheel', event => {
+     event.preventDefault();
+     zoomGridMap(event.deltaY < 0 ? 1.12 : 0.88, { x: event.clientX, y: event.clientY });
+   }, { passive: false });
+   svg.addEventListener('pointerdown', event => {
+     if (event.button !== 0) return;
+     mapState.dragging = true;
+     mapState.dragMoved = false;
+     mapState.dragX = event.clientX;
+     mapState.dragY = event.clientY;
+     svg.setPointerCapture(event.pointerId);
+   });
+   svg.addEventListener('pointermove', event => {
+     if (!mapState.dragging) return;
+     const dx = event.clientX - mapState.dragX;
+     const dy = event.clientY - mapState.dragY;
+     if (Math.abs(dx) + Math.abs(dy) > 4) mapState.dragMoved = true;
+     mapState.x += dx;
+     mapState.y += dy;
+     mapState.dragX = event.clientX;
+     mapState.dragY = event.clientY;
+     applyMapTransform();
+   });
+   svg.addEventListener('pointerup', event => {
+     mapState.dragging = false;
+     if (svg.hasPointerCapture(event.pointerId)) svg.releasePointerCapture(event.pointerId);
+   });
+   svg.addEventListener('click', event => {
+     if (mapState.dragMoved) { mapState.dragMoved = false; return; }
+     const nodeGroup = event.target.closest ? event.target.closest('.map-node') : null;
+     if (nodeGroup && nodeGroup.dataset.nodeId) {
+       const id = nodeGroup.dataset.nodeId;
+       if (mapState.selectedNodeId === id) clearSelection(); else selectNode(id);
+       return;
+     }
+     const hitLine = event.target.closest ? event.target.closest('.map-edge-hit') : null;
+     if (hitLine && hitLine.dataset.edgeKey) {
+       const key = hitLine.dataset.edgeKey;
+       if (mapState.selectedEdgeKey === key) clearSelection(); else selectEdge(key);
+       return;
+     }
+     clearSelection();
+   });
+   svg.addEventListener('keydown', event => {
+     const step = 26;
+     if (event.key === 'Escape') { clearSelection(); return; }
+     if (event.key === 'Enter') {
+       const nodeGroup = event.target.closest ? event.target.closest('.map-node') : null;
+       if (nodeGroup && nodeGroup.dataset.nodeId) { selectNode(nodeGroup.dataset.nodeId); event.preventDefault(); return; }
+     }
+     if (event.key === '+' || event.key === '=') { zoomGridMap(1.12); event.preventDefault(); return; }
+     if (event.key === '-' || event.key === '_') { zoomGridMap(0.88); event.preventDefault(); return; }
+     if (event.key === '0') { fitGridMap(); event.preventDefault(); return; }
+     if (event.key === 'ArrowLeft') { mapState.x += step; applyMapTransform(); event.preventDefault(); return; }
+     if (event.key === 'ArrowRight') { mapState.x -= step; applyMapTransform(); event.preventDefault(); return; }
+     if (event.key === 'ArrowUp') { mapState.y += step; applyMapTransform(); event.preventDefault(); return; }
+     if (event.key === 'ArrowDown') { mapState.y -= step; applyMapTransform(); event.preventDefault(); }
+   });
+ }
+
+ function initialViewFromLocation() {
+   const params = new URLSearchParams(window.location.search);
+   const hashView = window.location.hash.replace('#', '').toLowerCase();
+   return params.get('view') === 'map' || hashView === 'map' || hashView === 'grid-map' ? 'map' : 'operations';
+ }
+
+ function setConsoleView(view, updateUrl) {
+   const selected = view === 'map' ? 'map' : 'operations';
+   document.querySelectorAll('.app-view').forEach(section => { section.hidden = section.dataset.view !== selected; });
+   document.querySelectorAll('[data-view-target]').forEach(button => {
+     button.setAttribute('aria-selected', button.dataset.viewTarget === selected ? 'true' : 'false');
+   });
+   if (updateUrl) {
+     const url = new URL(window.location.href);
+     if (selected === 'map') url.searchParams.set('view', 'map');
+     else url.searchParams.delete('view');
+     url.hash = '';
+     history.replaceState({ view: selected }, '', url);
+   }
+   if (selected === 'map') {
+     renderGridMap();
+     window.setTimeout(fitGridMap, 0);
+   }
+ }
+
+ function initViewToggle() {
+   initSeverityFilter();
+   document.querySelectorAll('[data-view-target]').forEach(button => {
+     button.addEventListener('click', () => setConsoleView(button.dataset.viewTarget, true));
+   });
+   window.addEventListener('popstate', () => setConsoleView(initialViewFromLocation(), false));
+   window.addEventListener('hashchange', () => setConsoleView(initialViewFromLocation(), false));
+   document.getElementById('map-reset').addEventListener('click', fitGridMap);
+   document.getElementById('map-zoom-in').addEventListener('click', () => zoomGridMap(1.12));
+   document.getElementById('map-zoom-out').addEventListener('click', () => zoomGridMap(0.88));
+   window.addEventListener('resize', () => {
+     if (!document.getElementById('map-view').hidden) fitGridMap();
+   });
+   setConsoleView(initialViewFromLocation(), false);
+ }
+
+ initViewToggle();
+ updateClock(); updateMetrics(); loadDispatches(); loadAssets(); loadHealth();
 for (let i = 0; i < 10; i++) addLogEntry();
 setInterval(updateClock, 1000);
-setInterval(updateMetrics, 5000);
-setInterval(loadDispatches, 10000);
-setInterval(addLogEntry, 3000);
-setInterval(loadHealth, 30000);
-setInterval(loadAssets, 60000);
+ setInterval(updateMetrics, 5000);
+ setInterval(loadDispatches, 10000);
+ setInterval(addLogEntry, 3000);
+ setInterval(loadHealth, MAP_HEALTH_POLL_MS);
+ setInterval(updateMapHealthBanner, 5000);
+ setInterval(loadAssets, 60000);
 </script>
 </body>
 </html>

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -49,7 +49,7 @@
   .map-toolbar { display: flex; gap: .6rem; align-items: center; justify-content: space-between; flex-wrap: wrap; margin-bottom: .8rem; }
   .map-controls { display: flex; gap: .5rem; flex-wrap: wrap; }
   .map-button { background: #0f172a; border: 1px solid #475569; border-radius: 8px; color: var(--text); padding: .45rem .65rem; cursor: pointer; font: inherit; font-size: .85rem; }
-  .map-button:hover, .map-button:focus-visible { border-color: var(--cyan); outline: 2px solid rgba(34,211,238,.35); outline-offset: 2px; }
+  .map-button:hover, .map-button:focus-visible { border-color: var(--cyan); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
   .map-meta { color: var(--muted); font-size: .8rem; }
   .map-disclaimer { border: 1px solid rgba(251,191,36,.35); background: rgba(120,53,15,.18); color: #fde68a; border-radius: 10px; padding: .8rem 1rem; margin-bottom: 1rem; font-size: .86rem; line-height: 1.45; }
   .map-health-banner { border: 1px solid rgba(148,163,184,.38); background: rgba(15,23,42,.82); color: #cbd5e1; border-radius: 10px; padding: .75rem 1rem; margin-bottom: 1rem; font-size: .86rem; line-height: 1.45; }
@@ -102,26 +102,27 @@
   .map-node.selected .node-ring { stroke: var(--cyan); stroke-width: 3; filter: drop-shadow(0 0 8px rgba(34,211,238,.75)); }
   .map-node:focus-visible { outline: none; }
   .map-node:focus-visible .node-focus-ring { stroke: rgba(255,255,255,.88); stroke-width: 2; stroke-dasharray: 6 4; filter: drop-shadow(0 0 6px rgba(255,255,255,.45)); }
-  .map-node.dimmed { opacity: 0.22; }
-  .map-edge.dimmed { opacity: 0.12; }
+  .map-node.dimmed { opacity: 0.40; }
+  .map-edge.dimmed { opacity: 0.28; }
   .map-edge.selected { stroke: var(--cyan) !important; stroke-width: 5 !important; opacity: 1 !important; filter: drop-shadow(0 0 8px rgba(34,211,238,.65)); }
   .map-edge-hit { stroke: transparent; stroke-width: 14; fill: none; cursor: pointer; }
   .filter-bar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin-bottom: .75rem; }
   .filter-btn { background: rgba(15,23,42,.8); border: 1px solid #475569; border-radius: 8px; color: var(--muted); padding: .35rem .7rem; cursor: pointer; font: inherit; font-size: .82rem; display: inline-flex; align-items: center; gap: .4rem; }
-  .filter-btn:hover, .filter-btn:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.35); outline-offset: 2px; }
+  .filter-btn:hover, .filter-btn:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
   .filter-btn[aria-pressed="true"] { background: rgba(34,211,238,.15); border-color: var(--cyan); color: var(--cyan); font-weight: 600; }
   .filter-btn[data-filter="critical"][aria-pressed="true"] { background: rgba(248,113,113,.15); border-color: var(--red); color: var(--red); }
   .filter-btn[data-filter="warning"][aria-pressed="true"] { background: rgba(251,191,36,.15); border-color: var(--amber); color: var(--amber); }
   .filter-badge { display: inline-block; min-width: 1.3em; padding: .1em .35em; background: rgba(255,255,255,.1); border-radius: 999px; font-size: .75em; font-weight: 700; text-align: center; line-height: 1.4; }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 </style>
 </head>
  <body>
  <header>
    <div class="header-left">
      <h1>&#9881; Grid Operations Console</h1>
-     <nav class="view-toggle" aria-label="Console views">
-       <button type="button" id="operations-tab" data-view-target="operations" aria-selected="true">Operations</button>
-       <button type="button" id="map-tab" data-view-target="map" aria-selected="false">Grid Map</button>
+     <nav class="view-toggle" role="tablist" aria-label="Console views">
+       <button type="button" id="operations-tab" role="tab" aria-controls="operations-view" data-view-target="operations" aria-selected="true">Operations</button>
+       <button type="button" id="map-tab" role="tab" aria-controls="map-view" data-view-target="map" aria-selected="false">Grid Map</button>
      </nav>
    </div>
    <div class="status-bar">
@@ -130,7 +131,7 @@
    </div>
  </header>
  <main>
-   <section id="operations-view" class="app-view" data-view="operations">
+   <section id="operations-view" class="app-view" role="tabpanel" aria-labelledby="operations-tab" data-view="operations">
      <div class="grid">
        <div class="card">
          <h3>Dispatch Queue Depth</h3>
@@ -173,13 +174,13 @@
      <div class="grid" id="health-grid"></div>
    </section>
 
-   <section id="map-view" class="app-view" data-view="map" hidden>
+   <section id="map-view" class="app-view" role="tabpanel" aria-labelledby="map-tab" data-view="map" hidden>
      <div class="map-toolbar">
        <div>
          <h2 class="section-title" style="margin-top:0">&#128506; Cloud Demo Grid Map</h2>
           <div class="map-meta">Topology and live service health use the approved cloud grid-map data contract. Live checks poll every 30 seconds.</div>
        </div>
-       <div class="map-controls" aria-label="Grid map controls">
+       <div class="map-controls" role="group" aria-label="Grid map controls">
          <button class="map-button" type="button" id="map-zoom-in">Zoom in</button>
          <button class="map-button" type="button" id="map-zoom-out">Zoom out</button>
          <button class="map-button" type="button" id="map-reset">Fit / Reset</button>
@@ -187,9 +188,9 @@
      </div>
       <div class="filter-bar" role="group" aria-label="Severity filter">
         <span style="color:var(--muted);font-size:.82rem">Filter:</span>
-        <button class="filter-btn" type="button" data-filter="all" aria-pressed="true">All <span class="filter-badge" id="badge-all">—</span></button>
-        <button class="filter-btn" type="button" data-filter="critical" aria-pressed="false">Critical <span class="filter-badge" id="badge-critical">—</span></button>
-        <button class="filter-btn" type="button" data-filter="warning" aria-pressed="false">Warning <span class="filter-badge" id="badge-warning">—</span></button>
+        <button class="filter-btn" type="button" data-filter="all" aria-pressed="true">All <span class="filter-badge" id="badge-all" aria-label="loading">—</span></button>
+        <button class="filter-btn" type="button" data-filter="critical" aria-pressed="false">Critical <span class="filter-badge" id="badge-critical" aria-label="loading">—</span></button>
+        <button class="filter-btn" type="button" data-filter="warning" aria-pressed="false">Warning <span class="filter-badge" id="badge-warning" aria-label="loading">—</span></button>
       </div>
       <div class="map-disclaimer" role="note">
         Demo topology only. This map visualizes Kubernetes service/application health for the Azure SRE Agent demo and is not connected to real grid telemetry, SCADA, GIS, or utility infrastructure.
@@ -197,9 +198,11 @@
       <div class="map-health-banner warning" id="map-health-banner" role="status" aria-live="polite">
         Live service health has not been received yet. Static and optional nodes are shown in a safe unknown/static state.
       </div>
+      <p class="sr-only">Interactive topology map. Tab between nodes, Enter to select, Escape to deselect. Use arrow keys to pan, + / &#8722; to zoom, 0 to fit.</p>
+      <div id="map-selection-status" role="status" aria-live="polite" class="sr-only"></div>
       <div class="card">
        <div class="grid-map-shell" id="grid-map-shell">
-         <svg id="grid-map-svg" class="grid-map-svg" role="img" aria-label="Static cloud demo topology graph with service and data-store nodes" tabindex="0">
+         <svg id="grid-map-svg" class="grid-map-svg" role="application" aria-roledescription="interactive topology map" aria-label="Interactive cloud demo topology map" tabindex="0">
            <g id="grid-map-stage"></g>
          </svg>
          <div class="map-fallback" id="map-fallback" hidden>
@@ -513,29 +516,40 @@ function addLogEntry() {
     return { className: 'unknown', label: 'unknown/static endpoint state' };
   }
 
+ function updateSelectionStatus(text) {
+   var el = document.getElementById('map-selection-status');
+   if (el) el.textContent = text;
+ }
  function selectNode(nodeId) {
    mapState.selectedNodeId = nodeId;
    mapState.selectedEdgeKey = null;
    applyNodeSelection();
    applyEdgeSelection();
+   var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === nodeId; });
+   updateSelectionStatus(node ? node.label + ' selected' : '');
  }
  function selectEdge(key) {
    mapState.selectedEdgeKey = key;
    mapState.selectedNodeId = null;
    applyNodeSelection();
    applyEdgeSelection();
+   var parts = key ? key.split(':') : [];
+   var edge = GRID_TOPOLOGY.edges.find(function(e) { return e.source === parts[0] && e.target === parts[1]; });
+   updateSelectionStatus(edge ? edge.label + ' connection selected' : '');
  }
  function clearSelection() {
    mapState.selectedNodeId = null;
    mapState.selectedEdgeKey = null;
    applyNodeSelection();
    applyEdgeSelection();
+   updateSelectionStatus('');
  }
  function applyNodeSelection() {
    document.querySelectorAll('.map-node').forEach(function(group) {
      var isSelected = group.dataset.nodeId === mapState.selectedNodeId && !!mapState.selectedNodeId;
      group.classList.toggle('selected', isSelected);
-     group.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+     var base = (group.getAttribute('aria-label') || '').replace(', selected', '');
+     group.setAttribute('aria-label', isSelected ? base + ', selected' : base);
    });
  }
  function applyEdgeSelection() {
@@ -554,9 +568,9 @@ function addLogEntry() {
    var badgeAll = document.getElementById('badge-all');
    var badgeCritical = document.getElementById('badge-critical');
    var badgeWarning = document.getElementById('badge-warning');
-   if (badgeAll) badgeAll.textContent = total;
-   if (badgeCritical) badgeCritical.textContent = critical;
-   if (badgeWarning) badgeWarning.textContent = warning;
+   if (badgeAll) { badgeAll.textContent = total; badgeAll.removeAttribute('aria-label'); }
+   if (badgeCritical) { badgeCritical.textContent = critical; badgeCritical.removeAttribute('aria-label'); }
+   if (badgeWarning) { badgeWarning.textContent = warning; badgeWarning.removeAttribute('aria-label'); }
  }
  function applySeverityFilter() {
    var filter = mapState.activeFilter;
@@ -612,8 +626,7 @@ function addLogEntry() {
      tabindex: '0',
      role: 'img',
      'aria-label': node.label + ', ' + node.metaphor + ', ' + status.text,
-     'data-node-id': node.id,
-     'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
+     'data-node-id': node.id
    });
     const x = node.position.x;
     const y = node.position.y;
@@ -644,8 +657,7 @@ function addLogEntry() {
      tabindex: '0',
      role: 'img',
      'aria-label': node.label + ', data store, ' + node.metaphor + ', ' + status.text,
-     'data-node-id': node.id,
-     'aria-selected': mapState.selectedNodeId === node.id ? 'true' : 'false'
+     'data-node-id': node.id
    });
    const x = node.position.x;
    const y = node.position.y;
@@ -714,7 +726,7 @@ function addLogEntry() {
          'aria-hidden': 'true'
        });
        stage.appendChild(edgeHit);
-       const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle' });
+       const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle', 'aria-hidden': 'true' });
        label.textContent = edge.label + (edgeStatus.className === 'unknown' ? ' · unknown' : edgeStatus.className === 'critical' ? ' · critical' : edgeStatus.className === 'warning' ? ' · warning' : '');
        stage.appendChild(label);
     });

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -102,8 +102,8 @@
   .map-node.selected .node-ring { stroke: var(--cyan); stroke-width: 3; filter: drop-shadow(0 0 8px rgba(34,211,238,.75)); }
   .map-node:focus-visible { outline: none; }
   .map-node:focus-visible .node-focus-ring { stroke: rgba(255,255,255,.88); stroke-width: 2; stroke-dasharray: 6 4; filter: drop-shadow(0 0 6px rgba(255,255,255,.45)); }
-  .map-node.dimmed { opacity: 0.40; }
-  .map-edge.dimmed { opacity: 0.28; }
+  .map-node.dimmed { opacity: 0.52; }
+  .map-edge.dimmed { opacity: 0.45; pointer-events: none; }
   .map-edge.selected { stroke: var(--cyan) !important; stroke-width: 5 !important; opacity: 1 !important; filter: drop-shadow(0 0 8px rgba(34,211,238,.65)); }
   .map-edge-hit { stroke: transparent; stroke-width: 14; fill: none; cursor: pointer; }
   .filter-bar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin-bottom: .75rem; }
@@ -542,7 +542,7 @@ function addLogEntry() {
    mapState.selectedEdgeKey = null;
    applyNodeSelection();
    applyEdgeSelection();
-   updateSelectionStatus('');
+   updateSelectionStatus('Selection cleared.');
  }
  function applyNodeSelection() {
    document.querySelectorAll('.map-node').forEach(function(group) {
@@ -585,7 +585,7 @@ function addLogEntry() {
      group.classList.toggle('dimmed', severity !== filter);
    });
    document.querySelectorAll('.map-edge').forEach(function(line) {
-     if (filter === 'all') { line.classList.remove('dimmed'); return; }
+     if (filter === 'all') { line.classList.remove('dimmed'); line.removeAttribute('aria-hidden'); return; }
      var key = line.dataset.edgeKey;
      if (!key) return;
      var parts = key.split(':');
@@ -593,7 +593,9 @@ function addLogEntry() {
      var tgtNode = document.querySelector('.map-node[data-node-id="' + parts[1] + '"]');
      var srcDimmed = srcNode && srcNode.classList.contains('dimmed');
      var tgtDimmed = tgtNode && tgtNode.classList.contains('dimmed');
-     line.classList.toggle('dimmed', srcDimmed && tgtDimmed);
+     var isDimmed = srcDimmed && tgtDimmed;
+     line.classList.toggle('dimmed', isDimmed);
+     if (isDimmed) { line.setAttribute('aria-hidden', 'true'); } else { line.removeAttribute('aria-hidden'); }
    });
    updateFilterBadges();
  }
@@ -635,13 +637,13 @@ function addLogEntry() {
     const symbol = createSvgElement('text', { class: 'map-node-symbol', x: x + MAP_NODE.width - 22, y: y + 24, 'text-anchor': 'middle', 'aria-hidden': 'true' });
     symbol.textContent = status.symbol;
     group.appendChild(symbol);
-    const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 23 });
+    const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 23, 'aria-hidden': 'true' });
     title.textContent = node.label;
     group.appendChild(title);
-   const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 46 });
+   const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 46, 'aria-hidden': 'true' });
    subtitle.textContent = node.metaphor;
    group.appendChild(subtitle);
-   const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64 });
+   const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64, 'aria-hidden': 'true' });
    state.textContent = status.text;
    group.appendChild(state);
    group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 18, ry: 18 }));
@@ -668,13 +670,13 @@ function addLogEntry() {
     const symbol = createSvgElement('text', { class: 'map-node-symbol', x: x + MAP_NODE.width - 22, y: y + 27, 'text-anchor': 'middle', 'aria-hidden': 'true' });
     symbol.textContent = status.symbol;
     group.appendChild(symbol);
-    const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 27 });
+    const title = createSvgElement('text', { class: 'map-node-title', x: x + 30, y: y + 27, 'aria-hidden': 'true' });
    title.textContent = node.label;
    group.appendChild(title);
-   const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 50 });
+   const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 50, 'aria-hidden': 'true' });
    subtitle.textContent = node.metaphor;
    group.appendChild(subtitle);
-   const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 67 });
+   const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 67, 'aria-hidden': 'true' });
    state.textContent = status.text;
    group.appendChild(state);
    group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 14, ry: 14 }));
@@ -841,6 +843,8 @@ function addLogEntry() {
      const hitLine = event.target.closest ? event.target.closest('.map-edge-hit') : null;
      if (hitLine && hitLine.dataset.edgeKey) {
        const key = hitLine.dataset.edgeKey;
+       const edgeLine = document.querySelector('.map-edge[data-edge-key="' + key + '"]');
+       if (edgeLine && edgeLine.classList.contains('dimmed')) return;
        if (mapState.selectedEdgeKey === key) clearSelection(); else selectEdge(key);
        return;
      }

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -198,11 +198,11 @@
       <div class="map-health-banner warning" id="map-health-banner" role="status" aria-live="polite">
         Live service health has not been received yet. Static and optional nodes are shown in a safe unknown/static state.
       </div>
-      <p class="sr-only">Interactive topology map. Tab between nodes, Enter to select, Escape to deselect. Use arrow keys to pan, + / &#8722; to zoom, 0 to fit.</p>
+      <p class="sr-only" id="map-instructions">Interactive topology map. Tab between nodes, Enter to select, Escape to deselect. Use arrow keys to pan, + / &#8722; to zoom, 0 to fit.</p>
       <div id="map-selection-status" role="status" aria-live="polite" class="sr-only"></div>
       <div class="card">
        <div class="grid-map-shell" id="grid-map-shell">
-         <svg id="grid-map-svg" class="grid-map-svg" role="application" aria-roledescription="interactive topology map" aria-label="Interactive cloud demo topology map" tabindex="0">
+         <svg id="grid-map-svg" class="grid-map-svg" role="application" aria-roledescription="interactive topology map" aria-label="Interactive cloud demo topology map" aria-describedby="map-instructions" tabindex="0">
            <g id="grid-map-stage"></g>
          </svg>
          <div class="map-fallback" id="map-fallback" hidden>


### PR DESCRIPTION
## Summary
- adds node and edge selection for the deployed cloud demo Grid Map
- adds All/Critical/Warning severity filters with count badges and dimming instead of hiding
- adds keyboard navigation, accessible labels/status announcements, and source/ConfigMap HTML sync
- preserves pan/zoom across health-poll re-renders

## Validation
- parsed k8s/base/application.yaml with PyYAML
- verified k8s/base/ops-console.html is byte-identical to embedded ops-console-html ConfigMap
- extracted ops-console inline JavaScript and ran node --check
- validated grid-map topology references
- verified no local Mission Control API dependencies were introduced
- git diff --check
- code-review gate approved
- accessibility gate approved

Fixes #19