### PR TITLE
security(#57) + evidence(#48): resolve H-3 access-level gate and complete-failure-bundle scaffold

### DIFF
--- a/docs/EXTERNAL-DEMO-HARDENING.md
+++ b/docs/EXTERNAL-DEMO-HARDENING.md
@@ -11,6 +11,7 @@ This guide covers the two Tier A findings and what a demo operator must verify o
 | Finding | Component | Status | Owner |
 |---------|-----------|--------|-------|
 | H-1: AKS API server has no `authorizedIPRanges` | `infra/bicep/modules/aks.bicep` | ⚠️ Ripley — awaiting CIDR input from operator | Ripley (Infra) |
+| H-3: SRE Agent Contributor at resource-group scope | `infra/bicep/main.bicep`, `scripts/configure-rbac.ps1` | ✅ `Low` is now the default (diagnosis-only). `High` must be set explicitly in `main.bicepparam` and `-SreAgentAccessLevel High` for internal remediation demos. | Ripley (Infra) |
 | H-4: RabbitMQ credentials in plaintext K8s manifests | `k8s/base/application.yaml` | ✅ All service env vars use `secretKeyRef`; demo-static values in Secret `stringData` are accepted per issue #52 | Parker (SRE Dev) |
 
 ---
@@ -45,6 +46,38 @@ Before any external/customer-facing demo:
 - [ ] **Confirm SRE Agent portal access still works** — the agent connects outbound from Azure, not through the API server IP allowlist. But verify that `*.azuresre.ai` firewall rule is in place if you're behind a corporate proxy.
 
 > ⚠️ **Until Ripley's change lands and CIDRs are provided, this lab is NOT suitable for external demos.** Document this explicitly in your demo pre-flight notes.
+
+---
+
+## H-3: SRE Agent Contributor at Resource-Group Scope
+
+### Risk
+
+The SRE Agent managed identity previously held Contributor at resource-group scope by default. This grants broad write access (create, delete, modify any resource) and is unacceptable for external or customer-facing demos.
+
+### Resolution (issue #57)
+
+`Low` is now the default access level across Bicep and scripts. Roles granted:
+
+| Scope | Role |
+|-------|------|
+| Resource Group | Reader |
+| Resource Group | Log Analytics Reader |
+| Key Vault | Key Vault Secrets User |
+| Container Registry | AcrPull |
+
+The `High` level (adds Contributor + AKS admin roles) must be explicitly requested:
+- In Bicep: `sreAgentAccessLevel = 'High'` in `infra/bicep/main.bicepparam` (set for internal lab runs only)
+- In scripts: `-SreAgentAccessLevel High` passed to `deploy.ps1` or `configure-rbac.ps1`
+
+### Operator pre-demo checklist (H-3)
+
+- [ ] Confirm the deployment used `Low` access level (default when using `deploy.ps1` without `-SreAgentAccessLevel High`)
+- [ ] Or verify that `main.bicepparam` was **not** used as-is for this external deploy (it sets `High` for internal lab)
+- [ ] Confirm the SRE Agent managed identity does **not** hold Contributor on the resource group:
+  ```bash
+  az role assignment list --assignee <sre-agent-principal-id> --output table
+  ```
 
 ---
 
@@ -107,6 +140,12 @@ Copy this checklist into your demo pre-flight notes before any customer-facing r
 - [ ] AKS API server is reachable from demo machine: kubectl get nodes
 - [ ] Azure SRE Agent portal access is confirmed: https://aka.ms/sreagent/portal
 - [ ] *.azuresre.ai firewall rule is in place if behind corporate proxy
+
+### H-3: SRE Agent Access Level
+- [ ] Deployment used Low access level (default; no -SreAgentAccessLevel High passed)
+- [ ] OR: main.bicepparam sreAgentAccessLevel was overridden to Low for this deploy
+- [ ] SRE Agent managed identity does NOT hold Contributor on the resource group:
+      az role assignment list --assignee <sre-agent-principal-id> --output table
 
 ### H-4: RabbitMQ Credentials
 - [ ] Accepted: guest/guest demo-static values are acknowledged

--- a/docs/SRE-AGENT-SETUP.md
+++ b/docs/SRE-AGENT-SETUP.md
@@ -29,8 +29,10 @@ The SRE Agent is deployed automatically as part of `scripts/deploy.ps1` using th
 
 - Creates the SRE Agent resource
 - Creates a user-assigned managed identity
-- Assigns Log Analytics Reader, Reader, and Contributor roles
+- Assigns roles based on `sreAgentAccessLevel` (default `Low`: Reader + Log Analytics Reader only)
 - Grants the deploying user the **SRE Agent Administrator** role
+
+> **Access level**: `main.bicepparam` sets `sreAgentAccessLevel = 'High'` for the internal remediation demo. This is intentional — see `docs/SRE-AGENT-SETUP.md` for the access-level guide. For external demos, pass `-SreAgentAccessLevel Low` (the parameter default) to `deploy.ps1`.
 
 > **API version pin (issue #51)**: This lab uses `Microsoft.App/agents@2025-05-01-preview`. The `2026-01-01` GA version exists in ARM schema but has **not** been validated against this subscription. Do **not** change the API version until all three gates in issue #51 pass:
 > 1. `az provider show -n Microsoft.App --query "resourceTypes[?resourceType=='agents'].apiVersions"` lists `2026-01-01` for this subscription.
@@ -64,9 +66,9 @@ When you create an SRE Agent, Azure automatically provisions:
 
 ## Step 2: Configure Agent Permissions
 
-The SRE Agent needs access to your Azure resources to diagnose and **remediate** issues.
+The SRE Agent needs access to your Azure resources to diagnose issues — and optionally to remediate them.
 
-> **Note**: When deployed via Bicep (default), the agent's managed identity is automatically assigned Reader, Contributor, and Log Analytics Reader roles on the deployment resource group. The script below grants additional AKS-specific roles.
+> **Note**: When deployed via Bicep (default), the agent's managed identity receives roles determined by `sreAgentAccessLevel` (default `Low`). The script below can grant additional roles and aligns to the same access-level gate.
 
 ### Grant Access to Demo Resources
 
@@ -81,10 +83,32 @@ The SRE Agent needs access to your Azure resources to diagnose and **remediate**
 
 ### Permissions Granted to SRE Agent
 
-The script assigns these roles to enable both **diagnosis AND remediation**:
+The permissions granted depend on the `SreAgentAccessLevel` parameter (default: `Low`).
+
+#### Low access (default) — diagnosis only
+
+Safe for external/customer-facing demos. Set via `sreAgentAccessLevel = 'Low'` in Bicep or `-SreAgentAccessLevel Low` in scripts.
 
 | Scope | Role | What It Allows |
 |-------|------|----------------|
+| **Resource Group** | Reader | Read metadata for all resources |
+| **Resource Group** | Log Analytics Reader | Query and analyze logs |
+| **Log Analytics** | Log Analytics Reader | Query and analyze logs (explicit) |
+| **Key Vault** | Key Vault Secrets User | Read secrets (get/list only) |
+| **Container Registry** | AcrPull | Pull container images |
+
+SRE Agent can diagnose issues, query logs, surface hypotheses, and recommend remediations. It **cannot** write to or modify any resource.
+
+#### High access — remediation demos (internal only)
+
+Required for demo flows where SRE Agent performs or proposes write-level remediation. Set via `sreAgentAccessLevel = 'High'` in `main.bicepparam` and `-SreAgentAccessLevel High` in scripts.
+
+> ⚠️ **Do not use High access for external or customer-facing demos.**
+
+| Scope | Role | What It Allows |
+|-------|------|----------------|
+| **Resource Group** | Reader | Read metadata for all resources |
+| **Resource Group** | Log Analytics Reader | Query and analyze logs |
 | **Resource Group** | Contributor | Read/write access to all resources |
 | **Subscription** | Reader | Broader context for diagnosis |
 | **AKS Cluster** | AKS Cluster Admin Role | kubectl access to cluster |
@@ -94,13 +118,36 @@ The script assigns these roles to enable both **diagnosis AND remediation**:
 | **Key Vault** | Key Vault Secrets User | Read secrets (get/list only) |
 | **Container Registry** | AcrPull | Pull container images |
 
-> **Note**: This profile still includes broad **write permissions** through Contributor, AKS admin/contributor roles. Log Analytics, Key Vault, and ACR are read-only.
-> - H-3 (deferred, issue #53): Contributor at RG scope is required for remediation-capable demos. For read-only diagnosis, set `accessLevel = 'Low'` in Bicep and skip the Contributor grant in `configure-rbac.ps1`.
-> - M-8 (fixed): Key Vault Secrets Officer downgraded to Secrets User. If a demo flow requires secret rotation via SRE Agent, grant Secrets Officer manually for that session only.
-> - Restart pods, scale deployments, delete stuck resources
-> - Query and analyze logs
-> - Access/update Key Vault secrets
-> - Pull container images
+> **Note (M-8, fixed)**: Key Vault Secrets Officer was downgraded to Secrets User. If a demo flow requires secret rotation via SRE Agent, grant Secrets Officer manually for that session only.
+
+### Choosing an access level
+
+| Context | Use |
+|---------|-----|
+| External / customer-facing demo | `Low` |
+| Internal lab — diagnosis walkthrough | `Low` |
+| Internal lab — full remediation demo | `High` |
+| Production / security review | `Low` (or omit SRE Agent entirely) |
+
+To deploy with explicit access level control:
+
+```powershell
+# External demo — diagnosis only (default):
+.\scripts\deploy.ps1 -Location eastus2 -Yes
+
+# Internal remediation demo:
+.\scripts\deploy.ps1 -Location eastus2 -SreAgentAccessLevel High -Yes
+```
+
+Or standalone RBAC configuration:
+
+```powershell
+# Low (diagnosis only):
+.\scripts\configure-rbac.ps1 -ResourceGroupName "rg-srelab-eastus2" -SreAgentPrincipalId "<id>"
+
+# High (remediation):
+.\scripts\configure-rbac.ps1 -ResourceGroupName "rg-srelab-eastus2" -SreAgentPrincipalId "<id>" -SreAgentAccessLevel High
+```
 
 ### SRE Agent User Roles
 

--- a/docs/evidence/complete-failure-bundle/metrics/mttr-summary.yaml
+++ b/docs/evidence/complete-failure-bundle/metrics/mttr-summary.yaml
@@ -1,0 +1,53 @@
+# MTTR Summary — Complete Failure Bundle
+# Status: PENDING_HUMAN_CAPTURE
+# Issue: #48 (supporting #37)
+# Operator: fill during or immediately after the live run
+# Scenario: complete-failure-bundle (mongodb-down + network-block + service-mismatch)
+#
+# Instructions: replace placeholder timestamps with real UTC values from your run-notes.md.
+# Do NOT invent or estimate timestamps. Leave blank (empty string) if a phase was not completed.
+
+scenario: complete-failure-bundle
+operator: ""                          # e.g. john-stelmaszek
+run_date: ""                          # e.g. 2026-06-15
+cluster: ""                           # cluster name (redact subscription/tenant)
+region: ""                            # eastus2 | swedencentral | australiaeast
+
+# ── Timestamps (UTC ISO-8601) ───────────────────────────────────────────────
+T0_healthy_baseline: ""               # kubectl get pods confirmed all Running/Ready
+T1_bundle_applied: ""                 # kubectl apply -f complete-failure-bundle/scenario.yaml
+T2_degraded_state_observed: ""        # kubectl output confirms failure signals visible
+T3_sre_agent_prompt_sent: ""          # first prompt submitted to portal
+T3_sre_agent_response_complete: ""    # full portal response received
+T4_operator_recovery_started: ""      # kubectl delete networkpolicy / apply baseline
+T5_recovery_verified: ""              # all pods Running/Ready, endpoints populated
+
+# ── Derived metrics (seconds) ───────────────────────────────────────────────
+# Fill manually from timestamps above, or leave 0 if phase not completed.
+detection_time_seconds: 0             # T2 - T1: time from bundle inject to degradation confirmed
+sre_agent_response_time_seconds: 0    # T3_response - T3_prompt: time for portal to return diagnosis
+operator_decision_to_recovery_seconds: 0  # T4 - T3_response: decision + command execution
+recovery_time_seconds: 0             # T5 - T4: time from fix applied to healthy baseline
+total_incident_time_seconds: 0       # T5 - T1: full incident duration
+mttr_seconds: 0                       # T5 - T2: mean time to recovery from first observed failure
+
+# ── Pass criteria ──────────────────────────────────────────────────────────
+mttr_threshold_seconds: 900           # 15 minutes — baseline pass bar for demo quality
+pass_criteria_met: null               # true | false — fill after run
+
+# ── SRE Agent portal status ────────────────────────────────────────────────
+sre_agent_portal_available: null      # true | false
+sre_agent_response_quality: ""        # PASS | PARTIAL | FAIL | UNAVAILABLE
+sre_agent_identified_root_causes:
+  mongodb_scaled_to_zero: null        # true | false
+  network_policy_deny_meter: null     # true | false
+  service_selector_mismatch: null     # true | false
+
+# ── Observations ────────────────────────────────────────────────────────────
+observations: |
+  [Fill with factual observations from the run. Examples:]
+  - Bundle applied and three simultaneous failures manifested within Ns of injection.
+  - SRE Agent response time was Ns.
+  - Agent correctly identified N of 3 root causes.
+  - Recovery sequence executed in N steps.
+  - No residual failures observed at T5.

--- a/docs/evidence/complete-failure-bundle/sre-agent/diagnosis-response.md
+++ b/docs/evidence/complete-failure-bundle/sre-agent/diagnosis-response.md
@@ -1,0 +1,151 @@
+# SRE Agent Diagnosis Response — Complete Failure Bundle
+
+**Status**: ⏳ PENDING_HUMAN_CAPTURE — fill this during the live run.
+**Issue**: #48 (supporting #37)
+**Operator**: *(John or designated demo operator)*
+
+> **Instructions**: Paste the full, unparaphrased SRE Agent portal response for each prompt below.
+> Do **not** paraphrase, summarise, or infer. Record exactly what the portal shows.
+> If the portal is unavailable or does not return a usable response, skip to the Blockers section
+> and record explicit blocker notes per the template in `docs/evidence/screenshots/README.md`.
+
+---
+
+## Prompt 1 — Initial Triage
+
+**Timestamp (UTC)**: *(fill in)*
+**Exact prompt used**:
+```
+The energy grid platform is experiencing a broad outage.
+Multiple services are failing in the energy namespace.
+Can you investigate and tell me what's wrong?
+```
+
+**SRE Agent response (verbatim)**:
+```
+[PASTE FULL RESPONSE HERE — do not paraphrase]
+```
+
+**Root-cause coverage assessment**:
+- [ ] Agent identified MongoDB scaled to `replicas: 0`
+- [ ] Agent identified `NetworkPolicy/deny-meter-service`
+- [ ] Agent identified service selector mismatch (`app: meter-service-v2`)
+- [ ] Agent identified downstream symptoms (dispatch-service, grid-dashboard degradation)
+- [ ] Agent did **not** confuse symptoms with root causes
+
+**Result**: ☐ PASS &nbsp; ☐ PARTIAL &nbsp; ☐ FAIL &nbsp; ☐ N/A (portal unavailable)
+
+**Justification**:
+> *(one sentence)*
+
+---
+
+## Prompt 2 — Dependency Separation
+
+**Timestamp (UTC)**: *(fill in)*
+**Exact prompt used**:
+```
+Separate root cause from downstream symptoms across services in the energy namespace
+```
+
+**SRE Agent response (verbatim)**:
+```
+[PASTE FULL RESPONSE HERE — do not paraphrase]
+```
+
+**Assessment**:
+- [ ] Agent separated upstream root causes from downstream symptoms
+- [ ] Agent listed a dependency chain (MongoDB → dispatch-service → dashboard)
+
+**Result**: ☐ PASS &nbsp; ☐ PARTIAL &nbsp; ☐ FAIL &nbsp; ☐ N/A
+
+---
+
+## Prompt 3 — Recovery Planning
+
+**Timestamp (UTC)**: *(fill in)*
+**Exact prompt used**:
+```
+Recommend a prioritized recovery plan with dependencies first
+```
+
+**SRE Agent response (verbatim)**:
+```
+[PASTE FULL RESPONSE HERE — do not paraphrase]
+```
+
+**Assessment**:
+- [ ] Agent recommended restoring data layer (MongoDB) first
+- [ ] Agent recommended fixing routing/network isolation before restarting dependent services
+- [ ] Agent used safe language: **agent recommends; operator executes** (no claim of autonomous action)
+
+**Result**: ☐ PASS &nbsp; ☐ PARTIAL &nbsp; ☐ FAIL &nbsp; ☐ N/A
+
+---
+
+## Prompt 4 — Post-Recovery Verification
+
+**Timestamp (UTC)**: *(fill in)*
+**Exact prompt used**:
+```
+Verify that meter-service endpoints, MongoDB availability, and network access are all healthy
+```
+
+**SRE Agent response (verbatim)**:
+```
+[PASTE FULL RESPONSE HERE — do not paraphrase]
+```
+
+**Assessment**:
+- [ ] Agent confirmed meter-service endpoints are populated
+- [ ] Agent confirmed MongoDB `READY 1/1`
+- [ ] Agent confirmed `deny-meter-service` NetworkPolicy is absent
+
+**Result**: ☐ PASS &nbsp; ☐ PARTIAL &nbsp; ☐ FAIL &nbsp; ☐ N/A
+
+---
+
+## Proposal / Approval UI
+
+> If the SRE Agent portal exposed a recommendation or approval UI at any point, record it here.
+> If no approval UI was visible, leave this section blank — do **not** fabricate it.
+
+**Approval UI visible?** ☐ Yes &nbsp; ☐ No
+
+If yes, describe exactly what was shown:
+```
+[DESCRIBE EXACTLY]
+```
+
+Screenshot reference: `sre-agent/screenshots/proposal.png` *(if captured)*
+
+---
+
+## Blockers
+
+> If the portal was unavailable or did not return a usable response, document here.
+> Use the safe-language template from `docs/evidence/screenshots/README.md`.
+
+```
+PENDING PORTAL EVIDENCE — do not present as captured.
+Blocker: <portal unavailable | no live lab | auth/RBAC issue | SRE Agent resource missing | other>.
+Scenario: complete-failure-bundle.
+Required next action: John/demo operator must resolve the blocker and rerun the capture session.
+```
+
+---
+
+## Overall Diagnosis Quality
+
+| Criterion | Result |
+|-----------|--------|
+| Root causes correctly identified | ☐ PASS / ☐ PARTIAL / ☐ FAIL / ☐ N/A |
+| Symptoms separated from root causes | ☐ PASS / ☐ PARTIAL / ☐ FAIL / ☐ N/A |
+| Recovery sequence prioritised correctly | ☐ PASS / ☐ PARTIAL / ☐ FAIL / ☐ N/A |
+| Post-recovery verification provided | ☐ PASS / ☐ PARTIAL / ☐ FAIL / ☐ N/A |
+| Safe language maintained throughout | ☐ PASS / ☐ FAIL |
+
+**Overall result**: ☐ PASS &nbsp; ☐ PARTIAL &nbsp; ☐ FAIL &nbsp; ☐ BLOCKED
+
+**Operator signature**: ___________________
+**Date**: ___________________

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -103,6 +103,10 @@ param aksApiServerAuthorizedIpRanges array = []
 @description('Enable ACR admin user account (not required for default deploy path)')
 param acrAdminUserEnabled bool = false
 
+@description('SRE Agent access level. Low = Reader + Log Analytics Reader (diagnosis only, default for external/unknown contexts). High = adds Contributor at resource-group scope (required for remediation demos). Set explicitly in main.bicepparam for internal demo runs.')
+@allowed(['High', 'Low'])
+param sreAgentAccessLevel string = 'Low'
+
 @description('Tags to apply to all resources')
 param tags object = {
   workload: 'energy-grid-demo'
@@ -248,7 +252,7 @@ module sreAgent 'modules/sre-agent.bicep' = if (deploySreAgent) {
     agentName: names.sreAgent
     location: location
     tags: tags
-    accessLevel: 'High'
+    accessLevel: sreAgentAccessLevel
     appInsightsAppId: appInsights.outputs.appId
     appInsightsConnectionString: appInsights.outputs.connectionString
     uniqueSuffix: uniqueSuffix

--- a/infra/bicep/main.bicepparam
+++ b/infra/bicep/main.bicepparam
@@ -43,6 +43,13 @@ param aksApiServerAuthorizedIpRanges = []
 // ACR admin account is disabled by default; use role-based auth for pull/push.
 param acrAdminUserEnabled = false
 
+// SRE Agent access level for internal remediation demos.
+// 'High' = Reader + Log Analytics Reader + Contributor at RG scope (write access for remediation).
+// 'Low'  = Reader + Log Analytics Reader only (diagnosis-only; default for external/unknown contexts).
+// H-3: 'High' is intentional for the internal demo to allow SRE Agent remediation actions.
+// For external/customer-facing demos, omit this parameter or set to 'Low'.
+param sreAgentAccessLevel = 'High'
+
 // Tags
 param tags = {
   workload: 'energy-grid-demo'

--- a/scripts/configure-rbac.ps1
+++ b/scripts/configure-rbac.ps1
@@ -8,7 +8,7 @@
     
     Includes:
     - SRE Agent roles (when SRE Agent is created)
-    - Contributor access for managed identities
+    - Contributor access for managed identities (High access level only)
     - Key Vault access roles
 
 .PARAMETER ResourceGroupName
@@ -20,8 +20,19 @@
 .PARAMETER CurrentUserPrincipalId
     Object ID of the current user for admin access
 
+.PARAMETER SreAgentAccessLevel
+    Access level for SRE Agent role assignments.
+    'Low'  (default) — Reader + Log Analytics Reader only. Diagnosis-only; safe for external/customer-facing demos.
+    'High' — adds Contributor at RG scope + AKS admin roles. Required for remediation demos.
+    Must match the accessLevel used in Bicep (main.bicepparam: sreAgentAccessLevel).
+
 .EXAMPLE
-    .\configure-rbac.ps1 -ResourceGroupName "rg-srelab-eastus2"
+    # External/diagnosis-only demo (default):
+    .\configure-rbac.ps1 -ResourceGroupName "rg-srelab-eastus2" -SreAgentPrincipalId "<id>"
+
+.EXAMPLE
+    # Internal remediation demo:
+    .\configure-rbac.ps1 -ResourceGroupName "rg-srelab-eastus2" -SreAgentPrincipalId "<id>" -SreAgentAccessLevel High
 
 .NOTES
     This script is idempotent - safe to run multiple times.
@@ -36,7 +47,11 @@ param(
     [string]$SreAgentPrincipalId,
 
     [Parameter()]
-    [string]$CurrentUserPrincipalId
+    [string]$CurrentUserPrincipalId,
+
+    [Parameter()]
+    [ValidateSet('High', 'Low')]
+    [string]$SreAgentAccessLevel = 'Low'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -174,17 +189,20 @@ if ($SreAgentPrincipalId) {
     Write-Host "`n  📌 SRE Agent Access:" -ForegroundColor Cyan
     
     # SRE Agent needs Contributor on the resource group to diagnose AND remediate issues.
-    # H-3 / deferred: Contributor at RG scope is intentional for the High-access demo profile
-    # so that SRE Agent can perform remediation actions (restart pods, patch resources, etc.).
-    # Scope-down to a narrower custom role or Low-access (Reader-only) diagnosis mode is tracked
-    # in issue #53 and should be evaluated before production use or customer-facing demos
-    # where write access would be unacceptable.
-    Set-RoleAssignment `
-        -Scope "/subscriptions/$subscriptionId/resourceGroups/$ResourceGroupName" `
-        -RoleDefinition "Contributor" `
-        -PrincipalId $SreAgentPrincipalId `
-        -PrincipalType "ServicePrincipal" `
-        -Description "Contributor for SRE Agent (read/write access to resources)"
+    # H-3 (issue #57): Contributor at RG scope is gated behind SreAgentAccessLevel = 'High'.
+    # For diagnosis-only / external demos, use SreAgentAccessLevel = 'Low' — the Bicep module
+    # will assign Reader + Log Analytics Reader only, and this script skips all write grants.
+    if ($SreAgentAccessLevel -eq 'High') {
+        Set-RoleAssignment `
+            -Scope "/subscriptions/$subscriptionId/resourceGroups/$ResourceGroupName" `
+            -RoleDefinition "Contributor" `
+            -PrincipalId $SreAgentPrincipalId `
+            -PrincipalType "ServicePrincipal" `
+            -Description "Contributor for SRE Agent (High access: read/write for remediation demos)"
+    }
+    else {
+        Write-Host "    ℹ️  Contributor grant skipped (SreAgentAccessLevel = Low; diagnosis-only profile)" -ForegroundColor Gray
+    }
     
     # Reader on subscription for broader context
     Set-RoleAssignment `
@@ -196,31 +214,38 @@ if ($SreAgentPrincipalId) {
     
     # AKS-specific roles for Kubernetes operations (restart pods, scale, etc.)
     if ($aksCluster) {
-        Write-Host "`n  📌 SRE Agent AKS Access:" -ForegroundColor Cyan
-        
-        # Azure Kubernetes Service Cluster Admin - allows kubectl access
-        Set-RoleAssignment `
-            -Scope $aksCluster.id `
-            -RoleDefinition "Azure Kubernetes Service Cluster Admin Role" `
-            -PrincipalId $SreAgentPrincipalId `
-            -PrincipalType "ServicePrincipal" `
-            -Description "AKS Cluster Admin for SRE Agent (kubectl access)"
-        
-        # Azure Kubernetes Service RBAC Cluster Admin - full K8s RBAC permissions
-        Set-RoleAssignment `
-            -Scope $aksCluster.id `
-            -RoleDefinition "Azure Kubernetes Service RBAC Cluster Admin" `
-            -PrincipalId $SreAgentPrincipalId `
-            -PrincipalType "ServicePrincipal" `
-            -Description "AKS RBAC Cluster Admin for SRE Agent (full K8s permissions)"
-        
-        # Azure Kubernetes Service Contributor - manage AKS resource itself
-        Set-RoleAssignment `
-            -Scope $aksCluster.id `
-            -RoleDefinition "Azure Kubernetes Service Contributor Role" `
-            -PrincipalId $SreAgentPrincipalId `
-            -PrincipalType "ServicePrincipal" `
-            -Description "AKS Contributor for SRE Agent (scale nodes, update config)"
+        if ($SreAgentAccessLevel -eq 'High') {
+            Write-Host "`n  📌 SRE Agent AKS Access (High):" -ForegroundColor Cyan
+            
+            # Azure Kubernetes Service Cluster Admin - allows kubectl access
+            Set-RoleAssignment `
+                -Scope $aksCluster.id `
+                -RoleDefinition "Azure Kubernetes Service Cluster Admin Role" `
+                -PrincipalId $SreAgentPrincipalId `
+                -PrincipalType "ServicePrincipal" `
+                -Description "AKS Cluster Admin for SRE Agent (kubectl access)"
+            
+            # Azure Kubernetes Service RBAC Cluster Admin - full K8s RBAC permissions
+            Set-RoleAssignment `
+                -Scope $aksCluster.id `
+                -RoleDefinition "Azure Kubernetes Service RBAC Cluster Admin" `
+                -PrincipalId $SreAgentPrincipalId `
+                -PrincipalType "ServicePrincipal" `
+                -Description "AKS RBAC Cluster Admin for SRE Agent (full K8s permissions)"
+            
+            # Azure Kubernetes Service Contributor - manage AKS resource itself
+            Set-RoleAssignment `
+                -Scope $aksCluster.id `
+                -RoleDefinition "Azure Kubernetes Service Contributor Role" `
+                -PrincipalId $SreAgentPrincipalId `
+                -PrincipalType "ServicePrincipal" `
+                -Description "AKS Contributor for SRE Agent (scale nodes, update config)"
+        }
+        else {
+            Write-Host "`n  📌 SRE Agent AKS Access (Low — read-only):" -ForegroundColor Cyan
+            Write-Host "    ℹ️  AKS write roles skipped (SreAgentAccessLevel = Low; diagnosis-only profile)" -ForegroundColor Gray
+            Write-Host "    ℹ️  SRE Agent can still query cluster metadata via Reader role from Bicep." -ForegroundColor Gray
+        }
     }
     
     # Log Analytics access for querying logs


### PR DESCRIPTION
## Summary

Two related work items delivered on this branch:

### 1. #57 — H-3 least-privilege resolution: Low/High access-level gate

**Problem:** `accessLevel: 'High'` was hardcoded in `main.bicep`, silently granting the SRE Agent managed identity Contributor at resource-group scope for all deployments.

**Resolution:**
- Parameterized `sreAgentAccessLevel` in `infra/bicep/main.bicep` (default: `'Low'`)
- Wired through to `sre-agent` module — no more hardcoded `'High'`
- `infra/bicep/main.bicepparam` explicitly sets `'High'` for internal lab runs with documented H-3 comment
- `scripts/configure-rbac.ps1`: Contributor + AKS admin grants gated behind `-SreAgentAccessLevel High`
- `docs/EXTERNAL-DEMO-HARDENING.md`: H-3 added to findings table + full section (risk, resolution, operator checklist)
- `docs/SRE-AGENT-SETUP.md`: permissions section expanded into Low/High comparison tables with deploy examples

Closes #57.

### 2. #48 / #37 — Complete-failure-bundle evidence scaffold completion

Adds `diagnosis-response.md` and `mttr-summary.yaml` templates. No live evidence fabricated — all fields PENDING_HUMAN_CAPTURE.

Refs #48, #37.