### PR TITLE
Add cloud grid map handoff controls

### DIFF
--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -1474,7 +1474,7 @@ data:
        html += '<h3 class="drawer-section-title">Analyst handoff</h3>';
        html += '<div class="drawer-handoff-actions">';
        html += '<button type="button" class="drawer-handoff-btn" id="handoff-copy-btn" data-copy-text="' + safePrompt + '" aria-label="Copy prompt for Local Analyst">\u{1F4CB} Copy prompt</button>';
-       html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
+       html += '<a href="https://portal.azure.com/" id="handoff-portal-link" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
        html += '</div>';
        html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
        html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary id="handoff-prompt-summary">View prompt text</summary><pre id="handoff-prompt-pre" tabindex="0">' + safePrompt + '</pre></details>';
@@ -1520,6 +1520,8 @@ data:
        if (!drawer || drawer.hidden) return;
        var _bodyEl0 = document.getElementById('drawer-body');
        var _activeId = (_bodyEl0 && _bodyEl0.contains(document.activeElement) && document.activeElement.id) ? document.activeElement.id : null;
+       var _previewEl0 = document.getElementById('handoff-prompt-preview');
+       var _previewOpen = !!(_previewEl0 && _previewEl0.open);
        if (mapState.selectedNodeId) {
          var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === mapState.selectedNodeId; });
          if (node) {
@@ -1544,7 +1546,8 @@ data:
            }
          }
        }
-       if (_activeId) { var _toFocus = document.getElementById(_activeId); if (_toFocus && typeof _toFocus.focus === 'function') { try { _toFocus.focus(); } catch (e) {} } }
+       if (_previewOpen) { var _pe = document.getElementById('handoff-prompt-preview'); if (_pe) _pe.open = true; }
+       if (_activeId) { var _toFocus = document.getElementById(_activeId); if (_toFocus && typeof _toFocus.focus === 'function') _toFocus.focus(); }
      }
      function initDetailDrawer() {
        var closeBtn = document.getElementById('drawer-close');

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -885,6 +885,14 @@ data:
       .drawer-assessment { font-size: .8rem; color: #cbd5e1; line-height: 1.5; background: rgba(51,65,85,.4); border-radius: 6px; padding: .5rem .65rem; margin-top: .2rem; }
       .drawer-unavailable { font-size: .79rem; color: var(--muted); font-style: italic; line-height: 1.45; }
       .drawer-citation { font-size: .73rem; color: var(--muted); border-top: 1px solid #334155; margin-top: auto; line-height: 1.4; padding-top: .55rem; }
+      /* === #20 Handoff controls === */
+      .drawer-handoff { border-top: 1px solid #334155; padding-top: .6rem; }
+      .drawer-handoff-actions { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: .4rem; }
+      .drawer-handoff-btn { background: rgba(15,23,42,.8); border: 1px solid #475569; border-radius: 8px; color: var(--text); padding: .4rem .75rem; cursor: pointer; font: inherit; font-size: .82rem; text-decoration: none; display: inline-block; }
+      .drawer-handoff-btn:hover, .drawer-handoff-btn:focus-visible { border-color: var(--cyan); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
+      .drawer-handoff-btn.portal { border-color: rgba(167,139,250,.5); color: var(--accent); }
+      .drawer-handoff-btn.portal:hover, .drawer-handoff-btn.portal:focus-visible { border-color: var(--accent); }
+      .drawer-copy-status { font-size: .78rem; min-height: 1.3em; color: var(--green); line-height: 1.4; }
       @keyframes skeleton-pulse { 0%,100% { opacity: .55; } 50% { opacity: .22; } }
       .skeleton { background: #334155; border-radius: 4px; animation: skeleton-pulse 1.4s ease-in-out infinite; height: .85em; margin-bottom: .3rem; display: block; }
       .skeleton.short { width: 52%; }
@@ -1396,6 +1404,7 @@ data:
        html += '<h3 class="drawer-section-title">Optional details</h3>';
        html += '<div class="drawer-unavailable">Pod-level metrics, recent events, and application logs are not available from the V1 cloud demo health contract. This panel shows only the health snapshot from the approved cloud demo data source.</div>';
        html += '</div>';
+       html += buildHandoffSection(buildNodePrompt(node));
        return html;
      }
      function buildEdgeBody(edge, src, tgt) {
@@ -1440,6 +1449,31 @@ data:
        html += '<div class="drawer-section">';
        html += '<h3 class="drawer-section-title">Optional details</h3>';
        html += '<div class="drawer-unavailable">Endpoint-level telemetry, request rates, and error counts are not available from the V1 cloud demo health contract. This panel shows only connection state inferred from the approved cloud demo health snapshot.</div>';
+       html += '</div>';
+       html += buildHandoffSection(buildEdgePrompt(edge, src, tgt));
+       return html;
+     }
+     function buildNodePrompt(node) {
+       var status = getMapStatus(node);
+       var ts = citationTimestamp();
+       return 'Explain the current reported state of "' + node.label + '" (' + node.metaphor + ') based on the cloud demo snapshot from ' + ts + '. Reported status: ' + status.text + '. Use only the cloud demo health and status information shown here; do not assume real grid telemetry, SCADA data, direct Azure SRE Agent invocation, or autonomous remediation certainty.';
+     }
+     function buildEdgePrompt(edge, src, tgt) {
+       var srcStatus = getMapStatus(src);
+       var tgtStatus = getMapStatus(tgt);
+       var ts = citationTimestamp();
+       return 'Explain the current reported connection state between "' + src.label + '" and "' + tgt.label + '" (' + (edge.label || 'connection') + ') based on the cloud demo snapshot from ' + ts + '. Source reported status: ' + srcStatus.text + '. Target reported status: ' + tgtStatus.text + '. Use only the cloud demo health and status information shown here; do not assume real grid telemetry, SCADA data, direct Azure SRE Agent invocation, or autonomous remediation certainty.';
+     }
+     function buildHandoffSection(promptText) {
+       var safePrompt = escHtml(promptText);
+       var html = '';
+       html += '<div class="drawer-handoff">';
+       html += '<h3 class="drawer-section-title">Analyst handoff</h3>';
+       html += '<div class="drawer-handoff-actions">';
+       html += '<button type="button" class="drawer-handoff-btn" id="handoff-copy-btn" data-copy-text="' + safePrompt + '" aria-label="Copy prompt for Local Analyst">\u{1F4CB} Copy prompt</button>';
+       html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
+       html += '</div>';
+       html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
        html += '</div>';
        return html;
      }
@@ -1510,6 +1544,23 @@ data:
        if (closeBtn) closeBtn.addEventListener('click', clearSelection);
        var drawer = document.getElementById('detail-drawer');
        if (drawer) drawer.addEventListener('keydown', function(e) { if (e.key === 'Escape') { e.preventDefault(); clearSelection(); } });
+       var bodyEl = document.getElementById('drawer-body');
+       if (bodyEl) bodyEl.addEventListener('click', function(e) {
+         var btn = e.target.closest ? e.target.closest('#handoff-copy-btn') : (e.target.id === 'handoff-copy-btn' ? e.target : null);
+         if (!btn) return;
+         var text = (btn.dataset && btn.dataset.copyText) ? btn.dataset.copyText : (btn.getAttribute ? btn.getAttribute('data-copy-text') : '');
+         if (!text) return;
+         var statusEl = document.getElementById('handoff-copy-status');
+         if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+           navigator.clipboard.writeText(text).then(function() {
+             if (statusEl) { statusEl.textContent = 'Prompt copied to clipboard.'; setTimeout(function() { if (statusEl) statusEl.textContent = ''; }, 3000); }
+           }, function() {
+             if (statusEl) statusEl.textContent = 'Copy failed \u2014 prompt shown below.';
+           });
+         } else {
+           if (statusEl) statusEl.textContent = 'Clipboard unavailable \u2014 see prompt below.';
+         }
+       });
      }
      function selectNode(nodeId) {
        mapState.selectedNodeId = nodeId;
@@ -1961,6 +2012,7 @@ data:
     </script>
     </body>
     </html>
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -893,6 +893,9 @@ data:
       .drawer-handoff-btn.portal { border-color: rgba(167,139,250,.5); color: var(--accent); }
       .drawer-handoff-btn.portal:hover, .drawer-handoff-btn.portal:focus-visible { border-color: var(--accent); }
       .drawer-copy-status { font-size: .78rem; min-height: 1.3em; color: var(--green); line-height: 1.4; }
+      .drawer-prompt-preview { margin-top: .4rem; }
+      .drawer-prompt-preview summary { cursor: pointer; color: var(--muted); font-size: .78rem; }
+      .drawer-prompt-preview pre { margin: .3rem 0 0; padding: .45rem .6rem; background: rgba(15,23,42,.85); border: 1px solid #334155; border-radius: 6px; color: #cbd5e1; font-size: .75rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 9rem; overflow-y: auto; }
       @keyframes skeleton-pulse { 0%,100% { opacity: .55; } 50% { opacity: .22; } }
       .skeleton { background: #334155; border-radius: 4px; animation: skeleton-pulse 1.4s ease-in-out infinite; height: .85em; margin-bottom: .3rem; display: block; }
       .skeleton.short { width: 52%; }
@@ -1474,6 +1477,7 @@ data:
        html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
        html += '</div>';
        html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
+       html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary>View prompt text</summary><pre tabindex="0">' + safePrompt + '</pre></details>';
        html += '</div>';
        return html;
      }
@@ -1556,9 +1560,13 @@ data:
              if (statusEl) { statusEl.textContent = 'Prompt copied to clipboard.'; setTimeout(function() { if (statusEl) statusEl.textContent = ''; }, 3000); }
            }, function() {
              if (statusEl) statusEl.textContent = 'Copy failed \u2014 prompt shown below.';
+             var previewEl = document.getElementById('handoff-prompt-preview');
+             if (previewEl) previewEl.open = true;
            });
          } else {
            if (statusEl) statusEl.textContent = 'Clipboard unavailable \u2014 see prompt below.';
+           var previewEl = document.getElementById('handoff-prompt-preview');
+           if (previewEl) previewEl.open = true;
          }
        });
      }

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -1477,7 +1477,7 @@ data:
        html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
        html += '</div>';
        html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
-       html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary>View prompt text</summary><pre tabindex="0">' + safePrompt + '</pre></details>';
+       html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary id="handoff-prompt-summary">View prompt text</summary><pre id="handoff-prompt-pre" tabindex="0">' + safePrompt + '</pre></details>';
        html += '</div>';
        return html;
      }
@@ -1518,6 +1518,8 @@ data:
      function refreshDetailDrawerIfOpen() {
        var drawer = document.getElementById('detail-drawer');
        if (!drawer || drawer.hidden) return;
+       var _bodyEl0 = document.getElementById('drawer-body');
+       var _activeId = (_bodyEl0 && _bodyEl0.contains(document.activeElement) && document.activeElement.id) ? document.activeElement.id : null;
        if (mapState.selectedNodeId) {
          var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === mapState.selectedNodeId; });
          if (node) {
@@ -1542,6 +1544,7 @@ data:
            }
          }
        }
+       if (_activeId) { var _toFocus = document.getElementById(_activeId); if (_toFocus && typeof _toFocus.focus === 'function') { try { _toFocus.focus(); } catch (e) {} } }
      }
      function initDetailDrawer() {
        var closeBtn = document.getElementById('drawer-close');

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -135,6 +135,14 @@
   .drawer-assessment { font-size: .8rem; color: #cbd5e1; line-height: 1.5; background: rgba(51,65,85,.4); border-radius: 6px; padding: .5rem .65rem; margin-top: .2rem; }
   .drawer-unavailable { font-size: .79rem; color: var(--muted); font-style: italic; line-height: 1.45; }
   .drawer-citation { font-size: .73rem; color: var(--muted); border-top: 1px solid #334155; margin-top: auto; line-height: 1.4; padding-top: .55rem; }
+  /* === #20 Handoff controls === */
+  .drawer-handoff { border-top: 1px solid #334155; padding-top: .6rem; }
+  .drawer-handoff-actions { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: .4rem; }
+  .drawer-handoff-btn { background: rgba(15,23,42,.8); border: 1px solid #475569; border-radius: 8px; color: var(--text); padding: .4rem .75rem; cursor: pointer; font: inherit; font-size: .82rem; text-decoration: none; display: inline-block; }
+  .drawer-handoff-btn:hover, .drawer-handoff-btn:focus-visible { border-color: var(--cyan); outline: 2px solid rgba(34,211,238,.75); outline-offset: 2px; }
+  .drawer-handoff-btn.portal { border-color: rgba(167,139,250,.5); color: var(--accent); }
+  .drawer-handoff-btn.portal:hover, .drawer-handoff-btn.portal:focus-visible { border-color: var(--accent); }
+  .drawer-copy-status { font-size: .78rem; min-height: 1.3em; color: var(--green); line-height: 1.4; }
   @keyframes skeleton-pulse { 0%,100% { opacity: .55; } 50% { opacity: .22; } }
   .skeleton { background: #334155; border-radius: 4px; animation: skeleton-pulse 1.4s ease-in-out infinite; height: .85em; margin-bottom: .3rem; display: block; }
   .skeleton.short { width: 52%; }
@@ -646,6 +654,7 @@ function addLogEntry() {
    html += '<h3 class="drawer-section-title">Optional details</h3>';
    html += '<div class="drawer-unavailable">Pod-level metrics, recent events, and application logs are not available from the V1 cloud demo health contract. This panel shows only the health snapshot from the approved cloud demo data source.</div>';
    html += '</div>';
+   html += buildHandoffSection(buildNodePrompt(node));
    return html;
  }
  function buildEdgeBody(edge, src, tgt) {
@@ -690,6 +699,31 @@ function addLogEntry() {
    html += '<div class="drawer-section">';
    html += '<h3 class="drawer-section-title">Optional details</h3>';
    html += '<div class="drawer-unavailable">Endpoint-level telemetry, request rates, and error counts are not available from the V1 cloud demo health contract. This panel shows only connection state inferred from the approved cloud demo health snapshot.</div>';
+   html += '</div>';
+   html += buildHandoffSection(buildEdgePrompt(edge, src, tgt));
+   return html;
+ }
+ function buildNodePrompt(node) {
+   var status = getMapStatus(node);
+   var ts = citationTimestamp();
+   return 'Explain the current reported state of "' + node.label + '" (' + node.metaphor + ') based on the cloud demo snapshot from ' + ts + '. Reported status: ' + status.text + '. Use only the cloud demo health and status information shown here; do not assume real grid telemetry, SCADA data, direct Azure SRE Agent invocation, or autonomous remediation certainty.';
+ }
+ function buildEdgePrompt(edge, src, tgt) {
+   var srcStatus = getMapStatus(src);
+   var tgtStatus = getMapStatus(tgt);
+   var ts = citationTimestamp();
+   return 'Explain the current reported connection state between "' + src.label + '" and "' + tgt.label + '" (' + (edge.label || 'connection') + ') based on the cloud demo snapshot from ' + ts + '. Source reported status: ' + srcStatus.text + '. Target reported status: ' + tgtStatus.text + '. Use only the cloud demo health and status information shown here; do not assume real grid telemetry, SCADA data, direct Azure SRE Agent invocation, or autonomous remediation certainty.';
+ }
+ function buildHandoffSection(promptText) {
+   var safePrompt = escHtml(promptText);
+   var html = '';
+   html += '<div class="drawer-handoff">';
+   html += '<h3 class="drawer-section-title">Analyst handoff</h3>';
+   html += '<div class="drawer-handoff-actions">';
+   html += '<button type="button" class="drawer-handoff-btn" id="handoff-copy-btn" data-copy-text="' + safePrompt + '" aria-label="Copy prompt for Local Analyst">\u{1F4CB} Copy prompt</button>';
+   html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
+   html += '</div>';
+   html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
    html += '</div>';
    return html;
  }
@@ -760,6 +794,23 @@ function addLogEntry() {
    if (closeBtn) closeBtn.addEventListener('click', clearSelection);
    var drawer = document.getElementById('detail-drawer');
    if (drawer) drawer.addEventListener('keydown', function(e) { if (e.key === 'Escape') { e.preventDefault(); clearSelection(); } });
+   var bodyEl = document.getElementById('drawer-body');
+   if (bodyEl) bodyEl.addEventListener('click', function(e) {
+     var btn = e.target.closest ? e.target.closest('#handoff-copy-btn') : (e.target.id === 'handoff-copy-btn' ? e.target : null);
+     if (!btn) return;
+     var text = (btn.dataset && btn.dataset.copyText) ? btn.dataset.copyText : (btn.getAttribute ? btn.getAttribute('data-copy-text') : '');
+     if (!text) return;
+     var statusEl = document.getElementById('handoff-copy-status');
+     if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+       navigator.clipboard.writeText(text).then(function() {
+         if (statusEl) { statusEl.textContent = 'Prompt copied to clipboard.'; setTimeout(function() { if (statusEl) statusEl.textContent = ''; }, 3000); }
+       }, function() {
+         if (statusEl) statusEl.textContent = 'Copy failed \u2014 prompt shown below.';
+       });
+     } else {
+       if (statusEl) statusEl.textContent = 'Clipboard unavailable \u2014 see prompt below.';
+     }
+   });
  }
  function selectNode(nodeId) {
    mapState.selectedNodeId = nodeId;

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -724,7 +724,7 @@ function addLogEntry() {
    html += '<h3 class="drawer-section-title">Analyst handoff</h3>';
    html += '<div class="drawer-handoff-actions">';
    html += '<button type="button" class="drawer-handoff-btn" id="handoff-copy-btn" data-copy-text="' + safePrompt + '" aria-label="Copy prompt for Local Analyst">\u{1F4CB} Copy prompt</button>';
-   html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
+   html += '<a href="https://portal.azure.com/" id="handoff-portal-link" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
    html += '</div>';
    html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
    html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary id="handoff-prompt-summary">View prompt text</summary><pre id="handoff-prompt-pre" tabindex="0">' + safePrompt + '</pre></details>';
@@ -770,6 +770,8 @@ function addLogEntry() {
    if (!drawer || drawer.hidden) return;
    var _bodyEl0 = document.getElementById('drawer-body');
    var _activeId = (_bodyEl0 && _bodyEl0.contains(document.activeElement) && document.activeElement.id) ? document.activeElement.id : null;
+   var _previewEl0 = document.getElementById('handoff-prompt-preview');
+   var _previewOpen = !!(_previewEl0 && _previewEl0.open);
    if (mapState.selectedNodeId) {
      var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === mapState.selectedNodeId; });
      if (node) {
@@ -794,7 +796,8 @@ function addLogEntry() {
        }
      }
    }
-   if (_activeId) { var _toFocus = document.getElementById(_activeId); if (_toFocus && typeof _toFocus.focus === 'function') { try { _toFocus.focus(); } catch (e) {} } }
+   if (_previewOpen) { var _pe = document.getElementById('handoff-prompt-preview'); if (_pe) _pe.open = true; }
+   if (_activeId) { var _toFocus = document.getElementById(_activeId); if (_toFocus && typeof _toFocus.focus === 'function') _toFocus.focus(); }
  }
  function initDetailDrawer() {
    var closeBtn = document.getElementById('drawer-close');

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -727,7 +727,7 @@ function addLogEntry() {
    html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
    html += '</div>';
    html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
-   html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary>View prompt text</summary><pre tabindex="0">' + safePrompt + '</pre></details>';
+   html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary id="handoff-prompt-summary">View prompt text</summary><pre id="handoff-prompt-pre" tabindex="0">' + safePrompt + '</pre></details>';
    html += '</div>';
    return html;
  }
@@ -768,6 +768,8 @@ function addLogEntry() {
  function refreshDetailDrawerIfOpen() {
    var drawer = document.getElementById('detail-drawer');
    if (!drawer || drawer.hidden) return;
+   var _bodyEl0 = document.getElementById('drawer-body');
+   var _activeId = (_bodyEl0 && _bodyEl0.contains(document.activeElement) && document.activeElement.id) ? document.activeElement.id : null;
    if (mapState.selectedNodeId) {
      var node = GRID_TOPOLOGY.nodes.find(function(n) { return n.id === mapState.selectedNodeId; });
      if (node) {
@@ -792,6 +794,7 @@ function addLogEntry() {
        }
      }
    }
+   if (_activeId) { var _toFocus = document.getElementById(_activeId); if (_toFocus && typeof _toFocus.focus === 'function') { try { _toFocus.focus(); } catch (e) {} } }
  }
  function initDetailDrawer() {
    var closeBtn = document.getElementById('drawer-close');

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -143,6 +143,9 @@
   .drawer-handoff-btn.portal { border-color: rgba(167,139,250,.5); color: var(--accent); }
   .drawer-handoff-btn.portal:hover, .drawer-handoff-btn.portal:focus-visible { border-color: var(--accent); }
   .drawer-copy-status { font-size: .78rem; min-height: 1.3em; color: var(--green); line-height: 1.4; }
+  .drawer-prompt-preview { margin-top: .4rem; }
+  .drawer-prompt-preview summary { cursor: pointer; color: var(--muted); font-size: .78rem; }
+  .drawer-prompt-preview pre { margin: .3rem 0 0; padding: .45rem .6rem; background: rgba(15,23,42,.85); border: 1px solid #334155; border-radius: 6px; color: #cbd5e1; font-size: .75rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 9rem; overflow-y: auto; }
   @keyframes skeleton-pulse { 0%,100% { opacity: .55; } 50% { opacity: .22; } }
   .skeleton { background: #334155; border-radius: 4px; animation: skeleton-pulse 1.4s ease-in-out infinite; height: .85em; margin-bottom: .3rem; display: block; }
   .skeleton.short { width: 52%; }
@@ -724,6 +727,7 @@ function addLogEntry() {
    html += '<a href="https://portal.azure.com/" target="_blank" rel="noopener noreferrer" class="drawer-handoff-btn portal" aria-label="Open Azure Portal in new tab">\u{1F517} Azure Portal</a>';
    html += '</div>';
    html += '<p class="drawer-copy-status" id="handoff-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>';
+   html += '<details class="drawer-prompt-preview" id="handoff-prompt-preview"><summary>View prompt text</summary><pre tabindex="0">' + safePrompt + '</pre></details>';
    html += '</div>';
    return html;
  }
@@ -806,9 +810,13 @@ function addLogEntry() {
          if (statusEl) { statusEl.textContent = 'Prompt copied to clipboard.'; setTimeout(function() { if (statusEl) statusEl.textContent = ''; }, 3000); }
        }, function() {
          if (statusEl) statusEl.textContent = 'Copy failed \u2014 prompt shown below.';
+         var previewEl = document.getElementById('handoff-prompt-preview');
+         if (previewEl) previewEl.open = true;
        });
      } else {
        if (statusEl) statusEl.textContent = 'Clipboard unavailable \u2014 see prompt below.';
+       var previewEl = document.getElementById('handoff-prompt-preview');
+       if (previewEl) previewEl.open = true;
      }
    });
  }


### PR DESCRIPTION
## Summary
- add safe Analyst handoff prompts to grid-map node and edge drawers
- add root Azure Portal handoff link without hardcoded resource IDs
- add accessible prompt preview fallback and preserve drawer-body focus during health refreshes

## Validation
- PyYAML parsed k8s/base/application.yaml (23 docs)
- ops-console ConfigMap index.html is byte-identical to k8s/base/ops-console.html
- inline script passes node --check
- custom #20 focus/safe-language/API checks passed
- scripts/validate-grid-map-contract.ps1: 42 PASS / 0 WARN / 0 FAIL
- accessibility and code reviews approved

Closes #20

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>