### PR TITLE
Add cloud grid map detail drawer

### DIFF
--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -1471,6 +1471,8 @@ data:
      function initDetailDrawer() {
        var closeBtn = document.getElementById('drawer-close');
        if (closeBtn) closeBtn.addEventListener('click', clearSelection);
+       var drawer = document.getElementById('detail-drawer');
+       if (drawer) drawer.addEventListener('keydown', function(e) { if (e.key === 'Escape') { e.preventDefault(); clearSelection(); } });
      }
      function selectNode(nodeId) {
        mapState.selectedNodeId = nodeId;

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -1052,6 +1052,7 @@ data:
       const SEVERITY_RANK = { healthy: 0, warning: 1, critical: 2 };
        const mapState = { x: 0, y: 0, k: 1, rendered: false, dragging: false, dragX: 0, dragY: 0, dragMoved: false, healthById: {}, lastSuccessfulHealthPoll: null, healthPollInFlight: false, selectedNodeId: null, selectedEdgeKey: null, activeFilter: 'all' };
      var _drawerLastFocus = null;
+     var _drawerLastFocusNodeId = null;
 
     function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
 
@@ -1427,7 +1428,7 @@ data:
        if (subtitleEl) subtitleEl.textContent = subtitleText || '';
        if (bodyEl) bodyEl.innerHTML = bodyHtml;
        if (citEl) citEl.textContent = citationText;
-       if (drawer.hidden) { _drawerLastFocus = document.activeElement; }
+       if (drawer.hidden) { _drawerLastFocus = document.activeElement; _drawerLastFocusNodeId = (document.activeElement && document.activeElement.dataset && document.activeElement.dataset.nodeId) ? document.activeElement.dataset.nodeId : null; }
        drawer.hidden = false;
        var closeBtn = document.getElementById('drawer-close');
        if (closeBtn) closeBtn.focus();
@@ -1436,9 +1437,16 @@ data:
        var drawer = document.getElementById('detail-drawer');
        if (!drawer) return;
        drawer.hidden = true;
-       if (_drawerLastFocus && typeof _drawerLastFocus.focus === 'function') {
-         try { _drawerLastFocus.focus(); } catch (e) {}
+       var focusTarget = null;
+       if (_drawerLastFocusNodeId) {
+         focusTarget = document.querySelector('.map-node[data-node-id="' + _drawerLastFocusNodeId + '"]');
        }
+       if (!focusTarget && _drawerLastFocus && _drawerLastFocus.isConnected && typeof _drawerLastFocus.focus === 'function') {
+         focusTarget = _drawerLastFocus;
+       }
+       if (focusTarget) { try { focusTarget.focus(); } catch (e) {} }
+       _drawerLastFocus = null;
+       _drawerLastFocusNodeId = null;
      }
      function refreshDetailDrawerIfOpen() {
        var drawer = document.getElementById('detail-drawer');

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -870,10 +870,10 @@ data:
       .drawer-header { display: flex; align-items: flex-start; justify-content: space-between; gap: .5rem; }
       .drawer-close { background: none; border: 1px solid #475569; border-radius: 6px; color: var(--muted); padding: .25rem .55rem; cursor: pointer; font: inherit; font-size: 1rem; line-height: 1; flex-shrink: 0; }
       .drawer-close:hover, .drawer-close:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
-      .drawer-title { font-size: .95rem; font-weight: 700; color: var(--text); line-height: 1.3; }
+      .drawer-title { font-size: .95rem; font-weight: 700; color: var(--text); line-height: 1.3; margin: 0; }
       .drawer-subtitle { font-size: .78rem; color: var(--muted); margin-top: .15rem; }
       .drawer-section { border-top: 1px solid #334155; padding-top: .6rem; }
-      .drawer-section-title { font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin-bottom: .45rem; }
+      .drawer-section-title { font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin: 0 0 .45rem; }
       .drawer-row { display: flex; justify-content: space-between; gap: .5rem; font-size: .82rem; margin-bottom: .3rem; line-height: 1.4; }
       .drawer-label { color: var(--muted); flex-shrink: 0; }
       .drawer-value { color: var(--text); text-align: right; }
@@ -988,10 +988,10 @@ data:
                  Increase the browser window or use a larger display to view the topology safely.
                </div>
              </div>
-              <aside id="detail-drawer" class="detail-drawer" hidden aria-label="Selection detail panel">
+              <aside id="detail-drawer" class="detail-drawer" hidden aria-labelledby="drawer-title">
                 <div class="drawer-header">
                   <div>
-                    <div class="drawer-title" id="drawer-title"></div>
+                    <h2 class="drawer-title" id="drawer-title"></h2>
                     <div class="drawer-subtitle" id="drawer-subtitle"></div>
                   </div>
                   <button type="button" class="drawer-close" id="drawer-close" aria-label="Close detail panel">&#x2715;</button>
@@ -1328,7 +1328,7 @@ data:
        var result = node.healthSource === 'live' ? (mapState.healthById[node.id] || null) : null;
        var html = '';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Status</div>';
+       html += '<h3 class="drawer-section-title">Status</h3>';
        html += '<div class="drawer-row"><span class="drawer-label">Reported status</span><span class="drawer-value ' + escHtml(status.className) + '">' + escHtml(status.text) + '</span></div>';
        html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(node.metaphor) + '</span></div>';
        html += '<div class="drawer-row"><span class="drawer-label">Kind</span><span class="drawer-value">' + escHtml(node.kind) + '</span></div>';
@@ -1338,7 +1338,7 @@ data:
        }
        html += '</div>';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Health source</div>';
+       html += '<h3 class="drawer-section-title">Health source</h3>';
        if (node.healthSource === 'live' && result) {
          html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Cloud demo live endpoint</span></div>';
          html += '<div class="drawer-row"><span class="drawer-label">HTTP status</span><span class="drawer-value">' + (result.httpStatus ? result.httpStatus : '\u2014') + '</span></div>';
@@ -1366,7 +1366,7 @@ data:
        }
        html += '</div>';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Optional details</div>';
+       html += '<h3 class="drawer-section-title">Optional details</h3>';
        html += '<div class="drawer-unavailable">Pod-level metrics, recent events, and application logs are not available from the V1 cloud demo health contract. This panel shows only the health snapshot from the approved cloud demo data source.</div>';
        html += '</div>';
        return html;
@@ -1377,25 +1377,25 @@ data:
        var edgeStatus = getEdgeStatus(edge, src, tgt);
        var html = '';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Connection</div>';
+       html += '<h3 class="drawer-section-title">Connection</h3>';
        html += '<div class="drawer-row"><span class="drawer-label">Flow type</span><span class="drawer-value">' + escHtml(edge.type || 'sync') + '</span></div>';
        if (edge.disabled) html += '<div class="drawer-row"><span class="drawer-label">State</span><span class="drawer-value warning">Disabled path</span></div>';
        if (edge.optional) html += '<div class="drawer-row"><span class="drawer-label">Optional</span><span class="drawer-value">Yes \u2014 may be absent</span></div>';
        html += '</div>';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Source endpoint</div>';
+       html += '<h3 class="drawer-section-title">Source endpoint</h3>';
        html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(src.label) + '</span></div>';
        html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(src.metaphor) + '</span></div>';
        html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(srcStatus.className) + '">' + escHtml(srcStatus.text) + '</span></div>';
        html += '</div>';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Target endpoint</div>';
+       html += '<h3 class="drawer-section-title">Target endpoint</h3>';
        html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(tgt.label) + '</span></div>';
        html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(tgt.metaphor) + '</span></div>';
        html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(tgtStatus.className) + '">' + escHtml(tgtStatus.text) + '</span></div>';
        html += '</div>';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Connection assessment</div>';
+       html += '<h3 class="drawer-section-title">Connection assessment</h3>';
        var assess = '';
        if (edge.disabled) {
          assess = 'This connection path is disabled in the current deployment. No active data flow is expected on this path.';
@@ -1411,7 +1411,7 @@ data:
        html += '<div class="drawer-assessment">' + escHtml(assess) + '</div>';
        html += '</div>';
        html += '<div class="drawer-section">';
-       html += '<div class="drawer-section-title">Optional details</div>';
+       html += '<h3 class="drawer-section-title">Optional details</h3>';
        html += '<div class="drawer-unavailable">Endpoint-level telemetry, request rates, and error counts are not available from the V1 cloud demo health contract. This panel shows only connection state inferred from the approved cloud demo health snapshot.</div>';
        html += '</div>';
        return html;

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -1427,7 +1427,7 @@ data:
        if (subtitleEl) subtitleEl.textContent = subtitleText || '';
        if (bodyEl) bodyEl.innerHTML = bodyHtml;
        if (citEl) citEl.textContent = citationText;
-       _drawerLastFocus = document.activeElement;
+       if (drawer.hidden) { _drawerLastFocus = document.activeElement; }
        drawer.hidden = false;
        var closeBtn = document.getElementById('drawer-close');
        if (closeBtn) closeBtn.focus();

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -864,6 +864,33 @@ data:
       .filter-btn[data-filter="warning"][aria-pressed="true"] { background: rgba(251,191,36,.15); border-color: var(--amber); color: var(--amber); }
       .filter-badge { display: inline-block; min-width: 1.3em; padding: .1em .35em; background: rgba(255,255,255,.1); border-radius: 999px; font-size: .75em; font-weight: 700; text-align: center; line-height: 1.4; }
       .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+      /* Detail Drawer */
+      .detail-drawer { position: absolute; top: 0; right: 0; width: min(340px, 100%); height: 100%; background: rgba(15,23,42,.97); border-left: 1px solid #334155; border-radius: 0 12px 12px 0; padding: 1rem 1.1rem; overflow-y: auto; z-index: 10; display: flex; flex-direction: column; gap: .7rem; }
+      .detail-drawer[hidden] { display: none; }
+      .drawer-header { display: flex; align-items: flex-start; justify-content: space-between; gap: .5rem; }
+      .drawer-close { background: none; border: 1px solid #475569; border-radius: 6px; color: var(--muted); padding: .25rem .55rem; cursor: pointer; font: inherit; font-size: 1rem; line-height: 1; flex-shrink: 0; }
+      .drawer-close:hover, .drawer-close:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
+      .drawer-title { font-size: .95rem; font-weight: 700; color: var(--text); line-height: 1.3; }
+      .drawer-subtitle { font-size: .78rem; color: var(--muted); margin-top: .15rem; }
+      .drawer-section { border-top: 1px solid #334155; padding-top: .6rem; }
+      .drawer-section-title { font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin-bottom: .45rem; }
+      .drawer-row { display: flex; justify-content: space-between; gap: .5rem; font-size: .82rem; margin-bottom: .3rem; line-height: 1.4; }
+      .drawer-label { color: var(--muted); flex-shrink: 0; }
+      .drawer-value { color: var(--text); text-align: right; }
+      .drawer-value.healthy { color: var(--green); }
+      .drawer-value.warning { color: var(--amber); }
+      .drawer-value.critical { color: var(--red); }
+      .drawer-value.unknown, .drawer-value.static { color: var(--muted); }
+      .drawer-value.disabled { color: var(--amber); }
+      .drawer-assessment { font-size: .8rem; color: #cbd5e1; line-height: 1.5; background: rgba(51,65,85,.4); border-radius: 6px; padding: .5rem .65rem; margin-top: .2rem; }
+      .drawer-unavailable { font-size: .79rem; color: var(--muted); font-style: italic; line-height: 1.45; }
+      .drawer-citation { font-size: .73rem; color: var(--muted); border-top: 1px solid #334155; margin-top: auto; line-height: 1.4; padding-top: .55rem; }
+      @keyframes skeleton-pulse { 0%,100% { opacity: .55; } 50% { opacity: .22; } }
+      .skeleton { background: #334155; border-radius: 4px; animation: skeleton-pulse 1.4s ease-in-out infinite; height: .85em; margin-bottom: .3rem; display: block; }
+      .skeleton.short { width: 52%; }
+      .skeleton.long { width: 82%; }
+      @media (max-width: 799px) { .detail-drawer { position: static; width: 100%; height: auto; border-left: none; border-radius: 10px; border: 1px solid #334155; margin-top: .75rem; } }
+      @media (prefers-reduced-motion: reduce) { .skeleton { animation: none; opacity: .45; } }
     </style>
     </head>
      <body>
@@ -961,6 +988,17 @@ data:
                  Increase the browser window or use a larger display to view the topology safely.
                </div>
              </div>
+              <aside id="detail-drawer" class="detail-drawer" hidden aria-label="Selection detail panel">
+                <div class="drawer-header">
+                  <div>
+                    <div class="drawer-title" id="drawer-title"></div>
+                    <div class="drawer-subtitle" id="drawer-subtitle"></div>
+                  </div>
+                  <button type="button" class="drawer-close" id="drawer-close" aria-label="Close detail panel">&#x2715;</button>
+                </div>
+                <div id="drawer-body"></div>
+                <div class="drawer-citation" id="drawer-citation"></div>
+              </aside>
            </div>
          </div>
        </section>
@@ -1013,6 +1051,7 @@ data:
       const STALE_AFTER_MS = 60000;
       const SEVERITY_RANK = { healthy: 0, warning: 1, critical: 2 };
        const mapState = { x: 0, y: 0, k: 1, rendered: false, dragging: false, dragX: 0, dragY: 0, dragMoved: false, healthById: {}, lastSuccessfulHealthPoll: null, healthPollInFlight: false, selectedNodeId: null, selectedEdgeKey: null, activeFilter: 'all' };
+     var _drawerLastFocus = null;
 
     function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
 
@@ -1205,6 +1244,7 @@ data:
         mapState.rendered = false;
         const mapView = document.getElementById('map-view');
         if (mapView && !mapView.hidden) renderGridMap({ preserveViewport: true });
+        refreshDetailDrawerIfOpen();
       }
 
       function loadHealth() {
@@ -1270,6 +1310,168 @@ data:
        var el = document.getElementById('map-selection-status');
        if (el) el.textContent = text;
      }
+
+     function escHtml(str) {
+       if (str === null || str === undefined) return '';
+       return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+     }
+     function fmtTime(ts) {
+       if (!ts) return 'unknown time';
+       return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+     }
+     function citationTimestamp() {
+       var ts = mapState.lastSuccessfulHealthPoll;
+       return ts ? fmtTime(ts) : 'session start';
+     }
+     function buildNodeBody(node) {
+       var status = getMapStatus(node);
+       var result = node.healthSource === 'live' ? (mapState.healthById[node.id] || null) : null;
+       var html = '';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Status</div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Reported status</span><span class="drawer-value ' + escHtml(status.className) + '">' + escHtml(status.text) + '</span></div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(node.metaphor) + '</span></div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Kind</span><span class="drawer-value">' + escHtml(node.kind) + '</span></div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Resource</span><span class="drawer-value">' + escHtml(node.resourceName) + '</span></div>';
+       if (node.replicas === 0) {
+         html += '<div class="drawer-row"><span class="drawer-label">Replicas</span><span class="drawer-value warning">0 \u2014 disabled</span></div>';
+       }
+       html += '</div>';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Health source</div>';
+       if (node.healthSource === 'live' && result) {
+         html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Cloud demo live endpoint</span></div>';
+         html += '<div class="drawer-row"><span class="drawer-label">HTTP status</span><span class="drawer-value">' + (result.httpStatus ? result.httpStatus : '\u2014') + '</span></div>';
+         html += '<div class="drawer-row"><span class="drawer-label">Checked at</span><span class="drawer-value">' + escHtml(fmtTime(result.checkedAt)) + '</span></div>';
+         if (result.reason === 'network') {
+           html += '<div class="drawer-assessment">This service currently reports as unreachable from the browser. This may indicate an application health issue or a network configuration in the demo environment. This does not represent real grid operations.</div>';
+         } else if (result.severity === 'critical') {
+           html += '<div class="drawer-assessment">This service currently reports a server error response. This may indicate an application health issue in the cloud demo. The visual impact on connected edges reflects this status.</div>';
+         } else if (result.severity === 'warning') {
+           html += '<div class="drawer-assessment">This service currently reports a non-success response. This may indicate a degraded condition in the cloud demo. The visual impact on connected edges reflects this status.</div>';
+         }
+       } else if (node.healthSource === 'live' && !result) {
+         html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Cloud demo live endpoint</span></div>';
+         html += '<span class="skeleton long"></span><span class="skeleton short"></span>';
+         html += '<div class="drawer-assessment">Checking approved health endpoint&#x2026; Skeleton shown while live data loads.</div>';
+       } else if (node.healthSource === 'static') {
+         html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Static in-cluster</span></div>';
+         html += '<div class="drawer-assessment">No browser-accessible health endpoint is available for this node under the cloud demo contract. Health is inferred from topology context only.</div>';
+       } else if (node.healthSource === 'optional') {
+         html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Optional \u2014 absent</span></div>';
+         html += '<div class="drawer-assessment">This optional service was not detected in the current cloud demo deployment. No health data is available.</div>';
+       }
+       if (node.stateNote) {
+         html += '<div class="drawer-row" style="margin-top:.3rem"><span class="drawer-label">Note</span><span class="drawer-value" style="text-align:left;color:var(--muted)">' + escHtml(node.stateNote) + '</span></div>';
+       }
+       html += '</div>';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Optional details</div>';
+       html += '<div class="drawer-unavailable">Pod-level metrics, recent events, and application logs are not available from the V1 cloud demo health contract. This panel shows only the health snapshot from the approved cloud demo data source.</div>';
+       html += '</div>';
+       return html;
+     }
+     function buildEdgeBody(edge, src, tgt) {
+       var srcStatus = getMapStatus(src);
+       var tgtStatus = getMapStatus(tgt);
+       var edgeStatus = getEdgeStatus(edge, src, tgt);
+       var html = '';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Connection</div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Flow type</span><span class="drawer-value">' + escHtml(edge.type || 'sync') + '</span></div>';
+       if (edge.disabled) html += '<div class="drawer-row"><span class="drawer-label">State</span><span class="drawer-value warning">Disabled path</span></div>';
+       if (edge.optional) html += '<div class="drawer-row"><span class="drawer-label">Optional</span><span class="drawer-value">Yes \u2014 may be absent</span></div>';
+       html += '</div>';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Source endpoint</div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(src.label) + '</span></div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(src.metaphor) + '</span></div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(srcStatus.className) + '">' + escHtml(srcStatus.text) + '</span></div>';
+       html += '</div>';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Target endpoint</div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(tgt.label) + '</span></div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(tgt.metaphor) + '</span></div>';
+       html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(tgtStatus.className) + '">' + escHtml(tgtStatus.text) + '</span></div>';
+       html += '</div>';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Connection assessment</div>';
+       var assess = '';
+       if (edge.disabled) {
+         assess = 'This connection path is disabled in the current deployment. No active data flow is expected on this path.';
+       } else if (edgeStatus.className === 'healthy') {
+         assess = 'Both endpoints currently report healthy status. This connection path currently reports no visual impact.';
+       } else if (edgeStatus.className === 'critical') {
+         assess = 'One or more endpoints on this connection currently report a critical health status. The visual impact on this edge reflects the endpoint state. This may indicate an application health issue in the cloud demo environment.';
+       } else if (edgeStatus.className === 'warning') {
+         assess = 'One or more endpoints on this connection currently report a warning health status. The visual impact on this edge reflects the endpoint state. This may indicate a degraded condition in the cloud demo environment.';
+       } else {
+         assess = 'One or more endpoints are in an unknown or static state. Visual impact cannot be fully determined from the current cloud demo health data.';
+       }
+       html += '<div class="drawer-assessment">' + escHtml(assess) + '</div>';
+       html += '</div>';
+       html += '<div class="drawer-section">';
+       html += '<div class="drawer-section-title">Optional details</div>';
+       html += '<div class="drawer-unavailable">Endpoint-level telemetry, request rates, and error counts are not available from the V1 cloud demo health contract. This panel shows only connection state inferred from the approved cloud demo health snapshot.</div>';
+       html += '</div>';
+       return html;
+     }
+     function openDetailDrawer(titleText, subtitleText, bodyHtml, citationText) {
+       var drawer = document.getElementById('detail-drawer');
+       var titleEl = document.getElementById('drawer-title');
+       var subtitleEl = document.getElementById('drawer-subtitle');
+       var bodyEl = document.getElementById('drawer-body');
+       var citEl = document.getElementById('drawer-citation');
+       if (!drawer) return;
+       if (titleEl) titleEl.textContent = titleText;
+       if (subtitleEl) subtitleEl.textContent = subtitleText || '';
+       if (bodyEl) bodyEl.innerHTML = bodyHtml;
+       if (citEl) citEl.textContent = citationText;
+       _drawerLastFocus = document.activeElement;
+       drawer.hidden = false;
+       var closeBtn = document.getElementById('drawer-close');
+       if (closeBtn) closeBtn.focus();
+     }
+     function closeDetailDrawer() {
+       var drawer = document.getElementById('detail-drawer');
+       if (!drawer) return;
+       drawer.hidden = true;
+       if (_drawerLastFocus && typeof _drawerLastFocus.focus === 'function') {
+         try { _drawerLastFocus.focus(); } catch (e) {}
+       }
+     }
+     function refreshDetailDrawerIfOpen() {
+       var drawer = document.getElementById('detail-drawer');
+       if (!drawer || drawer.hidden) return;
+       if (mapState.selectedNodeId) {
+         var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === mapState.selectedNodeId; });
+         if (node) {
+           var bodyEl = document.getElementById('drawer-body');
+           var citEl = document.getElementById('drawer-citation');
+           if (bodyEl) bodyEl.innerHTML = buildNodeBody(node);
+           if (citEl) citEl.textContent = 'Data from cloud demo snapshot at ' + citationTimestamp();
+         }
+       } else if (mapState.selectedEdgeKey) {
+         var parts = mapState.selectedEdgeKey.split(':');
+         var edge = GRID_TOPOLOGY.edges.find(function(e) { return e.source === parts[0] && e.target === parts[1]; });
+         if (edge) {
+           var nodesById2 = {};
+           GRID_TOPOLOGY.nodes.forEach(function(n) { nodesById2[n.id] = n; });
+           var src = nodesById2[edge.source];
+           var tgt = nodesById2[edge.target];
+           if (src && tgt) {
+             var bodyEl2 = document.getElementById('drawer-body');
+             var citEl2 = document.getElementById('drawer-citation');
+             if (bodyEl2) bodyEl2.innerHTML = buildEdgeBody(edge, src, tgt);
+             if (citEl2) citEl2.textContent = 'Data from cloud demo snapshot at ' + citationTimestamp();
+           }
+         }
+       }
+     }
+     function initDetailDrawer() {
+       var closeBtn = document.getElementById('drawer-close');
+       if (closeBtn) closeBtn.addEventListener('click', clearSelection);
+     }
      function selectNode(nodeId) {
        mapState.selectedNodeId = nodeId;
        mapState.selectedEdgeKey = null;
@@ -1277,6 +1479,9 @@ data:
        applyEdgeSelection();
        var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === nodeId; });
        updateSelectionStatus(node ? node.label + ' selected' : '');
+       if (node) {
+         openDetailDrawer(node.label, node.metaphor + ' · ' + node.kind, buildNodeBody(node), 'Data from cloud demo snapshot at ' + citationTimestamp());
+       }
      }
      function selectEdge(key) {
        mapState.selectedEdgeKey = key;
@@ -1286,6 +1491,15 @@ data:
        var parts = key ? key.split(':') : [];
        var edge = GRID_TOPOLOGY.edges.find(function(e) { return e.source === parts[0] && e.target === parts[1]; });
        updateSelectionStatus(edge ? edge.label + ' connection selected' : '');
+       if (edge) {
+         var nodesById = {};
+         GRID_TOPOLOGY.nodes.forEach(function(n) { nodesById[n.id] = n; });
+         var src = nodesById[edge.source];
+         var tgt = nodesById[edge.target];
+         if (src && tgt) {
+           openDetailDrawer(edge.label, src.label + ' → ' + tgt.label, buildEdgeBody(edge, src, tgt), 'Data from cloud demo snapshot at ' + citationTimestamp());
+         }
+       }
      }
      function clearSelection() {
        mapState.selectedNodeId = null;
@@ -1293,6 +1507,7 @@ data:
        applyNodeSelection();
        applyEdgeSelection();
        updateSelectionStatus('Selection cleared.');
+       closeDetailDrawer();
      }
      function applyNodeSelection() {
        document.querySelectorAll('.map-node').forEach(function(group) {
@@ -1658,7 +1873,7 @@ data:
        setConsoleView(initialViewFromLocation(), false);
      }
 
-     initViewToggle();
+     initViewToggle(); initDetailDrawer();
      updateClock(); updateMetrics(); loadDispatches(); loadAssets(); loadHealth();
     for (let i = 0; i < 10; i++) addLogEntry();
     setInterval(updateClock, 1000);
@@ -1671,6 +1886,7 @@ data:
     </script>
     </body>
     </html>
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -302,6 +302,7 @@ const DISPATCH_TYPES = ['Load Balance', 'Frequency Adj', 'Capacity Shift', 'Emer
   const SEVERITY_RANK = { healthy: 0, warning: 1, critical: 2 };
    const mapState = { x: 0, y: 0, k: 1, rendered: false, dragging: false, dragX: 0, dragY: 0, dragMoved: false, healthById: {}, lastSuccessfulHealthPoll: null, healthPollInFlight: false, selectedNodeId: null, selectedEdgeKey: null, activeFilter: 'all' };
  var _drawerLastFocus = null;
+ var _drawerLastFocusNodeId = null;
 
 function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
 
@@ -677,7 +678,7 @@ function addLogEntry() {
    if (subtitleEl) subtitleEl.textContent = subtitleText || '';
    if (bodyEl) bodyEl.innerHTML = bodyHtml;
    if (citEl) citEl.textContent = citationText;
-   if (drawer.hidden) { _drawerLastFocus = document.activeElement; }
+   if (drawer.hidden) { _drawerLastFocus = document.activeElement; _drawerLastFocusNodeId = (document.activeElement && document.activeElement.dataset && document.activeElement.dataset.nodeId) ? document.activeElement.dataset.nodeId : null; }
    drawer.hidden = false;
    var closeBtn = document.getElementById('drawer-close');
    if (closeBtn) closeBtn.focus();
@@ -686,9 +687,16 @@ function addLogEntry() {
    var drawer = document.getElementById('detail-drawer');
    if (!drawer) return;
    drawer.hidden = true;
-   if (_drawerLastFocus && typeof _drawerLastFocus.focus === 'function') {
-     try { _drawerLastFocus.focus(); } catch (e) {}
+   var focusTarget = null;
+   if (_drawerLastFocusNodeId) {
+     focusTarget = document.querySelector('.map-node[data-node-id="' + _drawerLastFocusNodeId + '"]');
    }
+   if (!focusTarget && _drawerLastFocus && _drawerLastFocus.isConnected && typeof _drawerLastFocus.focus === 'function') {
+     focusTarget = _drawerLastFocus;
+   }
+   if (focusTarget) { try { focusTarget.focus(); } catch (e) {} }
+   _drawerLastFocus = null;
+   _drawerLastFocusNodeId = null;
  }
  function refreshDetailDrawerIfOpen() {
    var drawer = document.getElementById('detail-drawer');

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -721,6 +721,8 @@ function addLogEntry() {
  function initDetailDrawer() {
    var closeBtn = document.getElementById('drawer-close');
    if (closeBtn) closeBtn.addEventListener('click', clearSelection);
+   var drawer = document.getElementById('detail-drawer');
+   if (drawer) drawer.addEventListener('keydown', function(e) { if (e.key === 'Escape') { e.preventDefault(); clearSelection(); } });
  }
  function selectNode(nodeId) {
    mapState.selectedNodeId = nodeId;

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -120,10 +120,10 @@
   .drawer-header { display: flex; align-items: flex-start; justify-content: space-between; gap: .5rem; }
   .drawer-close { background: none; border: 1px solid #475569; border-radius: 6px; color: var(--muted); padding: .25rem .55rem; cursor: pointer; font: inherit; font-size: 1rem; line-height: 1; flex-shrink: 0; }
   .drawer-close:hover, .drawer-close:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
-  .drawer-title { font-size: .95rem; font-weight: 700; color: var(--text); line-height: 1.3; }
+  .drawer-title { font-size: .95rem; font-weight: 700; color: var(--text); line-height: 1.3; margin: 0; }
   .drawer-subtitle { font-size: .78rem; color: var(--muted); margin-top: .15rem; }
   .drawer-section { border-top: 1px solid #334155; padding-top: .6rem; }
-  .drawer-section-title { font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin-bottom: .45rem; }
+  .drawer-section-title { font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin: 0 0 .45rem; }
   .drawer-row { display: flex; justify-content: space-between; gap: .5rem; font-size: .82rem; margin-bottom: .3rem; line-height: 1.4; }
   .drawer-label { color: var(--muted); flex-shrink: 0; }
   .drawer-value { color: var(--text); text-align: right; }
@@ -238,10 +238,10 @@
              Increase the browser window or use a larger display to view the topology safely.
            </div>
          </div>
-          <aside id="detail-drawer" class="detail-drawer" hidden aria-label="Selection detail panel">
+          <aside id="detail-drawer" class="detail-drawer" hidden aria-labelledby="drawer-title">
             <div class="drawer-header">
               <div>
-                <div class="drawer-title" id="drawer-title"></div>
+                <h2 class="drawer-title" id="drawer-title"></h2>
                 <div class="drawer-subtitle" id="drawer-subtitle"></div>
               </div>
               <button type="button" class="drawer-close" id="drawer-close" aria-label="Close detail panel">&#x2715;</button>
@@ -578,7 +578,7 @@ function addLogEntry() {
    var result = node.healthSource === 'live' ? (mapState.healthById[node.id] || null) : null;
    var html = '';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Status</div>';
+   html += '<h3 class="drawer-section-title">Status</h3>';
    html += '<div class="drawer-row"><span class="drawer-label">Reported status</span><span class="drawer-value ' + escHtml(status.className) + '">' + escHtml(status.text) + '</span></div>';
    html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(node.metaphor) + '</span></div>';
    html += '<div class="drawer-row"><span class="drawer-label">Kind</span><span class="drawer-value">' + escHtml(node.kind) + '</span></div>';
@@ -588,7 +588,7 @@ function addLogEntry() {
    }
    html += '</div>';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Health source</div>';
+   html += '<h3 class="drawer-section-title">Health source</h3>';
    if (node.healthSource === 'live' && result) {
      html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Cloud demo live endpoint</span></div>';
      html += '<div class="drawer-row"><span class="drawer-label">HTTP status</span><span class="drawer-value">' + (result.httpStatus ? result.httpStatus : '\u2014') + '</span></div>';
@@ -616,7 +616,7 @@ function addLogEntry() {
    }
    html += '</div>';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Optional details</div>';
+   html += '<h3 class="drawer-section-title">Optional details</h3>';
    html += '<div class="drawer-unavailable">Pod-level metrics, recent events, and application logs are not available from the V1 cloud demo health contract. This panel shows only the health snapshot from the approved cloud demo data source.</div>';
    html += '</div>';
    return html;
@@ -627,25 +627,25 @@ function addLogEntry() {
    var edgeStatus = getEdgeStatus(edge, src, tgt);
    var html = '';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Connection</div>';
+   html += '<h3 class="drawer-section-title">Connection</h3>';
    html += '<div class="drawer-row"><span class="drawer-label">Flow type</span><span class="drawer-value">' + escHtml(edge.type || 'sync') + '</span></div>';
    if (edge.disabled) html += '<div class="drawer-row"><span class="drawer-label">State</span><span class="drawer-value warning">Disabled path</span></div>';
    if (edge.optional) html += '<div class="drawer-row"><span class="drawer-label">Optional</span><span class="drawer-value">Yes \u2014 may be absent</span></div>';
    html += '</div>';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Source endpoint</div>';
+   html += '<h3 class="drawer-section-title">Source endpoint</h3>';
    html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(src.label) + '</span></div>';
    html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(src.metaphor) + '</span></div>';
    html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(srcStatus.className) + '">' + escHtml(srcStatus.text) + '</span></div>';
    html += '</div>';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Target endpoint</div>';
+   html += '<h3 class="drawer-section-title">Target endpoint</h3>';
    html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(tgt.label) + '</span></div>';
    html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(tgt.metaphor) + '</span></div>';
    html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(tgtStatus.className) + '">' + escHtml(tgtStatus.text) + '</span></div>';
    html += '</div>';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Connection assessment</div>';
+   html += '<h3 class="drawer-section-title">Connection assessment</h3>';
    var assess = '';
    if (edge.disabled) {
      assess = 'This connection path is disabled in the current deployment. No active data flow is expected on this path.';
@@ -661,7 +661,7 @@ function addLogEntry() {
    html += '<div class="drawer-assessment">' + escHtml(assess) + '</div>';
    html += '</div>';
    html += '<div class="drawer-section">';
-   html += '<div class="drawer-section-title">Optional details</div>';
+   html += '<h3 class="drawer-section-title">Optional details</h3>';
    html += '<div class="drawer-unavailable">Endpoint-level telemetry, request rates, and error counts are not available from the V1 cloud demo health contract. This panel shows only connection state inferred from the approved cloud demo health snapshot.</div>';
    html += '</div>';
    return html;

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -677,7 +677,7 @@ function addLogEntry() {
    if (subtitleEl) subtitleEl.textContent = subtitleText || '';
    if (bodyEl) bodyEl.innerHTML = bodyHtml;
    if (citEl) citEl.textContent = citationText;
-   _drawerLastFocus = document.activeElement;
+   if (drawer.hidden) { _drawerLastFocus = document.activeElement; }
    drawer.hidden = false;
    var closeBtn = document.getElementById('drawer-close');
    if (closeBtn) closeBtn.focus();

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -114,6 +114,33 @@
   .filter-btn[data-filter="warning"][aria-pressed="true"] { background: rgba(251,191,36,.15); border-color: var(--amber); color: var(--amber); }
   .filter-badge { display: inline-block; min-width: 1.3em; padding: .1em .35em; background: rgba(255,255,255,.1); border-radius: 999px; font-size: .75em; font-weight: 700; text-align: center; line-height: 1.4; }
   .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+  /* Detail Drawer */
+  .detail-drawer { position: absolute; top: 0; right: 0; width: min(340px, 100%); height: 100%; background: rgba(15,23,42,.97); border-left: 1px solid #334155; border-radius: 0 12px 12px 0; padding: 1rem 1.1rem; overflow-y: auto; z-index: 10; display: flex; flex-direction: column; gap: .7rem; }
+  .detail-drawer[hidden] { display: none; }
+  .drawer-header { display: flex; align-items: flex-start; justify-content: space-between; gap: .5rem; }
+  .drawer-close { background: none; border: 1px solid #475569; border-radius: 6px; color: var(--muted); padding: .25rem .55rem; cursor: pointer; font: inherit; font-size: 1rem; line-height: 1; flex-shrink: 0; }
+  .drawer-close:hover, .drawer-close:focus-visible { border-color: var(--cyan); color: var(--text); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
+  .drawer-title { font-size: .95rem; font-weight: 700; color: var(--text); line-height: 1.3; }
+  .drawer-subtitle { font-size: .78rem; color: var(--muted); margin-top: .15rem; }
+  .drawer-section { border-top: 1px solid #334155; padding-top: .6rem; }
+  .drawer-section-title { font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin-bottom: .45rem; }
+  .drawer-row { display: flex; justify-content: space-between; gap: .5rem; font-size: .82rem; margin-bottom: .3rem; line-height: 1.4; }
+  .drawer-label { color: var(--muted); flex-shrink: 0; }
+  .drawer-value { color: var(--text); text-align: right; }
+  .drawer-value.healthy { color: var(--green); }
+  .drawer-value.warning { color: var(--amber); }
+  .drawer-value.critical { color: var(--red); }
+  .drawer-value.unknown, .drawer-value.static { color: var(--muted); }
+  .drawer-value.disabled { color: var(--amber); }
+  .drawer-assessment { font-size: .8rem; color: #cbd5e1; line-height: 1.5; background: rgba(51,65,85,.4); border-radius: 6px; padding: .5rem .65rem; margin-top: .2rem; }
+  .drawer-unavailable { font-size: .79rem; color: var(--muted); font-style: italic; line-height: 1.45; }
+  .drawer-citation { font-size: .73rem; color: var(--muted); border-top: 1px solid #334155; margin-top: auto; line-height: 1.4; padding-top: .55rem; }
+  @keyframes skeleton-pulse { 0%,100% { opacity: .55; } 50% { opacity: .22; } }
+  .skeleton { background: #334155; border-radius: 4px; animation: skeleton-pulse 1.4s ease-in-out infinite; height: .85em; margin-bottom: .3rem; display: block; }
+  .skeleton.short { width: 52%; }
+  .skeleton.long { width: 82%; }
+  @media (max-width: 799px) { .detail-drawer { position: static; width: 100%; height: auto; border-left: none; border-radius: 10px; border: 1px solid #334155; margin-top: .75rem; } }
+  @media (prefers-reduced-motion: reduce) { .skeleton { animation: none; opacity: .45; } }
 </style>
 </head>
  <body>
@@ -211,6 +238,17 @@
              Increase the browser window or use a larger display to view the topology safely.
            </div>
          </div>
+          <aside id="detail-drawer" class="detail-drawer" hidden aria-label="Selection detail panel">
+            <div class="drawer-header">
+              <div>
+                <div class="drawer-title" id="drawer-title"></div>
+                <div class="drawer-subtitle" id="drawer-subtitle"></div>
+              </div>
+              <button type="button" class="drawer-close" id="drawer-close" aria-label="Close detail panel">&#x2715;</button>
+            </div>
+            <div id="drawer-body"></div>
+            <div class="drawer-citation" id="drawer-citation"></div>
+          </aside>
        </div>
      </div>
    </section>
@@ -263,6 +301,7 @@ const DISPATCH_TYPES = ['Load Balance', 'Frequency Adj', 'Capacity Shift', 'Emer
   const STALE_AFTER_MS = 60000;
   const SEVERITY_RANK = { healthy: 0, warning: 1, critical: 2 };
    const mapState = { x: 0, y: 0, k: 1, rendered: false, dragging: false, dragX: 0, dragY: 0, dragMoved: false, healthById: {}, lastSuccessfulHealthPoll: null, healthPollInFlight: false, selectedNodeId: null, selectedEdgeKey: null, activeFilter: 'all' };
+ var _drawerLastFocus = null;
 
 function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
 
@@ -455,6 +494,7 @@ function addLogEntry() {
     mapState.rendered = false;
     const mapView = document.getElementById('map-view');
     if (mapView && !mapView.hidden) renderGridMap({ preserveViewport: true });
+    refreshDetailDrawerIfOpen();
   }
 
   function loadHealth() {
@@ -520,6 +560,168 @@ function addLogEntry() {
    var el = document.getElementById('map-selection-status');
    if (el) el.textContent = text;
  }
+
+ function escHtml(str) {
+   if (str === null || str === undefined) return '';
+   return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+ }
+ function fmtTime(ts) {
+   if (!ts) return 'unknown time';
+   return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+ }
+ function citationTimestamp() {
+   var ts = mapState.lastSuccessfulHealthPoll;
+   return ts ? fmtTime(ts) : 'session start';
+ }
+ function buildNodeBody(node) {
+   var status = getMapStatus(node);
+   var result = node.healthSource === 'live' ? (mapState.healthById[node.id] || null) : null;
+   var html = '';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Status</div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Reported status</span><span class="drawer-value ' + escHtml(status.className) + '">' + escHtml(status.text) + '</span></div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(node.metaphor) + '</span></div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Kind</span><span class="drawer-value">' + escHtml(node.kind) + '</span></div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Resource</span><span class="drawer-value">' + escHtml(node.resourceName) + '</span></div>';
+   if (node.replicas === 0) {
+     html += '<div class="drawer-row"><span class="drawer-label">Replicas</span><span class="drawer-value warning">0 \u2014 disabled</span></div>';
+   }
+   html += '</div>';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Health source</div>';
+   if (node.healthSource === 'live' && result) {
+     html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Cloud demo live endpoint</span></div>';
+     html += '<div class="drawer-row"><span class="drawer-label">HTTP status</span><span class="drawer-value">' + (result.httpStatus ? result.httpStatus : '\u2014') + '</span></div>';
+     html += '<div class="drawer-row"><span class="drawer-label">Checked at</span><span class="drawer-value">' + escHtml(fmtTime(result.checkedAt)) + '</span></div>';
+     if (result.reason === 'network') {
+       html += '<div class="drawer-assessment">This service currently reports as unreachable from the browser. This may indicate an application health issue or a network configuration in the demo environment. This does not represent real grid operations.</div>';
+     } else if (result.severity === 'critical') {
+       html += '<div class="drawer-assessment">This service currently reports a server error response. This may indicate an application health issue in the cloud demo. The visual impact on connected edges reflects this status.</div>';
+     } else if (result.severity === 'warning') {
+       html += '<div class="drawer-assessment">This service currently reports a non-success response. This may indicate a degraded condition in the cloud demo. The visual impact on connected edges reflects this status.</div>';
+     }
+   } else if (node.healthSource === 'live' && !result) {
+     html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Cloud demo live endpoint</span></div>';
+     html += '<span class="skeleton long"></span><span class="skeleton short"></span>';
+     html += '<div class="drawer-assessment">Checking approved health endpoint&#x2026; Skeleton shown while live data loads.</div>';
+   } else if (node.healthSource === 'static') {
+     html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Static in-cluster</span></div>';
+     html += '<div class="drawer-assessment">No browser-accessible health endpoint is available for this node under the cloud demo contract. Health is inferred from topology context only.</div>';
+   } else if (node.healthSource === 'optional') {
+     html += '<div class="drawer-row"><span class="drawer-label">Source</span><span class="drawer-value">Optional \u2014 absent</span></div>';
+     html += '<div class="drawer-assessment">This optional service was not detected in the current cloud demo deployment. No health data is available.</div>';
+   }
+   if (node.stateNote) {
+     html += '<div class="drawer-row" style="margin-top:.3rem"><span class="drawer-label">Note</span><span class="drawer-value" style="text-align:left;color:var(--muted)">' + escHtml(node.stateNote) + '</span></div>';
+   }
+   html += '</div>';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Optional details</div>';
+   html += '<div class="drawer-unavailable">Pod-level metrics, recent events, and application logs are not available from the V1 cloud demo health contract. This panel shows only the health snapshot from the approved cloud demo data source.</div>';
+   html += '</div>';
+   return html;
+ }
+ function buildEdgeBody(edge, src, tgt) {
+   var srcStatus = getMapStatus(src);
+   var tgtStatus = getMapStatus(tgt);
+   var edgeStatus = getEdgeStatus(edge, src, tgt);
+   var html = '';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Connection</div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Flow type</span><span class="drawer-value">' + escHtml(edge.type || 'sync') + '</span></div>';
+   if (edge.disabled) html += '<div class="drawer-row"><span class="drawer-label">State</span><span class="drawer-value warning">Disabled path</span></div>';
+   if (edge.optional) html += '<div class="drawer-row"><span class="drawer-label">Optional</span><span class="drawer-value">Yes \u2014 may be absent</span></div>';
+   html += '</div>';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Source endpoint</div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(src.label) + '</span></div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(src.metaphor) + '</span></div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(srcStatus.className) + '">' + escHtml(srcStatus.text) + '</span></div>';
+   html += '</div>';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Target endpoint</div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Service</span><span class="drawer-value">' + escHtml(tgt.label) + '</span></div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Role</span><span class="drawer-value">' + escHtml(tgt.metaphor) + '</span></div>';
+   html += '<div class="drawer-row"><span class="drawer-label">Status</span><span class="drawer-value ' + escHtml(tgtStatus.className) + '">' + escHtml(tgtStatus.text) + '</span></div>';
+   html += '</div>';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Connection assessment</div>';
+   var assess = '';
+   if (edge.disabled) {
+     assess = 'This connection path is disabled in the current deployment. No active data flow is expected on this path.';
+   } else if (edgeStatus.className === 'healthy') {
+     assess = 'Both endpoints currently report healthy status. This connection path currently reports no visual impact.';
+   } else if (edgeStatus.className === 'critical') {
+     assess = 'One or more endpoints on this connection currently report a critical health status. The visual impact on this edge reflects the endpoint state. This may indicate an application health issue in the cloud demo environment.';
+   } else if (edgeStatus.className === 'warning') {
+     assess = 'One or more endpoints on this connection currently report a warning health status. The visual impact on this edge reflects the endpoint state. This may indicate a degraded condition in the cloud demo environment.';
+   } else {
+     assess = 'One or more endpoints are in an unknown or static state. Visual impact cannot be fully determined from the current cloud demo health data.';
+   }
+   html += '<div class="drawer-assessment">' + escHtml(assess) + '</div>';
+   html += '</div>';
+   html += '<div class="drawer-section">';
+   html += '<div class="drawer-section-title">Optional details</div>';
+   html += '<div class="drawer-unavailable">Endpoint-level telemetry, request rates, and error counts are not available from the V1 cloud demo health contract. This panel shows only connection state inferred from the approved cloud demo health snapshot.</div>';
+   html += '</div>';
+   return html;
+ }
+ function openDetailDrawer(titleText, subtitleText, bodyHtml, citationText) {
+   var drawer = document.getElementById('detail-drawer');
+   var titleEl = document.getElementById('drawer-title');
+   var subtitleEl = document.getElementById('drawer-subtitle');
+   var bodyEl = document.getElementById('drawer-body');
+   var citEl = document.getElementById('drawer-citation');
+   if (!drawer) return;
+   if (titleEl) titleEl.textContent = titleText;
+   if (subtitleEl) subtitleEl.textContent = subtitleText || '';
+   if (bodyEl) bodyEl.innerHTML = bodyHtml;
+   if (citEl) citEl.textContent = citationText;
+   _drawerLastFocus = document.activeElement;
+   drawer.hidden = false;
+   var closeBtn = document.getElementById('drawer-close');
+   if (closeBtn) closeBtn.focus();
+ }
+ function closeDetailDrawer() {
+   var drawer = document.getElementById('detail-drawer');
+   if (!drawer) return;
+   drawer.hidden = true;
+   if (_drawerLastFocus && typeof _drawerLastFocus.focus === 'function') {
+     try { _drawerLastFocus.focus(); } catch (e) {}
+   }
+ }
+ function refreshDetailDrawerIfOpen() {
+   var drawer = document.getElementById('detail-drawer');
+   if (!drawer || drawer.hidden) return;
+   if (mapState.selectedNodeId) {
+     var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === mapState.selectedNodeId; });
+     if (node) {
+       var bodyEl = document.getElementById('drawer-body');
+       var citEl = document.getElementById('drawer-citation');
+       if (bodyEl) bodyEl.innerHTML = buildNodeBody(node);
+       if (citEl) citEl.textContent = 'Data from cloud demo snapshot at ' + citationTimestamp();
+     }
+   } else if (mapState.selectedEdgeKey) {
+     var parts = mapState.selectedEdgeKey.split(':');
+     var edge = GRID_TOPOLOGY.edges.find(function(e) { return e.source === parts[0] && e.target === parts[1]; });
+     if (edge) {
+       var nodesById2 = {};
+       GRID_TOPOLOGY.nodes.forEach(function(n) { nodesById2[n.id] = n; });
+       var src = nodesById2[edge.source];
+       var tgt = nodesById2[edge.target];
+       if (src && tgt) {
+         var bodyEl2 = document.getElementById('drawer-body');
+         var citEl2 = document.getElementById('drawer-citation');
+         if (bodyEl2) bodyEl2.innerHTML = buildEdgeBody(edge, src, tgt);
+         if (citEl2) citEl2.textContent = 'Data from cloud demo snapshot at ' + citationTimestamp();
+       }
+     }
+   }
+ }
+ function initDetailDrawer() {
+   var closeBtn = document.getElementById('drawer-close');
+   if (closeBtn) closeBtn.addEventListener('click', clearSelection);
+ }
  function selectNode(nodeId) {
    mapState.selectedNodeId = nodeId;
    mapState.selectedEdgeKey = null;
@@ -527,6 +729,9 @@ function addLogEntry() {
    applyEdgeSelection();
    var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === nodeId; });
    updateSelectionStatus(node ? node.label + ' selected' : '');
+   if (node) {
+     openDetailDrawer(node.label, node.metaphor + ' · ' + node.kind, buildNodeBody(node), 'Data from cloud demo snapshot at ' + citationTimestamp());
+   }
  }
  function selectEdge(key) {
    mapState.selectedEdgeKey = key;
@@ -536,6 +741,15 @@ function addLogEntry() {
    var parts = key ? key.split(':') : [];
    var edge = GRID_TOPOLOGY.edges.find(function(e) { return e.source === parts[0] && e.target === parts[1]; });
    updateSelectionStatus(edge ? edge.label + ' connection selected' : '');
+   if (edge) {
+     var nodesById = {};
+     GRID_TOPOLOGY.nodes.forEach(function(n) { nodesById[n.id] = n; });
+     var src = nodesById[edge.source];
+     var tgt = nodesById[edge.target];
+     if (src && tgt) {
+       openDetailDrawer(edge.label, src.label + ' → ' + tgt.label, buildEdgeBody(edge, src, tgt), 'Data from cloud demo snapshot at ' + citationTimestamp());
+     }
+   }
  }
  function clearSelection() {
    mapState.selectedNodeId = null;
@@ -543,6 +757,7 @@ function addLogEntry() {
    applyNodeSelection();
    applyEdgeSelection();
    updateSelectionStatus('Selection cleared.');
+   closeDetailDrawer();
  }
  function applyNodeSelection() {
    document.querySelectorAll('.map-node').forEach(function(group) {
@@ -908,7 +1123,7 @@ function addLogEntry() {
    setConsoleView(initialViewFromLocation(), false);
  }
 
- initViewToggle();
+ initViewToggle(); initDetailDrawer();
  updateClock(); updateMetrics(); loadDispatches(); loadAssets(); loadHealth();
 for (let i = 0; i < 10; i++) addLogEntry();
 setInterval(updateClock, 1000);


### PR DESCRIPTION
Fixes #18.

## Summary
- Adds a cloud-demo grid map detail drawer for selected nodes and edges.
- Shows health status, approved source endpoint, optional safe detail copy, edge connection details, and data citation.
- Preserves keyboard interaction with Escape close, focus restoration, semantic drawer headings, and health-poll-safe focus recovery.
- Keeps k8s/base/ops-console.html byte-identical to the embedded ops-console-html ConfigMap in k8s/base/application.yaml.

## Validation
- PyYAML parsed k8s/base/application.yaml: 23 docs.
- Confirmed source HTML and ConfigMap index.html are byte-identical.
- Extracted inline JavaScript and ran node --check.
- Verified no forbidden local Mission Control API references.
- Verified drawer aria-labelledby/h2/h3, Escape, hidden-to-visible focus capture, and live data-node-id focus restore assertions.
- Verified topology refs: 10 nodes, 13 edges, selector-safe node IDs.
- Ran git diff --check.

## Review gates
- Code review: approved.
- Accessibility review: approved after WCAG 1.3.1 heading/landmark and live-focus fixes.