### PR TITLE
docs(#37): clarify complete failure recovery path

### DIFF
--- a/docs/BREAKABLE-SCENARIOS.md
+++ b/docs/BREAKABLE-SCENARIOS.md
@@ -483,6 +483,16 @@ kubectl get pods,svc,endpoints -n energy
 kubectl get events -n energy --sort-by=.lastTimestamp | tail -30
 ```
 
+**Expected Kubernetes signals:**
+
+| Signal | Command | Expected degraded evidence |
+|--------|---------|----------------------------|
+| Data layer unavailable | `kubectl get deployment mongodb -n energy` | MongoDB desired/ready replicas are `0/0` |
+| Meter API Service unroutable | `kubectl get endpoints meter-service -n energy` | Endpoint list is empty (`<none>`) |
+| Traffic isolation present | `kubectl get networkpolicy deny-meter-service -n energy` | Deny policy exists for `app=meter-service` |
+| Blast radius visible | `kubectl get pods,svc,endpoints -n energy` | Dependencies, Services, and endpoints disagree |
+| Recent change/event timeline | `kubectl get events -n energy --sort-by=.lastTimestamp | tail -30` | Recent scenario application and rollout events are visible |
+
 **SRE Agent prompts:**
 - "Why is the entire energy grid platform down?"
 - "Separate root cause from downstream symptoms across the energy namespace"
@@ -497,16 +507,22 @@ kubectl get events -n energy --sort-by=.lastTimestamp | tail -30
 
 **Suggested operator execution order:**
 ```bash
-# 1) Remove network isolation
-kubectl delete networkpolicy deny-meter-service -n energy
-
-# 2) Restore baseline workloads/services
+# 1) Restore dependency and Service specs first
 kubectl apply -f k8s/base/application.yaml
 
-# 3) Verify platform recovery
-kubectl get pods -n energy
+# 2) Confirm data layer and routing specs recovered
+kubectl get deployment mongodb -n energy
 kubectl get endpoints meter-service -n energy
+
+# 3) Remove the extra NetworkPolicy that baseline apply does not delete
+kubectl delete networkpolicy deny-meter-service -n energy
+
+# 4) Verify platform recovery
+kubectl get pods -n energy
+kubectl get networkpolicy -n energy
 ```
+
+Expected recovery evidence: MongoDB returns to `READY 1/1`, `meter-service` endpoints are populated, `deny-meter-service` is absent, and application pods return to `Running` / `Ready`.
 
 **Pass/Fail Criteria:**
 - ✅ **PASS**: SRE Agent distinguishes upstream root cause(s) from downstream symptoms

--- a/docs/BREAKABLE-SCENARIOS.md
+++ b/docs/BREAKABLE-SCENARIOS.md
@@ -457,6 +457,7 @@ kubectl apply -f k8s/base/application.yaml
 **What happens:**
 - Applies an orchestrated bundle of existing scenarios:
   - `mongodb-down.yaml` (data layer outage)
+  - event-bus outage (RabbitMQ scaled to 0 replicas)
   - `network-block.yaml` (meter-service traffic isolation)
   - `service-mismatch.yaml` (meter-service endpoints empty)
 - Simulates broad application failure where dependencies and request paths fail at once
@@ -470,7 +471,8 @@ kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
 **What to observe:**
 ```bash
 # Dependency outage
-kubectl get deployment mongodb -n energy
+kubectl get deployment mongodb rabbitmq -n energy
+kubectl get endpoints mongodb rabbitmq -n energy
 
 # Silent routing failure (selector mismatch)
 kubectl get endpoints meter-service -n energy
@@ -488,6 +490,8 @@ kubectl get events -n energy --sort-by=.lastTimestamp | tail -30
 | Signal | Command | Expected degraded evidence |
 |--------|---------|----------------------------|
 | Data layer unavailable | `kubectl get deployment mongodb -n energy` | MongoDB desired/ready replicas are `0/0` |
+| Event bus unavailable | `kubectl get deployment rabbitmq -n energy` | RabbitMQ desired/ready replicas are `0/0` |
+| Dependency Services empty | `kubectl get endpoints mongodb rabbitmq -n energy` | MongoDB and RabbitMQ endpoints are empty (`<none>`) |
 | Meter API Service unroutable | `kubectl get endpoints meter-service -n energy` | Endpoint list is empty (`<none>`) |
 | Traffic isolation present | `kubectl get networkpolicy deny-meter-service -n energy` | Deny policy exists for `app=meter-service` |
 | Blast radius visible | `kubectl get pods,svc,endpoints -n energy` | Dependencies, Services, and endpoints disagree |
@@ -511,7 +515,8 @@ kubectl get events -n energy --sort-by=.lastTimestamp | tail -30
 kubectl apply -f k8s/base/application.yaml
 
 # 2) Confirm data layer and routing specs recovered
-kubectl get deployment mongodb -n energy
+kubectl get deployment mongodb rabbitmq -n energy
+kubectl get endpoints mongodb rabbitmq -n energy
 kubectl get endpoints meter-service -n energy
 
 # 3) Remove the extra NetworkPolicy that baseline apply does not delete
@@ -522,7 +527,7 @@ kubectl get pods -n energy
 kubectl get networkpolicy -n energy
 ```
 
-Expected recovery evidence: MongoDB returns to `READY 1/1`, `meter-service` endpoints are populated, `deny-meter-service` is absent, and application pods return to `Running` / `Ready`.
+Expected recovery evidence: MongoDB and RabbitMQ return to `READY 1/1`, dependency endpoints and `meter-service` endpoints are populated, `deny-meter-service` is absent, and application pods return to `Running` / `Ready`.
 
 **Pass/Fail Criteria:**
 - ✅ **PASS**: SRE Agent distinguishes upstream root cause(s) from downstream symptoms

--- a/docs/DEMO-RUNBOOK.md
+++ b/docs/DEMO-RUNBOOK.md
@@ -213,7 +213,8 @@ For the full prompt catalog, see [docs/PROMPTS-GUIDE.md](PROMPTS-GUIDE.md) or pe
 
 ```bash
 kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
-kubectl get deployment mongodb -n energy
+kubectl get deployment mongodb rabbitmq -n energy
+kubectl get endpoints mongodb rabbitmq -n energy
 kubectl get endpoints meter-service -n energy
 kubectl get networkpolicy deny-meter-service -n energy
 ```
@@ -223,7 +224,8 @@ Ask SRE Agent for dependency-aware recovery guidance, then keep the operator in 
 ```bash
 # Restore dependency and Service specs first.
 kubectl apply -f k8s/base/application.yaml
-kubectl get deployment mongodb -n energy
+kubectl get deployment mongodb rabbitmq -n energy
+kubectl get endpoints mongodb rabbitmq -n energy
 kubectl get endpoints meter-service -n energy
 
 # Remove the extra NetworkPolicy because apply does not prune it.

--- a/docs/DEMO-RUNBOOK.md
+++ b/docs/DEMO-RUNBOOK.md
@@ -139,7 +139,7 @@ az resource list --resource-group <rg-name> --resource-type Microsoft.App/agents
 
 ## Step 4: Run Scenario — Break, Diagnose, Fix
 
-For each scenario you plan to demo, follow this loop:
+For each scenario you plan to demo, follow this loop. Use the complete-failure bundle only after the core scenarios are understood, because it combines dependency outage, service routing failure, and network isolation in one incident.
 
 ### 4a. Inject the failure
 
@@ -205,8 +205,34 @@ Open the SRE Agent portal. Start with an open-ended prompt, then escalate to sce
 | **OOMKilled** | "Why is the meter-service pod restarting repeatedly?" |
 | **MongoDBDown** | "Smart meter data isn't being processed — what's wrong?" |
 | **ServiceMismatch** | "Grid dashboard loads but meter readings fail — what's broken?" |
+| **CompleteFailureBundle** | "Why is the entire energy grid platform down?" |
 
 For the full prompt catalog, see [docs/PROMPTS-GUIDE.md](PROMPTS-GUIDE.md) or per-scenario prompts in [docs/BREAKABLE-SCENARIOS.md](BREAKABLE-SCENARIOS.md).
+
+**Complete-failure bundle operator path (optional advanced demo):**
+
+```bash
+kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
+kubectl get deployment mongodb -n energy
+kubectl get endpoints meter-service -n energy
+kubectl get networkpolicy deny-meter-service -n energy
+```
+
+Ask SRE Agent for dependency-aware recovery guidance, then keep the operator in control:
+
+```bash
+# Restore dependency and Service specs first.
+kubectl apply -f k8s/base/application.yaml
+kubectl get deployment mongodb -n energy
+kubectl get endpoints meter-service -n energy
+
+# Remove the extra NetworkPolicy because apply does not prune it.
+kubectl delete networkpolicy deny-meter-service -n energy
+kubectl get pods -n energy
+kubectl get networkpolicy -n energy
+```
+
+Capture evidence in `docs/evidence/scenarios/complete-failure-bundle/run-notes.md`. Do not claim SRE Agent guided recovery unless the real portal conversation is captured or visible live.
 
 **Evidence capture — per scenario failure + recovery screenshots** (visual evidence pack, #38 / #45):
 

--- a/docs/SRE-AGENT-PROMPTS.md
+++ b/docs/SRE-AGENT-PROMPTS.md
@@ -128,7 +128,7 @@ Use this prompt chain for the `complete-failure-bundle` scenario.
 | "Separate root cause from downstream symptoms across services in the energy namespace" | Forces dependency-aware analysis instead of symptom chasing |
 | "Recommend a prioritized recovery plan with dependencies first" | Produces staged remediation sequence |
 | "After each recovery step, re-check health and tell me the next safest action" | Keeps remediation iterative and validated |
-| "Verify that meter-service endpoints, MongoDB availability, and network access are all healthy" | Confirms recovery across API path + data layer + connectivity |
+| "Verify that meter-service endpoints, MongoDB availability, RabbitMQ availability, and network access are all healthy" | Confirms recovery across API path + data layer + event bus + connectivity |
 
 ### Root Cause Analysis
 

--- a/docs/evidence/scenarios/complete-failure-bundle/run-notes.md
+++ b/docs/evidence/scenarios/complete-failure-bundle/run-notes.md
@@ -43,6 +43,18 @@ kubectl get deployment mongodb -n energy
 # Paste output here
 ```
 
+```bash
+kubectl get deployment rabbitmq -n energy
+# Expected: READY 1/1
+# Paste output here
+```
+
+```bash
+kubectl get endpoints mongodb rabbitmq -n energy
+# Expected: populated with pod IPs
+# Paste output here
+```
+
 **Baseline timestamp:** `HH:MM UTC`
 
 ---
@@ -87,6 +99,7 @@ kubectl get events -n energy --sort-by=.lastTimestamp | tail -30
 
 **Agent identified root causes:**
 - [ ] MongoDB scaled to replicas: 0
+- [ ] RabbitMQ scaled to replicas: 0
 - [ ] NetworkPolicy deny-meter-service
 - [ ] Service selector mismatch (meter-service-v2)
 - [ ] Other: ___
@@ -116,7 +129,7 @@ kubectl get events -n energy --sort-by=.lastTimestamp | tail -30
 ---
 
 ### Prompt 4: Post-recovery verification
-**Prompt sent:** `"Verify that meter-service endpoints, MongoDB availability, and network access are all healthy"`
+**Prompt sent:** `"Verify that meter-service endpoints, MongoDB availability, RabbitMQ availability, and network access are all healthy"`
 
 **Agent response:**
 ```
@@ -138,8 +151,14 @@ kubectl apply -f k8s/base/application.yaml
 
 **Step 2 — Validate data layer and Service routing**
 ```bash
-kubectl get deployment mongodb -n energy
-# Expected: READY 1/1
+kubectl get deployment mongodb rabbitmq -n energy
+# Expected: READY 1/1 for both
+# Paste output here
+```
+
+```bash
+kubectl get endpoints mongodb rabbitmq -n energy
+# Expected: populated
 # Paste output here
 ```
 
@@ -173,8 +192,14 @@ kubectl get endpoints meter-service -n energy
 ```
 
 ```bash
-kubectl get deployment mongodb -n energy
-# Expected: READY 1/1
+kubectl get deployment mongodb rabbitmq -n energy
+# Expected: READY 1/1 for both
+# Paste output here
+```
+
+```bash
+kubectl get endpoints mongodb rabbitmq -n energy
+# Expected: populated
 # Paste output here
 ```
 
@@ -199,6 +224,7 @@ kubectl get networkpolicy -n energy
 | meter-service endpoints populated after recovery | ☐ PASS / ☐ FAIL |
 | deny-meter-service NetworkPolicy absent after recovery | ☐ PASS / ☐ FAIL |
 | MongoDB READY 1/1 after recovery | ☐ PASS / ☐ FAIL |
+| RabbitMQ READY 1/1 after recovery | ☐ PASS / ☐ FAIL |
 
 **Overall result:** ☐ PASS / ☐ FAIL / ☐ BLOCKED
 

--- a/docs/evidence/scenarios/complete-failure-bundle/run-notes.md
+++ b/docs/evidence/scenarios/complete-failure-bundle/run-notes.md
@@ -129,16 +129,30 @@ kubectl get events -n energy --sort-by=.lastTimestamp | tail -30
 
 > Record what you actually ran, in order.
 
-**Step 1 — Remove network isolation**
+**Step 1 — Restore dependency and Service specs**
 ```bash
-kubectl delete networkpolicy deny-meter-service -n energy
+kubectl apply -f k8s/base/application.yaml
 # Paste output here
 ```
 **Timestamp:** `HH:MM UTC`
 
-**Step 2 — Restore healthy baseline**
+**Step 2 — Validate data layer and Service routing**
 ```bash
-kubectl apply -f k8s/base/application.yaml
+kubectl get deployment mongodb -n energy
+# Expected: READY 1/1
+# Paste output here
+```
+
+```bash
+kubectl get endpoints meter-service -n energy
+# Expected: populated
+# Paste output here
+```
+**Timestamp:** `HH:MM UTC`
+
+**Step 3 — Remove remaining network isolation**
+```bash
+kubectl delete networkpolicy deny-meter-service -n energy
 # Paste output here
 ```
 **Timestamp:** `HH:MM UTC`

--- a/k8s/scenarios/complete-failure-bundle/README.md
+++ b/k8s/scenarios/complete-failure-bundle/README.md
@@ -13,6 +13,7 @@ kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
 | Area | Command | Expected signal |
 |------|---------|-----------------|
 | Data layer | `kubectl get deployment mongodb -n energy` | MongoDB desired/ready replicas are `0/0` |
+| Event bus | `kubectl get deployment rabbitmq -n energy` | RabbitMQ desired/ready replicas are `0/0` |
 | Service routing | `kubectl get endpoints meter-service -n energy` | Endpoint list is empty |
 | Network policy | `kubectl get networkpolicy deny-meter-service -n energy` | Deny policy exists |
 | Blast radius | `kubectl get pods,svc,endpoints -n energy` | Pods, Services, and endpoints disagree |
@@ -29,7 +30,8 @@ kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
 ```bash
 # Restore dependency and Service specs first.
 kubectl apply -f k8s/base/application.yaml
-kubectl get deployment mongodb -n energy
+kubectl get deployment mongodb rabbitmq -n energy
+kubectl get endpoints mongodb rabbitmq -n energy
 kubectl get endpoints meter-service -n energy
 
 # Remove the extra NetworkPolicy that baseline apply does not prune.
@@ -38,6 +40,6 @@ kubectl get pods -n energy
 kubectl get networkpolicy -n energy
 ```
 
-Expected recovery evidence: MongoDB is `READY 1/1`, `meter-service` endpoints are populated, `deny-meter-service` is absent, and application pods are `Running` / `Ready`.
+Expected recovery evidence: MongoDB and RabbitMQ are `READY 1/1`, dependency endpoints and `meter-service` endpoints are populated, `deny-meter-service` is absent, and application pods are `Running` / `Ready`.
 
 Record live portal output and screenshots in `docs/evidence/scenarios/complete-failure-bundle/run-notes.md`. If portal evidence is unavailable, mark the run as blocked instead of paraphrasing or fabricating SRE Agent output.

--- a/k8s/scenarios/complete-failure-bundle/README.md
+++ b/k8s/scenarios/complete-failure-bundle/README.md
@@ -1,0 +1,43 @@
+# Complete Failure Bundle
+
+This bundle demonstrates a broad energy grid application outage while preserving the demo-safe pattern: **SRE Agent recommends, operator executes**.
+
+## Inject
+
+```bash
+kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
+```
+
+## Expected degraded signals
+
+| Area | Command | Expected signal |
+|------|---------|-----------------|
+| Data layer | `kubectl get deployment mongodb -n energy` | MongoDB desired/ready replicas are `0/0` |
+| Service routing | `kubectl get endpoints meter-service -n energy` | Endpoint list is empty |
+| Network policy | `kubectl get networkpolicy deny-meter-service -n energy` | Deny policy exists |
+| Blast radius | `kubectl get pods,svc,endpoints -n energy` | Pods, Services, and endpoints disagree |
+
+## SRE Agent prompt chain
+
+1. "Why is the entire energy grid platform down?"
+2. "Separate root cause from downstream symptoms across services in the energy namespace"
+3. "Recommend a prioritized recovery plan with dependencies first"
+4. "After each recovery step, re-check health and tell me the next safest action"
+
+## Operator recovery sequence
+
+```bash
+# Restore dependency and Service specs first.
+kubectl apply -f k8s/base/application.yaml
+kubectl get deployment mongodb -n energy
+kubectl get endpoints meter-service -n energy
+
+# Remove the extra NetworkPolicy that baseline apply does not prune.
+kubectl delete networkpolicy deny-meter-service -n energy
+kubectl get pods -n energy
+kubectl get networkpolicy -n energy
+```
+
+Expected recovery evidence: MongoDB is `READY 1/1`, `meter-service` endpoints are populated, `deny-meter-service` is absent, and application pods are `Running` / `Ready`.
+
+Record live portal output and screenshots in `docs/evidence/scenarios/complete-failure-bundle/run-notes.md`. If portal evidence is unavailable, mark the run as blocked instead of paraphrasing or fabricating SRE Agent output.

--- a/k8s/scenarios/complete-failure-bundle/scenario.yaml
+++ b/k8s/scenarios/complete-failure-bundle/scenario.yaml
@@ -8,8 +8,8 @@
 # kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
 #
 # HOW TO FIX:
-# kubectl delete networkpolicy deny-meter-service -n energy
 # kubectl apply -f k8s/base/application.yaml
+# kubectl delete networkpolicy deny-meter-service -n energy
 # =============================================================================
 ---
 apiVersion: apps/v1

--- a/k8s/scenarios/complete-failure-bundle/scenario.yaml
+++ b/k8s/scenarios/complete-failure-bundle/scenario.yaml
@@ -2,7 +2,8 @@
 # SCENARIO BUNDLE: Complete Application Failure (Cascading Outage)
 # =============================================================================
 # Simulates broad platform unavailability by combining dependency outage,
-# network isolation, and service selector mismatch in one injection.
+# event-bus outage, network isolation, and service selector mismatch in one
+# injection.
 #
 # HOW TO BREAK:
 # kubectl apply -f k8s/scenarios/complete-failure-bundle/scenario.yaml
@@ -11,6 +12,101 @@
 # kubectl apply -f k8s/base/application.yaml
 # kubectl delete networkpolicy deny-meter-service -n energy
 # =============================================================================
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  namespace: energy
+  labels:
+    app: rabbitmq
+    scenario: complete-failure-bundle
+    sre-demo: breakable
+  annotations:
+    sre.scenario: complete-failure-bundle
+    sre.service: rabbitmq
+    sre.namespace: energy
+    sre.component: rabbitmq
+    sre.runbook_id: RB-011-complete-failure-bundle
+    sre.root_cause_category: dependency
+    sre.change_source: scenario-bundle
+    sre.version: "2026-05-01"
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+        scenario: complete-failure-bundle
+      annotations:
+        sre.scenario: complete-failure-bundle
+        sre.service: rabbitmq
+        sre.namespace: energy
+        sre.component: rabbitmq
+        sre.runbook_id: RB-011-complete-failure-bundle
+        sre.root_cause_category: dependency
+        sre.change_source: scenario-bundle
+        sre.version: "2026-05-01"
+    spec:
+      nodeSelector:
+        nodepool-type: user
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3.11-management-alpine
+          ports:
+            - containerPort: 5672
+              name: amqp
+            - containerPort: 15672
+              name: management
+          volumeMounts:
+            - name: rabbitmq-enabled-plugins
+              mountPath: /etc/rabbitmq/enabled_plugins
+              subPath: enabled_plugins
+              readOnly: true
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          livenessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "check_port_connectivity"]
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            timeoutSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "check_port_connectivity"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 15
+            failureThreshold: 6
+          env:
+            - name: RABBITMQ_PLUGINS
+              value: "rabbitmq_management rabbitmq_prometheus rabbitmq_amqp1_0"
+            - name: RABBITMQ_DEFAULT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-username
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: rabbitmq-password
+      volumes:
+        - name: rabbitmq-enabled-plugins
+          configMap:
+            name: rabbitmq-enabled-plugins
+            items:
+              - key: enabled_plugins
+                path: enabled_plugins
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -29,7 +125,7 @@ metadata:
     sre.runbook_id: RB-011-complete-failure-bundle
     sre.root_cause_category: dependency
     sre.change_source: scenario-bundle
-    sre.version: "2026-04-30"
+    sre.version: "2026-05-01"
 spec:
   replicas: 0
   strategy:
@@ -81,7 +177,7 @@ metadata:
     sre.runbook_id: RB-011-complete-failure-bundle
     sre.root_cause_category: networking
     sre.change_source: scenario-bundle
-    sre.version: "2026-04-30"
+    sre.version: "2026-05-01"
 spec:
   podSelector:
     matchLabels:
@@ -108,7 +204,7 @@ metadata:
     sre.runbook_id: RB-011-complete-failure-bundle
     sre.root_cause_category: configuration
     sre.change_source: scenario-bundle
-    sre.version: "2026-04-30"
+    sre.version: "2026-05-01"
 spec:
   selector:
     app: meter-service-v2


### PR DESCRIPTION
## Summary
- clarifies the complete-failure bundle as an advanced, operator-controlled recovery demo
- documents expected degraded Kubernetes signals for MongoDB, meter-service endpoints, NetworkPolicy isolation, and blast radius
- updates the operator recovery order to restore dependency/Service specs first, then delete the extra NetworkPolicy that baseline apply cannot prune
- adds bundle-local README guidance and aligns the evidence run-notes template with the recovery sequence

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; docs = YAML.load_stream(File.read('k8s/scenarios/complete-failure-bundle/scenario.yaml')); abort 'expected 3 docs' unless docs.length == 3; puts docs.map { |d| [d['kind'], d.dig('metadata','name')].join('/') }.join('\\n')"`
- `pwsh -NoProfile -File scripts/validate-scenario-metadata.ps1`

Closes #37