### PR TITLE
fix(#57): wire -SreAgentAccessLevel through deploy.ps1

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -25,6 +25,11 @@
 .PARAMETER SkipSreAgent
     Skip Azure SRE Agent deployment and deploy only the core lab infrastructure
 
+.PARAMETER SreAgentAccessLevel
+    Access level for the SRE Agent managed identity. Default: Low (diagnosis-only; safe for external demos).
+    Use 'High' for internal remediation demos (adds Contributor at RG scope + AKS admin roles).
+    Passed to Bicep (overrides main.bicepparam value) and forwarded to configure-rbac.ps1.
+
 .PARAMETER WhatIf
     Show what would be deployed without making changes
 
@@ -57,6 +62,10 @@ param(
 
     [Parameter()]
     [switch]$SkipSreAgent,
+
+    [Parameter()]
+    [ValidateSet('High', 'Low')]
+    [string]$SreAgentAccessLevel = 'Low',
 
     [Parameter()]
     [switch]$WhatIf,
@@ -632,6 +641,7 @@ Write-Host "  • Workload Name:   $WorkloadName" -ForegroundColor White
 Write-Host "  • Resource Group:  $resourceGroupName" -ForegroundColor White
 Write-Host "  • Deployment Name: $deploymentName" -ForegroundColor White
 Write-Host "  • SRE Agent:       $(if ($deploySreAgent) { 'Enabled' } else { 'Disabled' })" -ForegroundColor White
+Write-Host "  • Agent Access:    $SreAgentAccessLevel$(if ($SreAgentAccessLevel -eq 'High') { ' ⚠️  (remediation; internal use only)' } else { ' ✅ (diagnosis-only)' })" -ForegroundColor White
 Write-Host "  • AKS API CIDRs:   $(if ($AksApiServerAuthorizedIpRanges.Count -gt 0) { $AksApiServerAuthorizedIpRanges -join ', ' } else { '(none - unrestricted public API endpoint)' })" -ForegroundColor White
 if ($sreAgentSkipReason) {
     Write-Host "  • SRE Agent Note:  $sreAgentSkipReason" -ForegroundColor Gray
@@ -648,6 +658,7 @@ if ($WhatIf) {
         "location=$Location"
         "workloadName=$WorkloadName"
         "deploySreAgent=$deploySreAgentValue"
+        "sreAgentAccessLevel=$SreAgentAccessLevel"
     )
     if ($kubernetesVersionParam) {
         $whatIfParameterArgs += "kubernetesVersion=$kubernetesVersionParam"
@@ -701,6 +712,7 @@ try {
         "location=$Location"
         "workloadName=$WorkloadName"
         "deploySreAgent=$deploySreAgentValue"
+        "sreAgentAccessLevel=$SreAgentAccessLevel"
     )
     if ($kubernetesVersionParam) {
         $deployParameterArgs += "kubernetesVersion=$kubernetesVersionParam"
@@ -874,7 +886,8 @@ if (-not $SkipRbac) {
     $rbacScript = Join-Path $PSScriptRoot "configure-rbac.ps1"
     if (Test-Path $rbacScript) {
         $rbacParams = @{
-            ResourceGroupName = $resourceGroupName
+            ResourceGroupName   = $resourceGroupName
+            SreAgentAccessLevel = $SreAgentAccessLevel
         }
 
         if ($sreAgentManagedIdentityPrincipalId) {


### PR DESCRIPTION
## Summary

Completes the `deploy.ps1` wiring that was missing after 73e0033 landed the Bicep + configure-rbac.ps1 changes for #57.

### Problem

Without this change, `deploy.ps1` always passed `main.bicepparam`'s `sreAgentAccessLevel = 'High'` to Bicep (Contributor grant), while `configure-rbac.ps1` defaulted to `Low` (no Contributor grant). The two halves of the stack were inconsistent.

### Changes

- Add `-SreAgentAccessLevel` parameter to `deploy.ps1` (default: `Low`, matching the Bicep default and the safe-by-default intent from #57)
- Pass `sreAgentAccessLevel` as an explicit Bicep parameter override in both what-if and deploy code paths — ensures the operator's intent overrides the params file
- Forward `SreAgentAccessLevel` to `configure-rbac.ps1` via `$rbacParams`
- Echo the access level in the deployment configuration banner with a visual indicator

### Behavior

| Command | Bicep accessLevel | RBAC Contributor grant |
|---------|------------------|------------------------|
| `deploy.ps1 -Yes` (external demo / default) | Low | No |
| `deploy.ps1 -SreAgentAccessLevel High -Yes` (internal lab) | High | Yes |

The internal lab params file (`main.bicepparam`) still documents `sreAgentAccessLevel = 'High'` as the annotated lab default but is now overridden by the script parameter when needed.

### Validation

- `az bicep build --file infra/bicep/main.bicep` ✅
- `validate-scenario-metadata.ps1` ✅
- No infrastructure deployed; script-only and Bicep pass-through change only

Refs #57, #53.