### PR TITLE
Security hardening for external demo readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ See [docs/COSTS.md](docs/COSTS.md) for detailed breakdown and optimization tips.
 **Deploy script parameters:**
 - `-Location`: Azure region (`eastus2`, `swedencentral`, `australiaeast`) - Default: `eastus2`
 - `-WorkloadName`: Resource prefix - Default: `srelab`
+- `-AksApiServerAuthorizedIpRanges`: Optional AKS API server CIDR allowlist (for external demos). Example: `-AksApiServerAuthorizedIpRanges @('203.0.113.10/32')`
 - `-SkipRbac`: Skip RBAC assignments if subscription policies block them
 - `-SkipSreAgent`: Skip Azure SRE Agent deployment (useful for regions/subscriptions without Preview access)
 - `-WhatIf`: Preview deployment without making changes

--- a/docs/AZURE-SRE-AGENT-CUSTOMER-DELTAS.md
+++ b/docs/AZURE-SRE-AGENT-CUSTOMER-DELTAS.md
@@ -196,7 +196,7 @@ actionConfiguration: {
 }
 ```
 
-With `accessLevel: 'High'`, the managed identity holds: Log Analytics Reader + Reader + **Contributor** (RG-scoped). Additional roles granted via RBAC script: AKS Cluster Admin, AKS RBAC Cluster Admin, AKS Contributor, Log Analytics Contributor, Key Vault Secrets Officer, AcrPush.
+With `accessLevel: 'High'`, the managed identity holds: Log Analytics Reader + Reader + **Contributor** (RG-scoped). Additional roles granted via RBAC script: AKS Cluster Admin, AKS RBAC Cluster Admin, AKS Contributor, Log Analytics Reader, Key Vault Secrets Officer, AcrPull.
 
 **Mission Control Backend** — Mixed read/write with confirmation gates:
 - Read: `GET /api/pods`, `GET /api/services`, `GET /api/events`, `GET /api/deployments` via structured `execFile()` (no `shell: true`)
@@ -448,11 +448,11 @@ graph TD
 | Identity | Roles Granted | Assessment |
 |----------|--------------|------------|
 | **SRE Agent MI (Bicep)** | Reader + Contributor + Log Analytics Reader (on RG) | Overprivileged for diagnosis-only; appropriate for remediation demo |
-| **SRE Agent MI (RBAC script)** | AKS Cluster Admin, AKS RBAC Cluster Admin, AKS Contributor, Log Analytics Contributor, Key Vault Secrets Officer, AcrPush | Deliberately broad — write permissions for "remediate" demo story |
+| **SRE Agent MI (RBAC script)** | AKS Cluster Admin, AKS RBAC Cluster Admin, AKS Contributor, Log Analytics Reader, Key Vault Secrets Officer, AcrPull | Deliberately broad for the demo; Log Analytics and ACR are now read/pull-only |
 | **AKS kubelet identity** | AcrPull (on RG) | ✅ Correct — read-only image pull |
 | **Grafana identity** | Monitoring Reader (on subscription) | ✅ Acceptable — read-only |
 | **Mission Control backend** | Inherits operator's `az` CLI session + `kubectl` context | Implicit — no dedicated service identity |
-| **AKS cluster** | Public API server (not private) | Required for SRE Agent Preview — expands attack surface |
+| **AKS cluster** | Public API server (not private) | Required for this lab's SRE Agent access model — expands attack surface |
 
 > **Critical customer note**: The current RBAC profile is demo-scoped. For a diagnosis-only deployment, `accessLevel: 'Low'` (Reader + Log Analytics Reader) eliminates all write permissions from the managed identity. This is not documented in the repo.
 >

--- a/docs/CAPABILITY-CONTRACTS.md
+++ b/docs/CAPABILITY-CONTRACTS.md
@@ -391,10 +391,10 @@ The current demo profile intentionally grants broad roles through `scripts/confi
 | AKS Cluster Admin | AKS | ⚠️ DEMO ONLY | ❌ Remove — use namespace-scoped RBAC | Over-privileged for diagnosis |
 | AKS RBAC Cluster Admin | AKS | ⚠️ DEMO ONLY | ❌ Remove — use namespace-scoped RBAC | Over-privileged |
 | AKS Contributor | AKS | ⚠️ DEMO ONLY | Azure Kubernetes Service Cluster User Role | Minimum for kubectl access |
-| Log Analytics Contributor | Resource Group | ⚠️ DEMO ONLY | Log Analytics Reader | Agent only queries logs |
+| Log Analytics Reader | Workspace | ✅ | ✅ Keep | Agent only queries logs |
 | Monitoring Reader | Resource Group | ✅ | ✅ Keep | Needed for metrics |
 | Key Vault Secrets Officer | Key Vault | ⚠️ DEMO ONLY | ❌ Remove or Key Vault Secrets User | Agent doesn't manage secrets |
-| AcrPush | ACR | ⚠️ DEMO ONLY | ❌ Remove or AcrPull | No scenario requires image push |
+| AcrPull | ACR | ✅ | ✅ Keep if image metadata/pull access is needed | No scenario requires image push |
 | Reader | Subscription | ⚠️ DEMO ONLY | Reader (Resource Group scope) | Limit enumeration surface |
 | Contributor | Resource Group | ⚠️ DEMO ONLY (`accessLevel: 'High'`) | ❌ Remove (`accessLevel: 'Low'`) | Use Low for read-only diagnosis |
 
@@ -444,7 +444,7 @@ Known TBD scope includes all fields emitted by the SRE Agent App Insights teleme
 
 | Shortcut | Location | Risk | Production Recommendation |
 |----------|----------|------|--------------------------|
-| ⚠️ DEMO ONLY — RabbitMQ `guest/guest` credentials | `k8s/base/application.yaml` lines 85-87, 286-288, 356-360 | Plaintext default credentials | Use Key Vault + Workload Identity for credentials |
+| ⚠️ DEMO ONLY — RabbitMQ static `guest/guest` credentials | `k8s/base/application.yaml` (`Secret/rabbitmq-credentials`) | Static credentials are stored in Git and not rotated | Use Key Vault + Workload Identity for credentials |
 | ⚠️ DEMO ONLY — MongoDB without authentication | `k8s/base/application.yaml` | Any pod can read/write all data | Enable `--auth`, create service accounts |
 | ⚠️ DEMO ONLY — No pod `securityContext` | All deployments in `application.yaml` | Containers run as root with full capabilities | Set `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, drop all capabilities |
 | ⚠️ DEMO ONLY — No default-deny NetworkPolicy | `energy` namespace | Any pod can reach any pod | Add default-deny policy, allow only required paths |

--- a/docs/SRE-AGENT-SETUP.md
+++ b/docs/SRE-AGENT-SETUP.md
@@ -86,15 +86,15 @@ The script assigns these roles to enable both **diagnosis AND remediation**:
 | **AKS Cluster** | AKS Cluster Admin Role | kubectl access to cluster |
 | **AKS Cluster** | AKS RBAC Cluster Admin | Full Kubernetes RBAC permissions |
 | **AKS Cluster** | AKS Contributor Role | Scale nodes, update cluster config |
-| **Log Analytics** | Log Analytics Contributor | Query and analyze logs |
+| **Log Analytics** | Log Analytics Reader | Query and analyze logs |
 | **Key Vault** | Key Vault Secrets Officer | Manage secrets |
-| **Container Registry** | AcrPush | Push/pull container images |
+| **Container Registry** | AcrPull | Pull container images |
 
-> **Note**: These are **write permissions** that allow SRE Agent to take actions like:
+> **Note**: This profile still includes broad **write permissions** through Contributor, AKS admin/contributor roles, and Key Vault Secrets Officer. Log Analytics and ACR are read/pull-only.
 > - Restart pods, scale deployments, delete stuck resources
 > - Query and analyze logs
 > - Access/update Key Vault secrets
-> - Push/pull container images
+> - Pull container images
 
 ### SRE Agent User Roles
 

--- a/docs/evidence/wave3-live/SECURITY-STATUS.md
+++ b/docs/evidence/wave3-live/SECURITY-STATUS.md
@@ -57,7 +57,7 @@ Avoid as production defaults:
 - AKS Cluster Admin
 - AKS RBAC Cluster Admin
 - Key Vault Secrets Officer
-- ACR admin credentials or `AcrPush`
+- ACR admin credentials or image push permissions
 - Subscription-wide Reader unless the operational scope truly spans the subscription
 
 Kubernetes posture:
@@ -74,7 +74,7 @@ Demo-only permissions observed in repo/scripts:
 - Resource-group `Contributor`
 - AKS Cluster Admin / AKS RBAC Cluster Admin via `scripts/configure-rbac.ps1`
 - Key Vault Secrets Officer via `scripts/configure-rbac.ps1`
-- `AcrPush` via `scripts/configure-rbac.ps1`
+- `AcrPull` via `scripts/configure-rbac.ps1`
 - Subscription-wide Reader via `scripts/configure-rbac.ps1`
 
 Required safe-language qualifier:

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -97,6 +97,12 @@ param systemMaxPods int = 50
 @maxValue(110)
 param userMaxPods int = 50
 
+@description('Optional CIDR ranges allowed to reach the AKS API server public endpoint for external demos. Leave empty to preserve current public-access behavior.')
+param aksApiServerAuthorizedIpRanges array = []
+
+@description('Enable ACR admin user account (not required for default deploy path)')
+param acrAdminUserEnabled bool = false
+
 @description('Tags to apply to all resources')
 param tags object = {
   workload: 'energy-grid-demo'
@@ -196,6 +202,7 @@ module containerRegistry 'modules/container-registry.bicep' = {
     location: location
     tags: tags
     sku: 'Basic'
+    adminUserEnabled: acrAdminUserEnabled
   }
 }
 
@@ -214,6 +221,7 @@ module aks 'modules/aks.bicep' = {
     userNodeCount: userNodeCount
     systemMaxPods: systemMaxPods
     userMaxPods: userMaxPods
+    aksApiServerAuthorizedIpRanges: aksApiServerAuthorizedIpRanges
     vnetSubnetId: network.outputs.aksSubnetId
     logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
     acrId: containerRegistry.outputs.acrId

--- a/infra/bicep/main.bicepparam
+++ b/infra/bicep/main.bicepparam
@@ -31,6 +31,18 @@ param userNodeCount = 3
 param systemMaxPods = 50
 param userMaxPods = 50
 
+// Optional AKS API server CIDR allowlist for external demos.
+// Leave empty to preserve current behavior (public endpoint without IP filtering).
+// Example:
+// param aksApiServerAuthorizedIpRanges = [
+//   '203.0.113.10/32'
+//   '198.51.100.0/24'
+// ]
+param aksApiServerAuthorizedIpRanges = []
+
+// ACR admin account is disabled by default; use role-based auth for pull/push.
+param acrAdminUserEnabled = false
+
 // Tags
 param tags = {
   workload: 'energy-grid-demo'

--- a/infra/bicep/modules/aks.bicep
+++ b/infra/bicep/modules/aks.bicep
@@ -48,6 +48,18 @@ param logAnalyticsWorkspaceId string
 @description('Azure Container Registry ID for image pull permissions')
 param acrId string
 
+@description('Optional CIDR ranges allowed to reach the AKS API server public endpoint (for example, ["203.0.113.10/32"]). Leave empty for current demo behavior.')
+param aksApiServerAuthorizedIpRanges array = []
+
+var apiServerAccessProfile = length(aksApiServerAuthorizedIpRanges) > 0
+  ? {
+      enablePrivateCluster: false
+      authorizedIPRanges: aksApiServerAuthorizedIpRanges
+    }
+  : {
+      enablePrivateCluster: false
+    }
+
 // =============================================================================
 // RESOURCES
 // =============================================================================
@@ -88,9 +100,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2024-02-01' = {
     }
     
     // API server access - Enable public access for SRE Agent
-    apiServerAccessProfile: {
-      enablePrivateCluster: false // IMPORTANT: Must be false for SRE Agent
-    }
+    apiServerAccessProfile: apiServerAccessProfile
     
     // System node pool
     agentPoolProfiles: [

--- a/infra/bicep/modules/container-registry.bicep
+++ b/infra/bicep/modules/container-registry.bicep
@@ -22,7 +22,7 @@ param tags object
 param sku string = 'Basic'
 
 @description('Enable admin user for local development')
-param adminUserEnabled bool = true
+param adminUserEnabled bool = false
 
 // =============================================================================
 // RESOURCES

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -44,6 +44,21 @@ data:
   enabled_plugins: "[rabbitmq_management,rabbitmq_prometheus,rabbitmq_amqp1_0]."
 
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-credentials
+  namespace: energy
+  labels:
+    app: rabbitmq
+    sre-demo: breakable
+type: Opaque
+stringData:
+  rabbitmq-username: "guest"
+  rabbitmq-password: "guest"
+  rabbitmq-amqp-uri: "amqp://guest:guest@rabbitmq:5672/"
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -101,9 +116,15 @@ spec:
             - name: RABBITMQ_PLUGINS
               value: "rabbitmq_management rabbitmq_prometheus rabbitmq_amqp1_0"
             - name: RABBITMQ_DEFAULT_USER
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-username
             - name: RABBITMQ_DEFAULT_PASS
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-password
       volumes:
         - name: rabbitmq-enabled-plugins
           configMap:
@@ -309,9 +330,15 @@ spec:
             - name: ORDER_QUEUE_PORT
               value: "5672"
             - name: ORDER_QUEUE_USERNAME
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-username
             - name: ORDER_QUEUE_PASSWORD
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-password
             - name: ORDER_QUEUE_NAME
               value: "meter-events"
             - name: FASTIFY_ADDRESS
@@ -379,11 +406,20 @@ spec:
               cpu: "100m"
           env:
             - name: ORDER_QUEUE_URI
-              value: "amqp://guest:guest@rabbitmq:5672/"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-amqp-uri
             - name: ORDER_QUEUE_USERNAME
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-username
             - name: ORDER_QUEUE_PASSWORD
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-password
             - name: ORDER_QUEUE_NAME
               value: "meter-events"
             - name: ORDER_DB_URI

--- a/k8s/scenarios/oom-killed.yaml
+++ b/k8s/scenarios/oom-killed.yaml
@@ -84,9 +84,15 @@ spec:
             - name: ORDER_QUEUE_PORT
               value: "5672"
             - name: ORDER_QUEUE_USERNAME
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-username
             - name: ORDER_QUEUE_PASSWORD
-              value: "guest"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-password
             - name: ORDER_QUEUE_NAME
               value: "meter-events"
             - name: FASTIFY_ADDRESS

--- a/scripts/configure-rbac.ps1
+++ b/scripts/configure-rbac.ps1
@@ -223,10 +223,10 @@ if ($SreAgentPrincipalId) {
     if ($logAnalytics) {
         Set-RoleAssignment `
             -Scope $logAnalytics.id `
-            -RoleDefinition "Log Analytics Contributor" `
+            -RoleDefinition "Log Analytics Reader" `
             -PrincipalId $SreAgentPrincipalId `
             -PrincipalType "ServicePrincipal" `
-            -Description "Log Analytics Contributor for SRE Agent (query and manage logs)"
+            -Description "Log Analytics Reader for SRE Agent (query logs)"
     }
 
     # Application Insights read access for telemetry correlation
@@ -266,10 +266,10 @@ if ($SreAgentPrincipalId) {
     if ($acr) {
         Set-RoleAssignment `
             -Scope $acr.id `
-            -RoleDefinition "AcrPush" `
+            -RoleDefinition "AcrPull" `
             -PrincipalId $SreAgentPrincipalId `
             -PrincipalType "ServicePrincipal" `
-            -Description "ACR Push for SRE Agent (push/pull images)"
+            -Description "ACR Pull for SRE Agent (pull images)"
     }
 }
 

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -15,6 +15,10 @@
 .PARAMETER WorkloadName
     Name prefix for resources. Default: srelab
 
+.PARAMETER AksApiServerAuthorizedIpRanges
+    Optional CIDR ranges allowed to reach the AKS API server public endpoint.
+    Example: -AksApiServerAuthorizedIpRanges @('203.0.113.10/32','198.51.100.0/24')
+
 .PARAMETER SkipRbac
     Skip RBAC role assignments (useful if subscription policies block them)
 
@@ -46,6 +50,9 @@ param(
     [string]$WorkloadName = 'srelab',
 
     [Parameter()]
+    [string[]]$AksApiServerAuthorizedIpRanges = @(),
+
+    [Parameter()]
     [switch]$SkipRbac,
 
     [Parameter()]
@@ -60,64 +67,11 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-function Invoke-AzCliJson {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$Command
-    )
-
-    # Run command and capture all output
-    $raw = Invoke-Expression $Command 2>&1 | Out-String
-    $exitCode = $LASTEXITCODE
-
-    if ($exitCode -ne 0) {
-        return [pscustomobject]@{
-            ExitCode = $exitCode
-            Raw      = $raw
-            Json     = $null
-        }
-    }
-
-    # Extract JSON from output (skip any warning lines before the JSON)
-    $jsonObjectStart = $raw.IndexOf('{')
-    $jsonArrayStart = $raw.IndexOf('[')
-
-    if ($jsonObjectStart -ge 0 -and $jsonArrayStart -ge 0) {
-        $jsonStart = [Math]::Min($jsonObjectStart, $jsonArrayStart)
-    }
-    elseif ($jsonObjectStart -ge 0) {
-        $jsonStart = $jsonObjectStart
-    }
-    elseif ($jsonArrayStart -ge 0) {
-        $jsonStart = $jsonArrayStart
-    }
-    else {
-        $jsonStart = -1
-    }
-
-    if ($jsonStart -ge 0) {
-        $jsonContent = $raw.Substring($jsonStart)
-    }
-    else {
-        $jsonContent = $raw
-    }
-
-    try {
-        $json = $jsonContent | ConvertFrom-Json
-    }
-    catch {
-        return [pscustomobject]@{
-            ExitCode = $exitCode
-            Raw      = $raw
-            Json     = $null
-        }
-    }
-
-    return [pscustomobject]@{
-        ExitCode = $exitCode
-        Raw      = $raw
-        Json     = $json
+if ($AksApiServerAuthorizedIpRanges.Count -gt 0) {
+    $cidrPattern = '^((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\/([0-9]|[12][0-9]|3[0-2])$'
+    $invalidCidrs = @($AksApiServerAuthorizedIpRanges | Where-Object { $_ -notmatch $cidrPattern })
+    if ($invalidCidrs.Count -gt 0) {
+        throw "Invalid CIDR value(s) for -AksApiServerAuthorizedIpRanges: $($invalidCidrs -join ', ')"
     }
 }
 
@@ -252,14 +206,35 @@ function Write-ResourceGroupDeploymentFailureSummary {
         [string]$Indent = '    '
     )
 
-    $operations = Invoke-AzCliJson -Command "az deployment operation group list --resource-group $ResourceGroupName --name $DeploymentName --output json"
+    $operations = Invoke-AzCliJsonArgs -Arguments @(
+        'deployment'
+        'operation'
+        'group'
+        'list'
+        '--resource-group'
+        $ResourceGroupName
+        '--name'
+        $DeploymentName
+        '--output'
+        'json'
+    )
     if ($operations.ExitCode -ne 0 -or -not $operations.Json) {
         return
     }
 
     $failedOperations = @($operations.Json | Where-Object { $_.properties.provisioningState -eq 'Failed' })
     if ($failedOperations.Count -eq 0) {
-        $deployment = Invoke-AzCliJson -Command "az deployment group show --resource-group $ResourceGroupName --name $DeploymentName --output json"
+        $deployment = Invoke-AzCliJsonArgs -Arguments @(
+            'deployment'
+            'group'
+            'show'
+            '--resource-group'
+            $ResourceGroupName
+            '--name'
+            $DeploymentName
+            '--output'
+            'json'
+        )
         if ($deployment.ExitCode -ne 0 -or -not $deployment.Json -or -not $deployment.Json.properties.error) {
             return
         }
@@ -300,7 +275,16 @@ function Write-SubscriptionDeploymentFailureSummary {
         [string]$ResourceGroupName
     )
 
-    $operations = Invoke-AzCliJson -Command "az deployment operation sub list --name $DeploymentName --output json"
+    $operations = Invoke-AzCliJsonArgs -Arguments @(
+        'deployment'
+        'operation'
+        'sub'
+        'list'
+        '--name'
+        $DeploymentName
+        '--output'
+        'json'
+    )
     if ($operations.ExitCode -ne 0 -or -not $operations.Json) {
         return
     }
@@ -335,7 +319,17 @@ function Get-DeletedKeyVaultConflict {
         [string]$ResourceGroupName
     )
 
-    $deployment = Invoke-AzCliJson -Command "az deployment group show --resource-group $ResourceGroupName --name deploy-keyvault --output json"
+    $deployment = Invoke-AzCliJsonArgs -Arguments @(
+        'deployment'
+        'group'
+        'show'
+        '--resource-group'
+        $ResourceGroupName
+        '--name'
+        'deploy-keyvault'
+        '--output'
+        'json'
+    )
     if ($deployment.ExitCode -ne 0 -or -not $deployment.Json -or -not $deployment.Json.properties.error) {
         return $null
     }
@@ -345,7 +339,18 @@ function Get-DeletedKeyVaultConflict {
         return $null
     }
 
-    $operations = Invoke-AzCliJson -Command "az deployment operation group list --resource-group $ResourceGroupName --name deploy-keyvault --output json"
+    $operations = Invoke-AzCliJsonArgs -Arguments @(
+        'deployment'
+        'operation'
+        'group'
+        'list'
+        '--resource-group'
+        $ResourceGroupName
+        '--name'
+        'deploy-keyvault'
+        '--output'
+        'json'
+    )
     if ($operations.ExitCode -ne 0 -or -not $operations.Json) {
         return $null
     }
@@ -627,6 +632,7 @@ Write-Host "  • Workload Name:   $WorkloadName" -ForegroundColor White
 Write-Host "  • Resource Group:  $resourceGroupName" -ForegroundColor White
 Write-Host "  • Deployment Name: $deploymentName" -ForegroundColor White
 Write-Host "  • SRE Agent:       $(if ($deploySreAgent) { 'Enabled' } else { 'Disabled' })" -ForegroundColor White
+Write-Host "  • AKS API CIDRs:   $(if ($AksApiServerAuthorizedIpRanges.Count -gt 0) { $AksApiServerAuthorizedIpRanges -join ', ' } else { '(none - unrestricted public API endpoint)' })" -ForegroundColor White
 if ($sreAgentSkipReason) {
     Write-Host "  • SRE Agent Note:  $sreAgentSkipReason" -ForegroundColor Gray
 }
@@ -657,6 +663,10 @@ if ($WhatIf) {
     }
     if ($userMaxPodsParam) {
         $whatIfParameterArgs += "userMaxPods=$userMaxPodsParam"
+    }
+    if ($AksApiServerAuthorizedIpRanges.Count -gt 0) {
+        $authorizedRangesJson = $AksApiServerAuthorizedIpRanges | ConvertTo-Json -Compress
+        $whatIfParameterArgs += "aksApiServerAuthorizedIpRanges=$authorizedRangesJson"
     }
 
     $whatIfOutput = az deployment sub what-if `
@@ -707,6 +717,10 @@ try {
     if ($userMaxPodsParam) {
         $deployParameterArgs += "userMaxPods=$userMaxPodsParam"
     }
+    if ($AksApiServerAuthorizedIpRanges.Count -gt 0) {
+        $authorizedRangesJson = $AksApiServerAuthorizedIpRanges | ConvertTo-Json -Compress
+        $deployParameterArgs += "aksApiServerAuthorizedIpRanges=$authorizedRangesJson"
+    }
 
     $createArgs = @(
         'deployment'
@@ -740,8 +754,15 @@ try {
         }
 
         # Best-effort: if a deployment record exists, pull structured error details.
-        $showCmd = "az deployment sub show --name $deploymentName --output json"
-        $show = Invoke-AzCliJson -Command $showCmd
+        $show = Invoke-AzCliJsonArgs -Arguments @(
+            'deployment'
+            'sub'
+            'show'
+            '--name'
+            $deploymentName
+            '--output'
+            'json'
+        )
         if ($show.ExitCode -eq 0 -and $show.Json) {
             $state = $show.Json.properties.provisioningState
             Write-Host "`nDeployment provisioningState: $state" -ForegroundColor Yellow


### PR DESCRIPTION
## Security hardening follow-up

Stacked on PR #50 per Dallas guidance so Wave 4 packaging remains scoped.

### Delivered
- Parameterized AKS API server `authorizedIPRanges` for external demo operators.
- Added `-AksApiServerAuthorizedIpRanges` deploy script parameter and documented usage.
- Moved RabbitMQ username/password/AMQP URI references to `Secret/rabbitmq-credentials`.
- Disabled ACR admin account by default via `acrAdminUserEnabled`.
- Narrowed selected SRE Agent RBAC script grants:
  - `Log Analytics Contributor` -> `Log Analytics Reader`
  - `AcrPush` -> `AcrPull`
- Replaced string-based Azure CLI invocation helper with argument-array invocation.
- Updated directly related security/RBAC docs and Scribe history.

### Deferred
- SRE Agent resource-group Contributor scope remains unchanged; decision deferred to #53.
- GA ARM API upgrade remains blocked/tracked in #51.
- John has not provided AKS API allowlist CIDRs yet; default preserves current public endpoint behavior until supplied.

### Validation
- `cd mission-control && npm run lint && npm run build && npm run test -w backend`
- `pwsh ./scripts/validate-scenario-metadata.ps1 -Strict`
- Python YAML parse for `k8s/**/*.yaml`
- `az bicep build` for `infra/bicep/main.bicep`, `modules/aks.bicep`, and `modules/container-registry.bicep`
- PowerShell parser check for `scripts/*.ps1`
- Grep checks for stale Preview language and old RBAC grants
- Scoped `git diff --check`

Related to #52
Related to #53
