### PR TITLE
[codex] fix deployment retry, SRE Agent API pin, and grid map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure SRE Agent Energy Grid Demo Lab ⚡
 
-> **Azure SRE Agent is generally available (GA).** This lab currently keeps Bicep pinned to `Microsoft.App/agents@2025-05-01-preview` because the active subscription provider metadata exposes only that API version today. We will move to `2026-01-01` after provider exposure and successful `what-if` validation; track the gate in [SRE Agent API Rollout](docs/SRE-AGENT-API-ROLLOUT.md). Remediation remains operator-controlled unless real approval UI/API evidence is captured.
+> **Azure SRE Agent is generally available (GA).** This lab pins Bicep to `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`. If a subscription still exposes only older preview provider metadata, `scripts/deploy.ps1` skips SRE Agent rather than falling back to the legacy preview API. Remediation remains operator-controlled unless real approval UI/API evidence is captured.
 
 ## Why This Demo Exists
 
@@ -152,7 +152,7 @@ The full demo lab is the default when SRE Agent deployment is available; use `.\
 |---------|-------------|
 | `.\scripts\deploy.ps1 -Location eastus2` | Deploy all infrastructure to Azure |
 | `.\scripts\deploy.ps1 -WhatIf` | Preview what would be deployed |
-| `.\scripts\check-sre-agent-api-rollout.ps1 -ResourceGroupName <rg>` | Check whether `Microsoft.App/agents@2026-01-01` can be safely adopted |
+| `.\scripts\check-sre-agent-api-rollout.ps1 -ResourceGroupName <rg>` | Check whether the subscription exposes `Microsoft.App/agents@2026-01-01` |
 | `.\scripts\validate-deployment.ps1 -ResourceGroupName <rg>` | Verify resources and app are healthy |
 | `.\scripts\destroy.ps1 -ResourceGroupName <rg>` | Tear down all infrastructure |
 
@@ -204,7 +204,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 **⚠️ Important Notes:**
 
-- SRE Agent docs use GA-language; this lab still pins the ARM API to `Microsoft.App/agents@2025-05-01-preview` until issue #51 validation gates pass.
+- SRE Agent docs use GA-language; this lab pins the ARM API to `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`.
 - SRE Agent is available for this lab in **East US 2**, **Sweden Central**, and **Australia East**
 - AKS cluster must **NOT** be a private cluster for SRE Agent to access
 - Firewall must allow `*.azuresre.ai`

--- a/docs/ANALYST-SAFE-LANGUAGE.md
+++ b/docs/ANALYST-SAFE-LANGUAGE.md
@@ -124,7 +124,7 @@ For `node-capacity`, include the scope caveat:
 | Azure SRE Agent handoff | "For diagnosis and remediation recommendations, ask Azure SRE Agent in the portal and capture the transcript or screenshot as evidence." |
 | Read-only boundary | "Local Analyst is read-only and cannot deploy, destroy, patch, restart, or remediate resources." |
 | Missing data | "That data source is unavailable, so I cannot verify this from Local Analyst." |
-| Service/API status | "Azure SRE Agent is GA. This lab remains pinned to `Microsoft.App/agents@2025-05-01-preview` in this subscription until `2026-01-01` is exposed and validated." |
+| Service/API status | "Azure SRE Agent is GA. This lab pins `Microsoft.App/agents@2026-01-01` with the Stable channel." |
 
 ### Prohibited phrases unless backed by Azure SRE Agent evidence
 

--- a/docs/AZURE-SRE-AGENT-CUSTOMER-DELTAS.md
+++ b/docs/AZURE-SRE-AGENT-CUSTOMER-DELTAS.md
@@ -1,6 +1,6 @@
 # Azure SRE Agent Service Demo — Customer Readiness Delta Analysis
 
-> **Version**: 1.0 &middot; **Date**: 2026-04-25 &middot; **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2025-05-01-preview` in this subscription)
+> **Version**: 1.0 &middot; **Date**: 2026-04-25 &middot; **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2026-01-01`, Stable channel)
 > **Applicable regions**: East US 2, Sweden Central, Australia East
 > **Repo**: [`johnstel/azure-sre-agent-energy-grid`](https://github.com/johnstel/azure-sre-agent-energy-grid)
 
@@ -75,7 +75,7 @@ The demo deploys a three-tier, fully-IaC architecture via a single `main.bicep` 
 | **Compute** | AKS (Standard tier, public API, Azure CNI + Calico, OIDC + Workload Identity, Container Insights, Azure Policy addon, Key Vault Secrets Provider) | `infra/bicep/modules/aks.bicep` |
 | **Application** | 8 microservices in `energy` namespace: grid-dashboard (Vue.js), ops-console (Vue.js), meter-service (Node.js), asset-service (Rust), dispatch-service (Go), load-simulator (Python), RabbitMQ, MongoDB | `k8s/base/application.yaml` |
 | **Observability** | Log Analytics (30-day retention), App Insights (90-day retention), Managed Grafana, Azure Monitor Prometheus, 4 scheduled-query alert rules (opt-in) | `infra/bicep/main.bicep:134-268` |
-| **SRE Agent** | `Microsoft.App/agents@2025-05-01-preview` with user-assigned managed identity, `accessLevel: 'High'`, `mode: 'Review'` | `infra/bicep/modules/sre-agent.bicep:77-107` |
+| **SRE Agent** | `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`, user-assigned managed identity, `accessLevel: 'High'`, `mode: 'Review'` | `infra/bicep/modules/sre-agent.bicep:76-108` |
 | **Mission Control** | Local-only Fastify 5 + Vue 3 SPA. Includes "Ask Copilot" assistant (read-only, GitHub Copilot SDK). Binds to `127.0.0.1:3333`. | `mission-control/README.md` |
 
 **Key distinction**: Azure SRE Agent is the cloud-side AI diagnostic and remediation service (the product being demonstrated). Mission Control is a local demo cockpit for launching scenarios and viewing wallboard state. They share the same AKS cluster and observability stack but have no direct integration with each other.

--- a/docs/BREAKABLE-SCENARIOS.md
+++ b/docs/BREAKABLE-SCENARIOS.md
@@ -269,14 +269,14 @@ kubectl delete deployment grid-health-monitor -n energy
 
 ---
 
-### 7. Network Policy Blocking — Meter Service Isolated
+### 7. Network Policy Blocking — Meter Service and Portals Isolated
 
 **File:** `k8s/scenarios/network-block.yaml`
 
 **What happens:**
-- Applies NetworkPolicy that blocks all traffic to meter-service
+- Applies NetworkPolicies that block all traffic to meter-service, grid-dashboard, and ops-console
 - Meter service becomes isolated from the grid after a bad security policy update
-- Grid dashboard can't submit meter readings
+- Public demo portals stop responding through their LoadBalancer IPs
 
 **How to break:**
 ```bash
@@ -285,25 +285,27 @@ kubectl apply -f k8s/scenarios/network-block.yaml
 
 **What to observe:**
 ```bash
-# Test connectivity from grid-dashboard
-kubectl exec -n energy deploy/grid-dashboard -- curl -s meter-service:3000/health
-# Should timeout or fail
+# Test public portals and meter-service
+curl -m 8 http://<ops-console-ip>/?view=map
+curl -m 8 http://<grid-dashboard-ip>/
+kubectl exec -n energy deploy/asset-service -- curl -s --max-time 5 meter-service:3000/health
+# Should timeout, fail, or return no response
 ```
 
 **SRE Agent prompts:**
-- "Why can't the grid dashboard reach meter-service?"
+- "Why did the live demo portals and meter-service stop responding?"
 - "Diagnose network connectivity issues in the energy namespace"
 - "What network policies are blocking meter data ingestion?"
 
 **Pass/Fail Criteria:**
-- ✅ **PASS**: SRE Agent identifies NetworkPolicy blocking traffic to meter-service
+- ✅ **PASS**: SRE Agent identifies NetworkPolicies blocking traffic to meter-service and the public portal pods
 - ✅ **PASS**: Agent recommends removing or modifying the blocking network policy
 - ❌ **FAIL**: Agent does not check NetworkPolicies
 - ❌ **FAIL**: Agent attributes connectivity failure to DNS or application issues
 
 **How to fix:**
 ```bash
-kubectl delete networkpolicy deny-meter-service -n energy
+kubectl delete networkpolicy deny-meter-service deny-grid-dashboard deny-ops-console -n energy
 ```
 
 ---
@@ -519,8 +521,8 @@ kubectl get deployment mongodb rabbitmq -n energy
 kubectl get endpoints mongodb rabbitmq -n energy
 kubectl get endpoints meter-service -n energy
 
-# 3) Remove the extra NetworkPolicy that baseline apply does not delete
-kubectl delete networkpolicy deny-meter-service -n energy
+# 3) Remove the extra NetworkPolicies that baseline apply does not delete
+kubectl delete networkpolicy deny-meter-service deny-grid-dashboard deny-ops-console -n energy
 
 # 4) Verify platform recovery
 kubectl get pods -n energy

--- a/docs/CAPABILITY-CONTRACTS.md
+++ b/docs/CAPABILITY-CONTRACTS.md
@@ -1,7 +1,7 @@
 # Capability Contracts
 
 > **Version**: 0.2 · **Wave**: 0 — Contracts only, no runtime changes
-> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2025-05-01-preview` in this subscription)
+> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2026-01-01`, Stable channel)
 > **Repo**: [`johnstel/azure-sre-agent-energy-grid`](https://github.com/johnstel/azure-sre-agent-energy-grid)
 
 This document defines the shared contracts that every capability in the demo lab consumes. No implementation work should start for a wave until the contracts it depends on are locked here.
@@ -353,13 +353,13 @@ Azure SRE Agent is GA. App Insights telemetry emitted by the agent (custom dimen
 
 1. Any KQL query or dashboard that references SRE Agent-specific App Insights fields must be tagged with a `// SCHEMA_TBD` comment.
 2. Do not build production-grade dashboards or alerts against `SCHEMA_TBD` fields.
-3. When this subscription exposes `Microsoft.App/agents@2026-01-01` and `what-if` validates it, audit all `SCHEMA_TBD` references and update or remove the tag.
-4. Document observed field names in `docs/evidence/kql/README.md` with the preview API version where they were seen.
+3. Keep `SCHEMA_TBD` tags until live evidence captures the exact telemetry fields emitted by the deployed `Microsoft.App/agents@2026-01-01` resource.
+4. Document observed field names in `docs/evidence/kql/README.md` with the deployed API version where they were seen.
 
 ### Example
 
 ```kql
-// SCHEMA_TBD — observed in 2025-05-01-preview, may change
+// SCHEMA_TBD — observed field names may change across SRE Agent service/API versions
 traces
 | where customDimensions["sre.agent.conversationId"] != ""
 | project timestamp, message, customDimensions

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -199,7 +199,7 @@ SRE Agent uses Azure AI Units (AAU) billing:
 
 **Total SRE Agent cost:** ~$322-400/month
 
-Use `-SkipSreAgent` for the lower core-lab estimate. SRE Agent is a Preview resource type in this repository (`Microsoft.App/agents@2025-05-01-preview`); pricing, availability, and execution costs may change. Treat the SRE Agent line as a planning estimate and confirm actual charges in Azure Cost Management.
+Use `-SkipSreAgent` for the lower core-lab estimate. This repository pins the SRE Agent resource to `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`; pricing, regional availability, and execution costs may change. Treat the SRE Agent line as a planning estimate and confirm actual charges in Azure Cost Management.
 
 ## Cost Optimization Strategies
 

--- a/docs/CUSTOMER-LEAVE-BEHIND.md
+++ b/docs/CUSTOMER-LEAVE-BEHIND.md
@@ -1,10 +1,10 @@
 # Customer Leave-Behind: Azure SRE Agent Energy Grid Demo
 
-> **Azure SRE Agent is generally available (GA).** This lab currently uses `Microsoft.App/agents@2025-05-01-preview` because the active subscription provider metadata only exposes that API version today. This document is an evidence-safe summary of the demo lab and **requires Dallas approval before external customer use**.
+> **Azure SRE Agent is generally available (GA).** This lab pins `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`. If a subscription exposes only older preview provider metadata, deployment skips SRE Agent rather than falling back. This document is an evidence-safe summary of the demo lab and **requires Dallas approval before external customer use**.
 
 **Version date:** 2026-04-29
 
-**Valid for API version:** `2025-05-01-preview` · **Check for updates:** Ask your Microsoft contact for the latest version of this document before sharing internally. We will move to `2026-01-01` after provider exposure and successful `what-if` validation.
+**Valid for API version:** `2026-01-01` · **Check for updates:** Ask your Microsoft contact for the latest version of this document before sharing internally.
 
 ## What Azure SRE Agent Is
 

--- a/docs/DEMO-NARRATIVE.md
+++ b/docs/DEMO-NARRATIVE.md
@@ -1,7 +1,7 @@
 # Demo Narrative: Energy Grid SRE Agent
 
 > **Duration**: 20 minutes · **Audience**: SRE managers, security reviewers, executive buyers
-> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2025-05-01-preview` in this subscription)
+> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2026-01-01`, Stable channel)
 > **Pre-read**: [SAFE-LANGUAGE-GUARDRAILS.md](SAFE-LANGUAGE-GUARDRAILS.md) · [DEMO-RUNBOOK.md](DEMO-RUNBOOK.md)
 
 ---
@@ -191,7 +191,7 @@ For a 10-minute demo, use only scenarios 1 and 2. For a 5-minute demo, use scena
 |---|----------|-----------------|
 | 1 | "Can it break things?" | "In this Review-mode demo, treat agent output as recommendations. The operator decides what to execute; do not claim a specific approval/denial API unless portal evidence exists." |
 | 2 | "What permissions does it need?" | "Minimum: Reader + Log Analytics Reader (`accessLevel: 'Low'`). For remediation: add Contributor (`accessLevel: 'High'`). See our RBAC matrix in CAPABILITY-CONTRACTS.md §10." |
-| 3 | "Is this production-ready?" | "Azure SRE Agent is GA, but this demo lab is not a production blueprint. We keep operator-controlled remediation, broad demo permissions, and a `2025-05-01-preview` API pin in this subscription until `2026-01-01` is exposed and validated." |
+| 3 | "Is this production-ready?" | "Azure SRE Agent is GA, but this demo lab is not a production blueprint. We keep operator-controlled remediation and broad demo permissions, and we pin the ARM resource to `Microsoft.App/agents@2026-01-01` with the Stable channel. If a subscription exposes only older preview provider metadata, deployment skips SRE Agent rather than falling back." |
 | 4 | "What about auto-remediation?" | "Auto mode exists but we deliberately run in Review mode. Auto requires a separate security review — rollback procedures, blast radius containment, and kill-switch documentation." |
 | 5 | "Where's the audit trail?" | "SRE Agent operational telemetry is configured to App Insights; ARM-level actions appear in the Activity Log. Exact conversation/action fields are SCHEMA_TBD until verified in the deployed API version. We capture KQL evidence for every demo run." |
 | 6 | "What if the agent is wrong?" | "In Review mode for this demo, treat the output as a recommendation. If it's wrong, the operator does not execute it. Do not claim a specific reject/deny API unless the portal exposes it and you capture evidence." |

--- a/docs/DEMO-RUNBOOK.md
+++ b/docs/DEMO-RUNBOOK.md
@@ -354,7 +354,7 @@ Azure SRE Agent is **GA**. If the portal is unresponsive during a live demo:
 | Issue | Workaround |
 |-------|------------|
 | Port 3333 conflict with Mission Control | Change port in Mission Control config or stop conflicting process |
-| `managedResources: []` in SRE Agent | Current API-version limitation in this subscription (`2025-05-01-preview`) — add managed resources manually via Azure Portal after deployment |
+| `managedResources: []` in SRE Agent | Current lab configuration keeps managed resources explicit; add managed resources manually via Azure Portal after deployment if required for the scenario |
 | Public AKS API server required | Current SRE Agent deployment path in this lab requires a public endpoint; do not enable private cluster |
 | Deployment output scrolls past SRE Agent URL | Use Option B or C in Step 3 above |
 | RabbitMQ severity stickiness after recovery | Wallboard may show warning after fix-all; redeploy RabbitMQ if needed |
@@ -481,7 +481,7 @@ Verify SRE Agent App Insights telemetry schema and document observed fields:
   | take 10
   ```
 - [ ] **Document observed field names** in `docs/evidence/kql/README.md` under "Observed SRE Agent Telemetry Fields (SCHEMA_TBD)"
-  - Record: API version (`2025-05-01-preview`), date observed, field name, type, purpose
+  - Record: deployed API version, date observed, field name, type, purpose
   - Example: `customDimensions["sre.agent.conversationId"]`, string, "Unique conversation session ID"
 - [ ] Update `sre-agent-telemetry.kql` if field names differ from expected
 - [ ] Keep `// SCHEMA_TBD` comments in place until GA schema is confirmed

--- a/docs/GRID-MAP-SMOKE-TESTS.md
+++ b/docs/GRID-MAP-SMOKE-TESTS.md
@@ -1,8 +1,9 @@
 # Cloud Demo Grid Map — Scenario Smoke Tests
 
-> **Azure SRE Agent is generally available (GA).** This demo currently uses
-> `Microsoft.App/agents@2025-05-01-preview` because this subscription provider metadata exposes only that API
-> version. Move to `2026-01-01` after provider exposure and successful `what-if` validation.
+> **Azure SRE Agent is generally available (GA).** This demo pins
+> `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`. If a
+> subscription exposes only older preview provider metadata, deployment skips
+> SRE Agent rather than falling back.
 
 > **Safety Disclaimer** — This checklist covers the Interactive Grid Map in the deployed cloud demo
 > (`ops-console`). The grid map visualizes Kubernetes service/application health for the Azure SRE

--- a/docs/INTERACTIVE-GRID-MAP-SPEC.md
+++ b/docs/INTERACTIVE-GRID-MAP-SPEC.md
@@ -11,7 +11,7 @@
 
 > **This grid map is a demo topology visualization inside the deployed cloud demo, over Kubernetes service and application health signals.** It does not connect to real SCADA systems, GIS coordinates, utility telemetry, or production energy grids. All "substation," "transmission line," and "generator" labels are fictional energy-domain metaphors for the Kubernetes services deployed in the `energy` namespace.
 >
-> **Azure SRE Agent is generally available (GA).** This demo currently uses `Microsoft.App/agents@2025-05-01-preview` because this subscription provider metadata exposes only that API version. Move to `2026-01-01` after provider exposure and successful `what-if` validation.
+> **Azure SRE Agent is generally available (GA).** This demo pins `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`. If a subscription exposes only older preview provider metadata, deployment skips SRE Agent rather than falling back.
 >
 > The grid map must comply with the safe-language rules in [Safe Language Guardrails](SAFE-LANGUAGE-GUARDRAILS.md) and [Analyst Safe Language](ANALYST-SAFE-LANGUAGE.md). No element of this screen may claim real utility grid monitoring, autonomous remediation, or production-grade observability.
 

--- a/docs/SAFE-LANGUAGE-EVIDENCE-AUDIT.md
+++ b/docs/SAFE-LANGUAGE-EVIDENCE-AUDIT.md
@@ -22,7 +22,7 @@ Audited surfaces:
 
 | Check | Result | Notes |
 |-------|--------|-------|
-| GA + API-pin disclosure appears in customer-facing docs | Pass | README, narrative, leave-behind, and runbook disclose GA status plus the `2025-05-01-preview` subscription API pin caveat. |
+| GA + API-pin disclosure appears in customer-facing docs | Pass | README, narrative, leave-behind, and runbook disclose GA status plus the `Microsoft.App/agents@2026-01-01` Stable-channel pin and no-preview-fallback behavior. |
 | No MTTR percentage claims in audited customer-facing docs | Pass | Existing MTTR timestamp/model references remain measurement scaffolding, not improvement percentages. |
 | No autonomous-remediation claim | Pass | Wording consistently says Review mode, recommendations, and operator execution unless real approval evidence exists. |
 | No fabricated portal output or deterministic agent transcript | Pass after updates | Scenario highlights and Wave 1 evidence instructions now require real portal output rather than expected agent wording. |

--- a/docs/SAFE-LANGUAGE-GUARDRAILS.md
+++ b/docs/SAFE-LANGUAGE-GUARDRAILS.md
@@ -1,7 +1,7 @@
 # Safe Language Guardrails
 
 > **Audience**: Anyone presenting, writing about, or demoing the Energy Grid SRE Agent lab
-> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2025-05-01-preview` in this subscription)
+> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2026-01-01`, Stable channel)
 > **Rule**: Every customer-facing artifact must reference this document before publication
 
 This document prevents accidental overclaiming. Review it before every demo.
@@ -28,7 +28,7 @@ This document prevents accidental overclaiming. Review it before every demo.
 | **Least Privilege** | "Production-grade RBAC" or "least-privilege permissions" | "The demo uses broad permissions for convenience. See our demo-vs-production RBAC matrix for what production deployments should look like." | Demo grants AKS Cluster Admin, subscription-scoped Reader, and other overbroad roles. These are documented as `⚠️ DEMO ONLY` in CAPABILITY-CONTRACTS.md §10. |
 | **Audit Evidence** | "Compliance-ready evidence package" | "We define evidence capture contracts (file paths, naming, MTTR timestamps) and populate them during demo runs. Full compliance packaging is a future wave." | Evidence folders exist but are empty placeholders until populated with real demo run artifacts. |
 | **Data Retention** | "Complete audit history" | "Log Analytics retains 90 days; App Insights retains 90 days. Activity Log export to Log Analytics is configured in Bicep but verify ingestion during live UAT before claiming full KQL queryability. See our retention table in CAPABILITY-CONTRACTS.md §11." | Retention is configured but live verification is needed before claiming complete audit evidence. |
-| **Status and API pin** | "API behavior is fully frozen in this tenant" | "Azure SRE Agent is GA. This lab currently uses `Microsoft.App/agents@2025-05-01-preview` because this subscription provider metadata exposes only that API version. Telemetry schemas may change across API versions." | Must appear in every customer-facing artifact, not just footers. |
+| **Status and API pin** | "API behavior is fully frozen in this tenant" | "Azure SRE Agent is GA. This lab pins `Microsoft.App/agents@2026-01-01` and `upgradeChannel: 'Stable'`. If a subscription exposes only older preview provider metadata, the deploy script skips SRE Agent instead of falling back." | Must appear in every customer-facing artifact, not just footers. |
 | **CI/CD Correlation** | "Commit-to-incident tracing" | "SRE Agent supports MCP integration with GitHub/Azure DevOps for commit-to-incident correlation — this is a natural extension." | No CI/CD pipeline exists in this demo. |
 
 ---
@@ -48,7 +48,7 @@ This document prevents accidental overclaiming. Review it before every demo.
 
 The following statement (or equivalent) must appear **prominently** in every customer-facing artifact:
 
-> **Azure SRE Agent is generally available (GA).** This demo lab currently uses `Microsoft.App/agents@2025-05-01-preview` because the active subscription provider metadata exposes only that API version. We will move to `2026-01-01` after provider exposure and successful `what-if` validation.
+> **Azure SRE Agent is generally available (GA).** This demo lab pins `Microsoft.App/agents@2026-01-01` and `upgradeChannel: 'Stable'`. If a subscription exposes only older preview provider metadata, the deploy script skips SRE Agent rather than silently deploying the legacy preview API.
 
 "Prominently" means: in the first section of the document, not in a footer or appendix.
 

--- a/docs/SRE-AGENT-API-RESEARCH.md
+++ b/docs/SRE-AGENT-API-RESEARCH.md
@@ -3,7 +3,7 @@
 > **Issue**: [#5 — Research SRE Agent REST API integration](https://github.com/johnstel/azure-sre-agent-energy-grid/issues/5)
 > **Owner**: Parker, project SRE Dev
 > **Date**: 2026-04-27
-> **Status**: Azure SRE Agent is GA. This lab remains pinned to `Microsoft.App/agents@2025-05-01-preview` because this subscription currently exposes only that API version.
+> **Status**: Azure SRE Agent is GA. This lab now pins `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`; subscriptions that expose only older preview provider metadata skip SRE Agent deployment instead of falling back.
 
 ## Executive verdict
 
@@ -123,8 +123,8 @@ Recommended demo language:
 
 | Risk | Evidence | Demo impact | Mitigation |
 |---|---|---|---|
-| Tenant/API-version behavior can change | Repo guardrails require GA status + API-pin disclosure; provider metadata in this subscription still exposes `2025-05-01-preview`. | API, telemetry schema, and portal UX can differ until `2026-01-01` is exposed and validated here. | Keep safe language in all customer-facing docs and demos. |
-| ARM API version drift | Repo setup references `Microsoft.App/agents@2025-05-01-preview`; current Microsoft Learn ARM template reference lists `Microsoft.App/agents@2026-01-01` as latest. | Infrastructure may need later review, but this spike must not modify Bicep. | Track separately with infra owner if deployment drift appears. |
+| Tenant/API-version behavior can change | Repo guardrails require GA status + API-pin disclosure; provider metadata in this subscription still exposes only the older preview API. | API, telemetry schema, and portal UX can differ until `2026-01-01` is exposed and validated here. | Keep safe language in all customer-facing docs and demos. |
+| ARM API version drift | Repo setup now references `Microsoft.App/agents@2026-01-01`; current Microsoft Learn ARM template reference lists it as latest. | Subscriptions without provider exposure skip SRE Agent deployment. | Re-run provider metadata and what-if validation before customer demo use. |
 | Chat/action API gap | Official docs reviewed do not document a supported chat/conversation/action endpoint and auth model. | Direct Mission Control integration could overclaim unsupported behavior. | Block direct API implementation until Microsoft publishes docs. |
 | Hook API is narrow | Hook API manages custom-agent hooks via REST API v2; it is not a conversation API. | Misusing hook API as integration proof would be misleading. | Document hooks as governance/customization only. |
 | Telemetry schema may vary | Audit docs document `customEvents` event types and fields, but repo guardrails currently mark exact fields as `SCHEMA_TBD` until verified in the deployed API version. | Demo evidence queries could fail or fields may differ. | Validate KQL in the customer's deployed agent before claiming specific fields. |

--- a/docs/SRE-AGENT-API-ROLLOUT.md
+++ b/docs/SRE-AGENT-API-ROLLOUT.md
@@ -1,23 +1,23 @@
 # SRE Agent API Rollout Tracker
 
-This lab deploys Azure SRE Agent with `Microsoft.App/agents@2025-05-01-preview` until the active subscription exposes and validates the `2026-01-01` API version.
+This lab deploys Azure SRE Agent with the latest documented GA ARM API, `Microsoft.App/agents@2026-01-01`, and `upgradeChannel: 'Stable'`. It does not fall back to the legacy preview API.
 
 ## Current status
 
-As of the latest issue #51 check, live provider metadata for `Microsoft.App/agents` in the demo subscription lists only:
+As of the latest check on May 7, 2026, live provider metadata for `Microsoft.App/agents` in the demo subscription lists only:
 
 ```text
 2025-05-01-preview
 ```
 
-That blocks the Bicep upgrade. Do not edit `infra/bicep/modules/sre-agent.bicep` to `2026-01-01` until all rollout gates below pass.
+That blocks SRE Agent deployment in this subscription. The Bicep module remains pinned to `2026-01-01`; `scripts/deploy.ps1` skips SRE Agent instead of deploying `2025-05-01-preview`.
 
 ## Rollout gates
 
 1. Provider metadata lists `Microsoft.App/agents@2026-01-01`.
-2. Deployment validation succeeds with a temporary `2026-01-01` candidate module.
-3. Deployment what-if succeeds and shows no replacement or delete for the existing SRE Agent resource.
-4. Dallas/Lambert owners confirm go/no-go before merge and deployment.
+2. Deployment validation succeeds with the checked-in `2026-01-01` module.
+3. Deployment what-if succeeds and shows no replacement or delete for any existing SRE Agent resource.
+4. Dallas/Lambert owners confirm go/no-go before customer demo use.
 
 Run the gate script from the repo root:
 
@@ -39,12 +39,10 @@ Exit codes are:
 | `1` | Script, validation, or what-if failed |
 | `2` | Provider metadata does not expose the target API version yet |
 
-## Upgrade procedure after gates pass
+## Validation procedure after provider exposure
 
-1. Update `infra/bicep/modules/sre-agent.bicep` from `Microsoft.App/agents@2025-05-01-preview` to `Microsoft.App/agents@2026-01-01`.
-2. Remove the `#disable-next-line BCP081` suppression only if the local Bicep compiler recognizes the GA type.
-3. Run `.\scripts\check-sre-agent-api-rollout.ps1 -ResourceGroupName rg-srelab-eastus2`.
-4. Run the normal deployment validation path used for the demo environment.
-5. Update customer-facing status language in `README.md`, `docs/SRE-AGENT-SETUP.md`, and `docs/SAFE-LANGUAGE-GUARDRAILS.md`.
+1. Run `.\scripts\check-sre-agent-api-rollout.ps1 -ResourceGroupName rg-srelab-eastus2`.
+2. Run the normal deployment validation path used for the demo environment.
+3. Capture live portal evidence before making customer-facing claims about SRE Agent diagnosis behavior.
 
-Until this procedure completes, keep customer-facing language explicit: Azure SRE Agent is GA, but this lab remains pinned to the preview ARM API version because this subscription has not exposed the GA resource API.
+Until provider metadata exposes `2026-01-01`, keep customer-facing language explicit: Azure SRE Agent is GA, the lab is pinned to the GA ARM API, and the deploy script skips SRE Agent in subscriptions that expose only preview provider metadata.

--- a/docs/SRE-AGENT-SETUP.md
+++ b/docs/SRE-AGENT-SETUP.md
@@ -24,7 +24,7 @@ Before creating an SRE Agent, ensure you have:
 
 ### Automated via Bicep (Default)
 
-The SRE Agent is deployed automatically as part of `scripts/deploy.ps1` using the `Microsoft.App/agents@2025-05-01-preview` resource type. The deployment:
+The SRE Agent is deployed automatically as part of `scripts/deploy.ps1` using the `Microsoft.App/agents@2026-01-01` resource type and `upgradeChannel: 'Stable'`. The deployment:
 
 - Creates the SRE Agent resource
 - Creates a user-assigned managed identity
@@ -33,12 +33,8 @@ The SRE Agent is deployed automatically as part of `scripts/deploy.ps1` using th
 
 > **Access level**: `main.bicepparam` sets `sreAgentAccessLevel = 'High'` for the internal remediation demo. This is intentional — see `docs/SRE-AGENT-SETUP.md` for the access-level guide. For external demos, pass `-SreAgentAccessLevel Low` (the parameter default) to `deploy.ps1`.
 
-> **API version pin (issue #51)**: This lab uses `Microsoft.App/agents@2025-05-01-preview`. The `2026-01-01` GA version exists in ARM schema but has **not** been validated against this subscription. Track rollout in [SRE Agent API Rollout](SRE-AGENT-API-ROLLOUT.md), and do **not** change the API version until all three gates in issue #51 pass:
-> 1. `az provider show -n Microsoft.App --query "resourceTypes[?resourceType=='agents'].apiVersions"` lists `2026-01-01` for this subscription.
-> 2. `az deployment group validate` passes with a temporary `2026-01-01` candidate module.
-> 3. `az deployment group what-if` shows **no replacement or delete** of the existing SRE Agent resource.
-> Once gates pass, update the `resource sreAgent` declaration in `infra/bicep/modules/sre-agent.bicep` and remove the `#disable-next-line BCP081` suppression.
-> Use `.\scripts\check-sre-agent-api-rollout.ps1 -ResourceGroupName rg-srelab-eastus2` to run the repeatable gate check.
+> **API version pin**: This lab pins the latest documented GA ARM API, `Microsoft.App/agents@2026-01-01`, and does not fall back to the legacy preview API. If provider metadata in the active subscription has not exposed `2026-01-01` yet, `scripts/deploy.ps1` deploys the core lab and skips SRE Agent with a clear warning.
+> Use `.\scripts\check-sre-agent-api-rollout.ps1 -ResourceGroupName rg-srelab-eastus2 -MetadataOnly` to confirm provider metadata exposure before a demo.
 
 To skip SRE Agent deployment, set `deploySreAgent = false` in `infra/bicep/main.bicepparam`.
 

--- a/docs/SUPPORTABILITY.md
+++ b/docs/SUPPORTABILITY.md
@@ -1,7 +1,7 @@
 # Supportability Guide
 
 > **Audience**: Customer support engineers, SRE teams, and operators responsible for this demo lab
-> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2025-05-01-preview` in this subscription)
+> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2026-01-01`, Stable channel)
 > **Trust model**: Agent recommends, operator executes — unless real portal approval UI/API evidence is captured
 
 This document is the starting point for anyone supporting the Azure SRE Agent Energy Grid demo lab. It defines what is supportable, how to verify health, when to escalate, and how to restore a working state.
@@ -207,7 +207,7 @@ For the complete guardrail table, see [Safe Language Guardrails](SAFE-LANGUAGE-G
 
 | Limitation | Impact | Workaround | Reference |
 |------------|--------|------------|-----------|
-| API version pinned to `2025-05-01-preview` | Cannot use `2026-01-01` GA features until provider validates | Wait for issue #51 gates to pass | [SRE Agent Setup](SRE-AGENT-SETUP.md) |
+| Subscription provider metadata may expose only preview API versions | SRE Agent deployment is skipped instead of falling back to a legacy preview API | Wait for `Microsoft.App/agents@2026-01-01` provider exposure, then rerun deployment | [SRE Agent Setup](SRE-AGENT-SETUP.md) |
 | `maxPods=30` on existing node pools | Pod scheduling pressure at scale | Maintenance-window node pool replacement | [AKS maxPods Runbook](AKS-MAXPODS-MAINTENANCE-RUNBOOK.md) |
 | `SCHEMA_TBD` telemetry fields | SRE Agent App Insights dimensions may change | Do not build production dashboards against these fields | [Capability Contracts §8](CAPABILITY-CONTRACTS.md) |
 | Private clusters not supported | SRE Agent cannot access private API servers | Use public or authorized-IP clusters | [SRE Agent Setup](SRE-AGENT-SETUP.md) |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,7 +1,7 @@
 # Troubleshooting Guide
 
 > **Audience**: Operators and support engineers diagnosing issues in the Energy Grid demo lab
-> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2025-05-01-preview`)
+> **Status**: Azure SRE Agent is **GA** (lab API pin: `Microsoft.App/agents@2026-01-01`, Stable channel)
 > **Trust model**: Agent recommends, operator executes
 
 This guide is organized by **symptom**. Start with what you observe, follow the decision tree to the right section, and each section gives you diagnosis, fix, and verification steps.

--- a/docs/evidence/wave3-live/README.md
+++ b/docs/evidence/wave3-live/README.md
@@ -5,7 +5,7 @@
 **Scope**: Azure SRE Agent Service capabilities only — **Mission Control is out of scope**
 **Current verdict recommendation**: 🟡 `PASS_WITH_PENDING_HUMAN_PORTAL`
 
-> **GA/lab API disclosure**: Azure SRE Agent is generally available, but this lab currently pins `Microsoft.App/agents@2025-05-01-preview` because the active subscription provider metadata exposes only that API version. This evidence package documents only what this repo can prove. Where the deployed service or portal has not been human-validated, the status remains pending and must not be presented as proven.
+> **GA/lab API disclosure**: Azure SRE Agent is generally available, and this lab pins `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`. If a subscription exposes only older preview provider metadata, deployment skips the SRE Agent instead of falling back to the legacy preview API. This evidence package documents only what this repo can prove. Where the deployed service or portal has not been human-validated, the status remains pending and must not be presented as proven.
 
 ---
 

--- a/docs/scenario-narration.json
+++ b/docs/scenario-narration.json
@@ -76,7 +76,7 @@
         }
       ],
       "safetyNotes": [
-        "Azure SRE Agent is GA; this lab remains pinned to Microsoft.App/agents@2025-05-01-preview in the current subscription, and you should not describe a live diagnosis unless real portal evidence is captured.",
+        "Azure SRE Agent is GA; this lab pins Microsoft.App/agents@2026-01-01 with the Stable channel, and you should not describe a live diagnosis unless real portal evidence is captured.",
         "Frame remediation as recommendation-first; the operator executes recovery in this demo."
       ]
     },
@@ -312,26 +312,26 @@
     },
     {
       "scenarioName": "network-block",
-      "title": "Network Block \u2014 Meter Service Isolated",
+      "title": "Network Block \u2014 Portals and Meter Service Isolated",
       "demoTier": "extended",
       "order": 3,
       "hook": [
-        "You have meter-service isolated by a NetworkPolicy after a security policy update."
+        "You have the live portals and meter-service isolated by NetworkPolicies after a security policy update."
       ],
       "observe": [
         "Check Mission Control Scenarios tile for one active fault.",
         "Open Mission Control Active Incidents for dependent workload symptoms.",
-        "Run kubectl exec -n energy deploy/grid-dashboard -- curl -s meter-service:3000/health to test reachability.",
+        "Run kubectl get svc -n energy to get the Grid Dashboard and Ops Console public IPs, then curl both; they should fail while pods remain Running.",
         "Run kubectl get networkpolicy -n energy to inspect policy changes."
       ],
       "suggestedPrompt": {
         "stage": "specific",
-        "text": "Are there any network policies blocking traffic in the energy namespace?",
+        "text": "Are there any network policies blocking the live portals or meter traffic in the energy namespace?",
         "source": "docs/SRE-AGENT-PROMPTS.md"
       },
       "restorePath": {
-        "label": "Operator Restore: use Mission Control Repair All if available. Manual Restore: delete the blocking NetworkPolicy.",
-        "command": "kubectl delete networkpolicy deny-meter-service -n energy",
+        "label": "Operator Restore: use Mission Control Repair All if available. Manual Restore: delete the blocking NetworkPolicies.",
+        "command": "kubectl delete networkpolicy deny-meter-service deny-grid-dashboard deny-ops-console -n energy",
         "missionControlAction": "repair-all"
       },
       "sourceRefs": [

--- a/docs/spikes/ux-mission-control-narration-panel-spike.md
+++ b/docs/spikes/ux-mission-control-narration-panel-spike.md
@@ -112,7 +112,7 @@ The active wallboard surface is `MissionWallboard.vue`, where scenario buttons l
 
 The narration panel is customer-facing presenter support. It must inherit the constraints in `docs/SAFE-LANGUAGE-GUARDRAILS.md`, especially:
 
-- Azure SRE Agent is GA, while this lab remains pinned to `Microsoft.App/agents@2025-05-01-preview` in the current subscription.
+- Azure SRE Agent is GA, while this lab pins `Microsoft.App/agents@2026-01-01` with the Stable channel and skips SRE Agent deployment if a subscription exposes only older preview provider metadata.
 - Say "diagnoses issues you point it to" rather than "autonomously detects incidents."
 - Say "recommends; operator executes" for this demo unless real approval evidence exists.
 - Do not claim production readiness, production-grade RBAC, full audit trail, or quantified MTTR reduction.

--- a/infra/bicep/modules/sre-agent.bicep
+++ b/infra/bicep/modules/sre-agent.bicep
@@ -3,7 +3,7 @@
 // =============================================================================
 // Deploys an Azure SRE Agent with managed identity and role assignments.
 // Based on: https://github.com/microsoft/sre-agent/tree/main/samples/bicep-deployment
-// Resource type: Microsoft.App/agents@2025-05-01-preview
+// Resource type: Microsoft.App/agents@2026-01-01
 // =============================================================================
 
 @description('Name of the SRE Agent')
@@ -73,8 +73,7 @@ resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = 
 }]
 
 // SRE Agent
-#disable-next-line BCP081
-resource sreAgent 'Microsoft.App/agents@2025-05-01-preview' = {
+resource sreAgent 'Microsoft.App/agents@2026-01-01' = {
   name: agentName
   location: location
   tags: tags
@@ -100,6 +99,7 @@ resource sreAgent 'Microsoft.App/agents@2025-05-01-preview' = {
         connectionString: appInsightsConnectionString
       }
     }
+    upgradeChannel: 'Stable'
   }
   dependsOn: [
     roleAssignments

--- a/k8s/base/application.yaml
+++ b/k8s/base/application.yaml
@@ -852,15 +852,21 @@ data:
       .grid-map-svg:focus-visible { outline: 3px solid rgba(34,211,238,.6); outline-offset: -3px; }
       .map-fallback { position: absolute; inset: 0; display: grid; place-items: center; padding: 2rem; text-align: center; background: rgba(15,23,42,.96); color: var(--muted); line-height: 1.5; }
       .map-fallback[hidden] { display: none; }
-      .map-edge { stroke: #64748b; stroke-width: 2.4; fill: none; opacity: .82; }
+      .map-edge { stroke: #64748b; stroke-width: 2.6; fill: none; opacity: .82; stroke-linecap: square; stroke-linejoin: miter; }
       .map-edge.healthy { stroke: var(--green); opacity: .86; }
       .map-edge.warning { stroke: var(--amber); stroke-width: 3; opacity: .9; }
       .map-edge.critical { stroke: var(--red); stroke-width: 3.4; opacity: .95; filter: drop-shadow(0 0 6px rgba(248,113,113,.45)); }
       .map-edge.unknown { stroke: #94a3b8; stroke-dasharray: 8 7; opacity: .58; }
       .map-edge.disabled { stroke: #94a3b8; stroke-dasharray: 3 7; opacity: .5; }
+      .map-edge.transmission { stroke-width: 4; }
+      .map-edge.distribution { stroke-width: 3; }
+      .map-edge.control { stroke-dasharray: 7 6; stroke-width: 2.2; }
       .map-edge-label { fill: #cbd5e1; font-size: 11px; paint-order: stroke; stroke: #020617; stroke-width: 4px; stroke-linejoin: round; }
+      .map-busbar { stroke: #cbd5e1; stroke-width: 3.2; stroke-linecap: square; opacity: .8; }
+      .map-busbar-label { fill: #94a3b8; font-size: 10px; letter-spacing: .08em; text-transform: uppercase; paint-order: stroke; stroke: #020617; stroke-width: 4px; stroke-linejoin: round; }
       .map-node .node-box { fill: #182338; stroke: #475569; stroke-width: 1.5; filter: drop-shadow(0 10px 18px rgba(2,6,23,.45)); }
       .map-node.service .node-box { stroke: rgba(34,211,238,.65); }
+      .map-node-symbol-shape { fill: none; stroke: #e2e8f0; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; opacity: .9; pointer-events: none; }
       .map-node.datastore .node-box, .map-node.datastore .node-cap { fill: #14213a; stroke: rgba(167,139,250,.75); stroke-width: 1.5; }
       .map-node.healthy .node-box, .map-node.datastore.healthy .node-box, .map-node.datastore.healthy .node-cap { fill: rgba(6,78,59,.92); stroke: var(--green); stroke-width: 2.2; filter: drop-shadow(0 0 14px rgba(52,211,153,.36)); }
       .map-node.warning .node-box, .map-node.datastore.warning .node-box, .map-node.datastore.warning .node-cap { fill: rgba(120,53,15,.92); stroke: var(--amber); stroke-width: 2.4; filter: drop-shadow(0 0 14px rgba(251,191,36,.34)); }
@@ -1141,30 +1147,28 @@ data:
        namespace: 'energy',
        disclaimer: 'Demo electrical-grid model only. Asset colors are driven by approved lab health endpoints and static scenario context; this is not connected to real SCADA, GIS, OMS, or utility operations.',
        nodes: [
-         { id: 'north-generation', label: 'North Gen', resourceName: 'asset-service', metaphor: '230 kV generation', kind: 'generation', position: { x: 90, y: 100 }, healthSource: 'live', healthPath: '/api/assets/health', stateNote: 'Demo signal: asset-service health represents generation/asset telemetry availability.' },
-         { id: 'west-wind', label: 'West Wind', resourceName: 'asset-service', metaphor: '115 kV wind tie', kind: 'generation', position: { x: 90, y: 280 }, healthSource: 'static', nominal: true },
-         { id: 'grid-control', label: 'Grid Control', resourceName: 'dispatch-service', metaphor: 'Balancing authority', kind: 'control', position: { x: 360, y: 40 }, healthSource: 'live', healthPath: '/api/dispatch/health', stateNote: 'Demo signal: dispatch-service health represents control and dispatch availability.' },
-         { id: 'north-substation', label: 'North Substation', resourceName: 'asset-service', metaphor: 'Transmission node', kind: 'substation', position: { x: 360, y: 220 }, healthSource: 'live', healthPath: '/api/assets/health' },
-         { id: 'battery-reserve', label: 'Battery Reserve', resourceName: 'asset-service', metaphor: 'Grid storage', kind: 'storage', position: { x: 360, y: 500 }, healthSource: 'static', nominal: true },
-         { id: 'east-substation', label: 'East Substation', resourceName: 'dispatch-service', metaphor: 'Distribution node', kind: 'substation', position: { x: 610, y: 170 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
-         { id: 'south-substation', label: 'South Substation', resourceName: 'dispatch-service', metaphor: 'Distribution node', kind: 'substation', position: { x: 610, y: 370 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
-         { id: 'ami-feeder', label: 'AMI Feeder A', resourceName: 'meter-service', metaphor: 'Smart meter circuit', kind: 'feeder', position: { x: 860, y: 100 }, healthSource: 'live', healthPath: '/api/meter/health', stateNote: 'Demo signal: meter-service health represents AMI telemetry and customer outage visibility.' },
-         { id: 'hospital-feeder', label: 'Hospital Feeder', resourceName: 'meter-service', metaphor: 'Critical load circuit', kind: 'feeder', position: { x: 860, y: 300 }, healthSource: 'live', healthPath: '/api/meter/health' },
-         { id: 'residential-feeder', label: 'Residential Feed', resourceName: 'load-simulator', metaphor: 'Customer load zone', kind: 'feeder', position: { x: 860, y: 500 }, healthSource: 'static', nominal: true }
+         { id: 'north-generation', label: 'North Gen', resourceName: 'asset-service', metaphor: '230 kV generation', kind: 'generation', position: { x: 70, y: 80 }, healthSource: 'live', healthPath: '/api/assets/health', stateNote: 'Demo signal: asset-service health represents generation/asset telemetry availability.' },
+         { id: 'west-wind', label: 'West Wind', resourceName: 'asset-service', metaphor: '115 kV wind tie', kind: 'generation', position: { x: 70, y: 210 }, healthSource: 'static', nominal: true },
+         { id: 'grid-control', label: 'Grid Control', resourceName: 'dispatch-service', metaphor: 'Balancing authority', kind: 'control', position: { x: 320, y: 38 }, healthSource: 'live', healthPath: '/api/dispatch/health', stateNote: 'Demo signal: dispatch-service health represents control and dispatch availability.' },
+         { id: 'north-substation', label: 'North Substation', resourceName: 'asset-service', metaphor: 'Transmission bus', kind: 'substation', position: { x: 320, y: 185 }, healthSource: 'live', healthPath: '/api/assets/health' },
+         { id: 'battery-reserve', label: 'Battery Reserve', resourceName: 'asset-service', metaphor: 'Grid storage', kind: 'storage', position: { x: 320, y: 430 }, healthSource: 'static', nominal: true },
+         { id: 'east-substation', label: 'East Substation', resourceName: 'dispatch-service', metaphor: 'Distribution bus', kind: 'substation', position: { x: 585, y: 185 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
+         { id: 'south-substation', label: 'South Substation', resourceName: 'dispatch-service', metaphor: 'Distribution bus', kind: 'substation', position: { x: 585, y: 430 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
+         { id: 'ami-feeder', label: 'AMI Feeder A', resourceName: 'meter-service', metaphor: 'Smart meter circuit', kind: 'feeder', position: { x: 840, y: 95 }, healthSource: 'live', healthPath: '/api/meter/health', stateNote: 'Demo signal: meter-service health represents AMI telemetry and customer outage visibility.' },
+         { id: 'hospital-feeder', label: 'Hospital Feeder', resourceName: 'meter-service', metaphor: 'Critical load circuit', kind: 'feeder', position: { x: 840, y: 285 }, healthSource: 'live', healthPath: '/api/meter/health' },
+         { id: 'residential-feeder', label: 'Residential Feed', resourceName: 'load-simulator', metaphor: 'Customer load zone', kind: 'feeder', position: { x: 840, y: 475 }, healthSource: 'static', nominal: true }
        ],
        edges: [
-         { source: 'north-generation', target: 'north-substation', label: '230 kV gen tie', type: 'transmission' },
-         { source: 'west-wind', target: 'north-substation', label: '115 kV wind tie', type: 'transmission' },
-         { source: 'grid-control', target: 'north-substation', label: 'SCADA control', type: 'control' },
-         { source: 'grid-control', target: 'east-substation', label: 'Dispatch control', type: 'control' },
-         { source: 'grid-control', target: 'south-substation', label: 'Dispatch control', type: 'control' },
-         { source: 'north-substation', target: 'east-substation', label: '230 kV backbone', type: 'transmission' },
-         { source: 'north-substation', target: 'battery-reserve', label: '34.5 kV storage tie', type: 'distribution' },
-         { source: 'battery-reserve', target: 'south-substation', label: 'Reserve support', type: 'distribution' },
-         { source: 'east-substation', target: 'ami-feeder', label: '13.8 kV feeder A', type: 'distribution' },
-         { source: 'east-substation', target: 'hospital-feeder', label: 'Critical feeder', type: 'distribution' },
-         { source: 'south-substation', target: 'residential-feeder', label: '13.8 kV feeder C', type: 'distribution' },
-         { source: 'ami-feeder', target: 'residential-feeder', label: 'AMI outage reports', type: 'telemetry' }
+         { source: 'north-generation', target: 'north-substation', label: '230 kV gen tie', type: 'transmission', route: [[246, 118], [320, 118], [320, 223]], labelPosition: { x: 257, y: 108 } },
+         { source: 'west-wind', target: 'north-substation', label: '115 kV wind tie', type: 'transmission', route: [[246, 248], [285, 248], [285, 223], [320, 223]], labelPosition: { x: 252, y: 268 } },
+         { source: 'grid-control', target: 'north-substation', label: 'SCADA control', type: 'control', route: [[408, 114], [408, 185]], labelPosition: { x: 426, y: 151 } },
+         { source: 'grid-control', target: 'east-substation', label: 'Dispatch control', type: 'control', route: [[496, 76], [673, 76], [673, 185]], labelPosition: { x: 585, y: 65 } },
+         { source: 'north-substation', target: 'east-substation', label: '230 kV backbone', type: 'transmission', route: [[496, 223], [585, 223]], labelPosition: { x: 540, y: 211 } },
+         { source: 'north-substation', target: 'battery-reserve', label: '34.5 kV storage tie', type: 'distribution', route: [[408, 261], [408, 430]], labelPosition: { x: 425, y: 348 } },
+         { source: 'battery-reserve', target: 'south-substation', label: 'Reserve support', type: 'distribution', route: [[496, 468], [585, 468]], labelPosition: { x: 541, y: 456 } },
+         { source: 'east-substation', target: 'ami-feeder', label: '13.8 kV feeder A', type: 'distribution', route: [[761, 205], [805, 205], [805, 133], [840, 133]], labelPosition: { x: 785, y: 194 } },
+         { source: 'east-substation', target: 'hospital-feeder', label: 'Critical feeder', type: 'distribution', route: [[761, 241], [805, 241], [805, 323], [840, 323]], labelPosition: { x: 785, y: 262 } },
+         { source: 'south-substation', target: 'residential-feeder', label: '13.8 kV feeder C', type: 'distribution', route: [[761, 468], [840, 468], [840, 513]], labelPosition: { x: 798, y: 456 } }
        ]
       };
       const MAP_NODE = { width: 176, height: 76 };
@@ -1288,6 +1292,15 @@ data:
         if (result.severity === 'warning') return 'warning - HTTP ' + result.httpStatus;
         if (result.severity === 'critical') return 'critical - HTTP ' + result.httpStatus;
         return 'unknown';
+      }
+
+      function gridStateTextForResult(result) {
+        if (!result) return 'checking grid signal';
+        if (result.reason === 'network') return 'signal unreachable';
+        if (result.severity === 'healthy') return 'grid normal';
+        if (result.severity === 'warning') return 'fault indicator';
+        if (result.severity === 'critical') return 'outage indicator';
+        return 'unknown grid state';
       }
 
       function fetchLiveHealth(node) {
@@ -1417,9 +1430,9 @@ data:
           const result = mapState.healthById[node.id];
           if (!result) return { text: 'checking live health', className: 'unknown', severity: 'unknown', symbol: '?' };
           const symbol = result.severity === 'healthy' ? '✓' : result.severity === 'warning' ? '!' : '×';
-          return { text: healthTextForResult(result), className: result.severity, severity: result.severity, symbol };
+          return { text: gridStateTextForResult(result), className: result.severity, severity: result.severity, symbol };
         }
-        if (node.nominal) return { text: 'nominal - static demo', className: 'healthy', severity: 'healthy', symbol: '✓' };
+        if (node.nominal) return { text: 'grid normal', className: 'healthy', severity: 'healthy', symbol: '✓' };
          return { text: 'static demo context', className: 'static', severity: 'unknown', symbol: 'S' };
       }
 
@@ -1868,10 +1881,49 @@ data:
        return { x: a.x + dx / scale, y: a.y + dy / scale };
      }
 
+     function routePath(points) {
+       return points.map(function(point, index) {
+         return (index === 0 ? 'M ' : 'L ') + point[0] + ' ' + point[1];
+       }).join(' ');
+     }
+
+     function edgeRoute(edge, source, target) {
+       if (edge.route && edge.route.length >= 2) return edge.route;
+       const start = edgeAnchor(source, target);
+       const end = edgeAnchor(target, source);
+       const midX = Math.round((start.x + end.x) / 2);
+       return [[Math.round(start.x), Math.round(start.y)], [midX, Math.round(start.y)], [midX, Math.round(end.y)], [Math.round(end.x), Math.round(end.y)]];
+     }
+
+     function edgeLabelPosition(edge, points) {
+       if (edge.labelPosition) return edge.labelPosition;
+       const midpoint = points[Math.floor(points.length / 2)];
+       return { x: midpoint[0], y: midpoint[1] - 10 };
+     }
+
+     function renderElectricalSymbol(group, node, x, y) {
+       const sx = x + MAP_NODE.width - 28;
+       const sy = y + MAP_NODE.height - 24;
+       const symbol = createSvgElement('g', { class: 'map-node-symbol-shape', 'aria-hidden': 'true' });
+       if (node.kind === 'generation') {
+         symbol.appendChild(createSvgElement('circle', { cx: sx, cy: sy, r: 11 }));
+         symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 7) + ' ' + sy + ' C ' + (sx - 3) + ' ' + (sy - 8) + ' ' + (sx + 3) + ' ' + (sy + 8) + ' ' + (sx + 7) + ' ' + sy }));
+       } else if (node.kind === 'substation') {
+         symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 12) + ' ' + (sy - 8) + ' L ' + (sx + 12) + ' ' + (sy - 8) + ' M ' + (sx - 12) + ' ' + sy + ' L ' + (sx + 12) + ' ' + sy + ' M ' + (sx - 12) + ' ' + (sy + 8) + ' L ' + (sx + 12) + ' ' + (sy + 8) }));
+       } else if (node.kind === 'feeder') {
+         symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 12) + ' ' + sy + ' L ' + (sx - 4) + ' ' + sy + ' M ' + (sx - 4) + ' ' + (sy - 8) + ' L ' + (sx - 4) + ' ' + (sy + 8) + ' M ' + (sx + 4) + ' ' + (sy - 8) + ' L ' + (sx + 4) + ' ' + (sy + 8) + ' M ' + (sx + 4) + ' ' + sy + ' L ' + (sx + 12) + ' ' + sy }));
+       } else if (node.kind === 'storage') {
+         symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 12) + ' ' + (sy - 8) + ' L ' + (sx - 12) + ' ' + (sy + 8) + ' M ' + (sx - 5) + ' ' + (sy - 5) + ' L ' + (sx - 5) + ' ' + (sy + 5) + ' M ' + (sx + 3) + ' ' + (sy - 8) + ' L ' + (sx + 3) + ' ' + (sy + 8) + ' M ' + (sx + 10) + ' ' + (sy - 5) + ' L ' + (sx + 10) + ' ' + (sy + 5) }));
+       } else {
+         symbol.appendChild(createSvgElement('path', { d: 'M ' + sx + ' ' + (sy - 12) + ' L ' + (sx + 12) + ' ' + sy + ' L ' + sx + ' ' + (sy + 12) + ' L ' + (sx - 12) + ' ' + sy + ' Z' }));
+       }
+       group.appendChild(symbol);
+     }
+
      function renderServiceNode(stage, node) {
        const status = getMapStatus(node);
        const group = createSvgElement('g', {
-          class: 'map-node service ' + status.className,
+          class: 'map-node service kind-' + node.kind + ' ' + status.className,
           tabindex: '0',
           role: 'button',
           'aria-label': node.label + ', ' + node.metaphor + ', ' + status.text + '. Activate to open details.',
@@ -1890,9 +1942,10 @@ data:
        const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 46, 'aria-hidden': 'true' });
        subtitle.textContent = node.metaphor;
        group.appendChild(subtitle);
-       const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64, 'aria-hidden': 'true' });
-       state.textContent = status.text;
-       group.appendChild(state);
+        const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64, 'aria-hidden': 'true' });
+        state.textContent = status.text;
+        group.appendChild(state);
+       renderElectricalSymbol(group, node, x, y);
        group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 18, ry: 18 }));
        group.appendChild(createSvgElement('rect', { class: 'node-focus-ring', x: x - 7, y: y - 7, width: MAP_NODE.width + 14, height: MAP_NODE.height + 14, rx: 21, ry: 21 }));
        if (mapState.selectedNodeId === node.id) group.classList.add('selected');
@@ -1937,47 +1990,46 @@ data:
        const stage = document.getElementById('grid-map-stage');
        if (!svg || !stage || mapState.rendered) return;
        stage.innerHTML = '';
-       const defs = createSvgElement('defs');
-       const marker = createSvgElement('marker', { id: 'map-arrowhead', viewBox: '0 0 10 10', refX: '9', refY: '5', markerWidth: '7', markerHeight: '7', orient: 'auto-start-reverse' });
-       marker.appendChild(createSvgElement('path', { d: 'M 0 0 L 10 5 L 0 10 z', fill: '#94a3b8' }));
-       defs.appendChild(marker);
-       stage.appendChild(defs);
 
        const nodesById = GRID_TOPOLOGY.nodes.reduce((acc, node) => {
          acc[node.id] = node;
          return acc;
        }, {});
 
+       [
+        { x1: 496, y1: 223, x2: 585, y2: 223, label: '230 kV bus', x: 540, y: 211 },
+        { x1: 761, y1: 205, x2: 840, y2: 205, label: '13.8 kV feeder bus', x: 801, y: 194 },
+        { x1: 761, y1: 468, x2: 840, y2: 468, label: '13.8 kV feeder bus', x: 801, y: 456 }
+       ].forEach(bus => {
+         stage.appendChild(createSvgElement('line', { class: 'map-busbar', x1: bus.x1, y1: bus.y1, x2: bus.x2, y2: bus.y2, 'aria-hidden': 'true' }));
+         const label = createSvgElement('text', { class: 'map-busbar-label', x: bus.x, y: bus.y, 'aria-hidden': 'true' });
+         label.textContent = bus.label;
+         stage.appendChild(label);
+       });
+
        GRID_TOPOLOGY.edges.forEach(edge => {
          const source = nodesById[edge.source];
           const target = nodesById[edge.target];
           if (!source || !target) return;
-           const start = edgeAnchor(source, target);
-           const end = edgeAnchor(target, source);
+           const points = edgeRoute(edge, source, target);
+           const pathData = routePath(points);
            const edgeStatus = getEdgeStatus(edge, source, target);
            const edgeKey = edge.source + ':' + edge.target;
-           const edgeLine = createSvgElement('line', {
-             class: 'map-edge ' + edgeStatus.className + (mapState.selectedEdgeKey === edgeKey ? ' selected' : ''),
-             x1: start.x,
-             y1: start.y,
-             x2: end.x,
-             y2: end.y,
-             'marker-end': 'url(#map-arrowhead)',
+           const edgeLine = createSvgElement('path', {
+             class: 'map-edge ' + (edge.type || 'distribution') + ' ' + edgeStatus.className + (mapState.selectedEdgeKey === edgeKey ? ' selected' : ''),
+             d: pathData,
              role: 'img',
              'aria-label': edge.label + ', ' + edgeStatus.label,
              'data-edge-key': edgeKey
            });
            stage.appendChild(edgeLine);
-           const edgeHit = createSvgElement('line', {
+           const edgeHit = createSvgElement('path', {
              class: 'map-edge-hit',
-             x1: start.x, y1: start.y, x2: end.x, y2: end.y,
+             d: pathData,
              'data-edge-key': edgeKey,
              'aria-hidden': 'true'
            });
            stage.appendChild(edgeHit);
-           const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle', 'aria-hidden': 'true' });
-           label.textContent = edge.label + (edgeStatus.className === 'unknown' ? ' · unknown' : edgeStatus.className === 'critical' ? ' · critical' : edgeStatus.className === 'warning' ? ' · warning' : '');
-           stage.appendChild(label);
         });
 
        GRID_TOPOLOGY.nodes.forEach(node => {

--- a/k8s/base/ops-console.html
+++ b/k8s/base/ops-console.html
@@ -61,15 +61,21 @@
   .grid-map-svg:focus-visible { outline: 3px solid rgba(34,211,238,.6); outline-offset: -3px; }
   .map-fallback { position: absolute; inset: 0; display: grid; place-items: center; padding: 2rem; text-align: center; background: rgba(15,23,42,.96); color: var(--muted); line-height: 1.5; }
   .map-fallback[hidden] { display: none; }
-  .map-edge { stroke: #64748b; stroke-width: 2.4; fill: none; opacity: .82; }
+  .map-edge { stroke: #64748b; stroke-width: 2.6; fill: none; opacity: .82; stroke-linecap: square; stroke-linejoin: miter; }
   .map-edge.healthy { stroke: var(--green); opacity: .86; }
   .map-edge.warning { stroke: var(--amber); stroke-width: 3; opacity: .9; }
   .map-edge.critical { stroke: var(--red); stroke-width: 3.4; opacity: .95; filter: drop-shadow(0 0 6px rgba(248,113,113,.45)); }
   .map-edge.unknown { stroke: #94a3b8; stroke-dasharray: 8 7; opacity: .58; }
   .map-edge.disabled { stroke: #94a3b8; stroke-dasharray: 3 7; opacity: .5; }
+  .map-edge.transmission { stroke-width: 4; }
+  .map-edge.distribution { stroke-width: 3; }
+  .map-edge.control { stroke-dasharray: 7 6; stroke-width: 2.2; }
   .map-edge-label { fill: #cbd5e1; font-size: 11px; paint-order: stroke; stroke: #020617; stroke-width: 4px; stroke-linejoin: round; }
+  .map-busbar { stroke: #cbd5e1; stroke-width: 3.2; stroke-linecap: square; opacity: .8; }
+  .map-busbar-label { fill: #94a3b8; font-size: 10px; letter-spacing: .08em; text-transform: uppercase; paint-order: stroke; stroke: #020617; stroke-width: 4px; stroke-linejoin: round; }
   .map-node .node-box { fill: #182338; stroke: #475569; stroke-width: 1.5; filter: drop-shadow(0 10px 18px rgba(2,6,23,.45)); }
   .map-node.service .node-box { stroke: rgba(34,211,238,.65); }
+  .map-node-symbol-shape { fill: none; stroke: #e2e8f0; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; opacity: .9; pointer-events: none; }
   .map-node.datastore .node-box, .map-node.datastore .node-cap { fill: #14213a; stroke: rgba(167,139,250,.75); stroke-width: 1.5; }
   .map-node.healthy .node-box, .map-node.datastore.healthy .node-box, .map-node.datastore.healthy .node-cap { fill: rgba(6,78,59,.92); stroke: var(--green); stroke-width: 2.2; filter: drop-shadow(0 0 14px rgba(52,211,153,.36)); }
   .map-node.warning .node-box, .map-node.datastore.warning .node-box, .map-node.datastore.warning .node-cap { fill: rgba(120,53,15,.92); stroke: var(--amber); stroke-width: 2.4; filter: drop-shadow(0 0 14px rgba(251,191,36,.34)); }
@@ -350,30 +356,28 @@ const DISPATCH_TYPES = ['Load Balance', 'Frequency Adj', 'Capacity Shift', 'Emer
    namespace: 'energy',
    disclaimer: 'Demo electrical-grid model only. Asset colors are driven by approved lab health endpoints and static scenario context; this is not connected to real SCADA, GIS, OMS, or utility operations.',
    nodes: [
-     { id: 'north-generation', label: 'North Gen', resourceName: 'asset-service', metaphor: '230 kV generation', kind: 'generation', position: { x: 90, y: 100 }, healthSource: 'live', healthPath: '/api/assets/health', stateNote: 'Demo signal: asset-service health represents generation/asset telemetry availability.' },
-     { id: 'west-wind', label: 'West Wind', resourceName: 'asset-service', metaphor: '115 kV wind tie', kind: 'generation', position: { x: 90, y: 280 }, healthSource: 'static', nominal: true },
-     { id: 'grid-control', label: 'Grid Control', resourceName: 'dispatch-service', metaphor: 'Balancing authority', kind: 'control', position: { x: 360, y: 40 }, healthSource: 'live', healthPath: '/api/dispatch/health', stateNote: 'Demo signal: dispatch-service health represents control and dispatch availability.' },
-     { id: 'north-substation', label: 'North Substation', resourceName: 'asset-service', metaphor: 'Transmission node', kind: 'substation', position: { x: 360, y: 220 }, healthSource: 'live', healthPath: '/api/assets/health' },
-     { id: 'battery-reserve', label: 'Battery Reserve', resourceName: 'asset-service', metaphor: 'Grid storage', kind: 'storage', position: { x: 360, y: 500 }, healthSource: 'static', nominal: true },
-     { id: 'east-substation', label: 'East Substation', resourceName: 'dispatch-service', metaphor: 'Distribution node', kind: 'substation', position: { x: 610, y: 170 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
-     { id: 'south-substation', label: 'South Substation', resourceName: 'dispatch-service', metaphor: 'Distribution node', kind: 'substation', position: { x: 610, y: 370 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
-     { id: 'ami-feeder', label: 'AMI Feeder A', resourceName: 'meter-service', metaphor: 'Smart meter circuit', kind: 'feeder', position: { x: 860, y: 100 }, healthSource: 'live', healthPath: '/api/meter/health', stateNote: 'Demo signal: meter-service health represents AMI telemetry and customer outage visibility.' },
-     { id: 'hospital-feeder', label: 'Hospital Feeder', resourceName: 'meter-service', metaphor: 'Critical load circuit', kind: 'feeder', position: { x: 860, y: 300 }, healthSource: 'live', healthPath: '/api/meter/health' },
-     { id: 'residential-feeder', label: 'Residential Feed', resourceName: 'load-simulator', metaphor: 'Customer load zone', kind: 'feeder', position: { x: 860, y: 500 }, healthSource: 'static', nominal: true }
+     { id: 'north-generation', label: 'North Gen', resourceName: 'asset-service', metaphor: '230 kV generation', kind: 'generation', position: { x: 70, y: 80 }, healthSource: 'live', healthPath: '/api/assets/health', stateNote: 'Demo signal: asset-service health represents generation/asset telemetry availability.' },
+     { id: 'west-wind', label: 'West Wind', resourceName: 'asset-service', metaphor: '115 kV wind tie', kind: 'generation', position: { x: 70, y: 210 }, healthSource: 'static', nominal: true },
+     { id: 'grid-control', label: 'Grid Control', resourceName: 'dispatch-service', metaphor: 'Balancing authority', kind: 'control', position: { x: 320, y: 38 }, healthSource: 'live', healthPath: '/api/dispatch/health', stateNote: 'Demo signal: dispatch-service health represents control and dispatch availability.' },
+     { id: 'north-substation', label: 'North Substation', resourceName: 'asset-service', metaphor: 'Transmission bus', kind: 'substation', position: { x: 320, y: 185 }, healthSource: 'live', healthPath: '/api/assets/health' },
+     { id: 'battery-reserve', label: 'Battery Reserve', resourceName: 'asset-service', metaphor: 'Grid storage', kind: 'storage', position: { x: 320, y: 430 }, healthSource: 'static', nominal: true },
+     { id: 'east-substation', label: 'East Substation', resourceName: 'dispatch-service', metaphor: 'Distribution bus', kind: 'substation', position: { x: 585, y: 185 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
+     { id: 'south-substation', label: 'South Substation', resourceName: 'dispatch-service', metaphor: 'Distribution bus', kind: 'substation', position: { x: 585, y: 430 }, healthSource: 'live', healthPath: '/api/dispatch/health' },
+     { id: 'ami-feeder', label: 'AMI Feeder A', resourceName: 'meter-service', metaphor: 'Smart meter circuit', kind: 'feeder', position: { x: 840, y: 95 }, healthSource: 'live', healthPath: '/api/meter/health', stateNote: 'Demo signal: meter-service health represents AMI telemetry and customer outage visibility.' },
+     { id: 'hospital-feeder', label: 'Hospital Feeder', resourceName: 'meter-service', metaphor: 'Critical load circuit', kind: 'feeder', position: { x: 840, y: 285 }, healthSource: 'live', healthPath: '/api/meter/health' },
+     { id: 'residential-feeder', label: 'Residential Feed', resourceName: 'load-simulator', metaphor: 'Customer load zone', kind: 'feeder', position: { x: 840, y: 475 }, healthSource: 'static', nominal: true }
    ],
    edges: [
-     { source: 'north-generation', target: 'north-substation', label: '230 kV gen tie', type: 'transmission' },
-     { source: 'west-wind', target: 'north-substation', label: '115 kV wind tie', type: 'transmission' },
-     { source: 'grid-control', target: 'north-substation', label: 'SCADA control', type: 'control' },
-     { source: 'grid-control', target: 'east-substation', label: 'Dispatch control', type: 'control' },
-     { source: 'grid-control', target: 'south-substation', label: 'Dispatch control', type: 'control' },
-     { source: 'north-substation', target: 'east-substation', label: '230 kV backbone', type: 'transmission' },
-     { source: 'north-substation', target: 'battery-reserve', label: '34.5 kV storage tie', type: 'distribution' },
-     { source: 'battery-reserve', target: 'south-substation', label: 'Reserve support', type: 'distribution' },
-     { source: 'east-substation', target: 'ami-feeder', label: '13.8 kV feeder A', type: 'distribution' },
-     { source: 'east-substation', target: 'hospital-feeder', label: 'Critical feeder', type: 'distribution' },
-     { source: 'south-substation', target: 'residential-feeder', label: '13.8 kV feeder C', type: 'distribution' },
-     { source: 'ami-feeder', target: 'residential-feeder', label: 'AMI outage reports', type: 'telemetry' }
+     { source: 'north-generation', target: 'north-substation', label: '230 kV gen tie', type: 'transmission', route: [[246, 118], [320, 118], [320, 223]], labelPosition: { x: 257, y: 108 } },
+     { source: 'west-wind', target: 'north-substation', label: '115 kV wind tie', type: 'transmission', route: [[246, 248], [285, 248], [285, 223], [320, 223]], labelPosition: { x: 252, y: 268 } },
+     { source: 'grid-control', target: 'north-substation', label: 'SCADA control', type: 'control', route: [[408, 114], [408, 185]], labelPosition: { x: 426, y: 151 } },
+     { source: 'grid-control', target: 'east-substation', label: 'Dispatch control', type: 'control', route: [[496, 76], [673, 76], [673, 185]], labelPosition: { x: 585, y: 65 } },
+     { source: 'north-substation', target: 'east-substation', label: '230 kV backbone', type: 'transmission', route: [[496, 223], [585, 223]], labelPosition: { x: 540, y: 211 } },
+     { source: 'north-substation', target: 'battery-reserve', label: '34.5 kV storage tie', type: 'distribution', route: [[408, 261], [408, 430]], labelPosition: { x: 425, y: 348 } },
+     { source: 'battery-reserve', target: 'south-substation', label: 'Reserve support', type: 'distribution', route: [[496, 468], [585, 468]], labelPosition: { x: 541, y: 456 } },
+     { source: 'east-substation', target: 'ami-feeder', label: '13.8 kV feeder A', type: 'distribution', route: [[761, 205], [805, 205], [805, 133], [840, 133]], labelPosition: { x: 785, y: 194 } },
+     { source: 'east-substation', target: 'hospital-feeder', label: 'Critical feeder', type: 'distribution', route: [[761, 241], [805, 241], [805, 323], [840, 323]], labelPosition: { x: 785, y: 262 } },
+     { source: 'south-substation', target: 'residential-feeder', label: '13.8 kV feeder C', type: 'distribution', route: [[761, 468], [840, 468], [840, 513]], labelPosition: { x: 798, y: 456 } }
    ]
   };
   const MAP_NODE = { width: 176, height: 76 };
@@ -497,6 +501,15 @@ function addLogEntry() {
     if (result.severity === 'warning') return 'warning - HTTP ' + result.httpStatus;
     if (result.severity === 'critical') return 'critical - HTTP ' + result.httpStatus;
     return 'unknown';
+  }
+
+  function gridStateTextForResult(result) {
+    if (!result) return 'checking grid signal';
+    if (result.reason === 'network') return 'signal unreachable';
+    if (result.severity === 'healthy') return 'grid normal';
+    if (result.severity === 'warning') return 'fault indicator';
+    if (result.severity === 'critical') return 'outage indicator';
+    return 'unknown grid state';
   }
 
   function fetchLiveHealth(node) {
@@ -626,9 +639,9 @@ function addLogEntry() {
       const result = mapState.healthById[node.id];
       if (!result) return { text: 'checking live health', className: 'unknown', severity: 'unknown', symbol: '?' };
       const symbol = result.severity === 'healthy' ? '✓' : result.severity === 'warning' ? '!' : '×';
-      return { text: healthTextForResult(result), className: result.severity, severity: result.severity, symbol };
+      return { text: gridStateTextForResult(result), className: result.severity, severity: result.severity, symbol };
     }
-    if (node.nominal) return { text: 'nominal - static demo', className: 'healthy', severity: 'healthy', symbol: '✓' };
+    if (node.nominal) return { text: 'grid normal', className: 'healthy', severity: 'healthy', symbol: '✓' };
      return { text: 'static demo context', className: 'static', severity: 'unknown', symbol: 'S' };
   }
 
@@ -1077,10 +1090,49 @@ function addLogEntry() {
    return { x: a.x + dx / scale, y: a.y + dy / scale };
  }
 
+ function routePath(points) {
+   return points.map(function(point, index) {
+     return (index === 0 ? 'M ' : 'L ') + point[0] + ' ' + point[1];
+   }).join(' ');
+ }
+
+ function edgeRoute(edge, source, target) {
+   if (edge.route && edge.route.length >= 2) return edge.route;
+   const start = edgeAnchor(source, target);
+   const end = edgeAnchor(target, source);
+   const midX = Math.round((start.x + end.x) / 2);
+   return [[Math.round(start.x), Math.round(start.y)], [midX, Math.round(start.y)], [midX, Math.round(end.y)], [Math.round(end.x), Math.round(end.y)]];
+ }
+
+ function edgeLabelPosition(edge, points) {
+   if (edge.labelPosition) return edge.labelPosition;
+   const midpoint = points[Math.floor(points.length / 2)];
+   return { x: midpoint[0], y: midpoint[1] - 10 };
+ }
+
+ function renderElectricalSymbol(group, node, x, y) {
+   const sx = x + MAP_NODE.width - 28;
+   const sy = y + MAP_NODE.height - 24;
+   const symbol = createSvgElement('g', { class: 'map-node-symbol-shape', 'aria-hidden': 'true' });
+   if (node.kind === 'generation') {
+     symbol.appendChild(createSvgElement('circle', { cx: sx, cy: sy, r: 11 }));
+     symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 7) + ' ' + sy + ' C ' + (sx - 3) + ' ' + (sy - 8) + ' ' + (sx + 3) + ' ' + (sy + 8) + ' ' + (sx + 7) + ' ' + sy }));
+   } else if (node.kind === 'substation') {
+     symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 12) + ' ' + (sy - 8) + ' L ' + (sx + 12) + ' ' + (sy - 8) + ' M ' + (sx - 12) + ' ' + sy + ' L ' + (sx + 12) + ' ' + sy + ' M ' + (sx - 12) + ' ' + (sy + 8) + ' L ' + (sx + 12) + ' ' + (sy + 8) }));
+   } else if (node.kind === 'feeder') {
+     symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 12) + ' ' + sy + ' L ' + (sx - 4) + ' ' + sy + ' M ' + (sx - 4) + ' ' + (sy - 8) + ' L ' + (sx - 4) + ' ' + (sy + 8) + ' M ' + (sx + 4) + ' ' + (sy - 8) + ' L ' + (sx + 4) + ' ' + (sy + 8) + ' M ' + (sx + 4) + ' ' + sy + ' L ' + (sx + 12) + ' ' + sy }));
+   } else if (node.kind === 'storage') {
+     symbol.appendChild(createSvgElement('path', { d: 'M ' + (sx - 12) + ' ' + (sy - 8) + ' L ' + (sx - 12) + ' ' + (sy + 8) + ' M ' + (sx - 5) + ' ' + (sy - 5) + ' L ' + (sx - 5) + ' ' + (sy + 5) + ' M ' + (sx + 3) + ' ' + (sy - 8) + ' L ' + (sx + 3) + ' ' + (sy + 8) + ' M ' + (sx + 10) + ' ' + (sy - 5) + ' L ' + (sx + 10) + ' ' + (sy + 5) }));
+   } else {
+     symbol.appendChild(createSvgElement('path', { d: 'M ' + sx + ' ' + (sy - 12) + ' L ' + (sx + 12) + ' ' + sy + ' L ' + sx + ' ' + (sy + 12) + ' L ' + (sx - 12) + ' ' + sy + ' Z' }));
+   }
+   group.appendChild(symbol);
+ }
+
  function renderServiceNode(stage, node) {
    const status = getMapStatus(node);
    const group = createSvgElement('g', {
-      class: 'map-node service ' + status.className,
+      class: 'map-node service kind-' + node.kind + ' ' + status.className,
       tabindex: '0',
       role: 'button',
       'aria-label': node.label + ', ' + node.metaphor + ', ' + status.text + '. Activate to open details.',
@@ -1099,9 +1151,10 @@ function addLogEntry() {
    const subtitle = createSvgElement('text', { class: 'map-node-subtitle', x: x + 16, y: y + 46, 'aria-hidden': 'true' });
    subtitle.textContent = node.metaphor;
    group.appendChild(subtitle);
-   const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64, 'aria-hidden': 'true' });
-   state.textContent = status.text;
-   group.appendChild(state);
+    const state = createSvgElement('text', { class: 'map-node-status', x: x + 16, y: y + 64, 'aria-hidden': 'true' });
+    state.textContent = status.text;
+    group.appendChild(state);
+   renderElectricalSymbol(group, node, x, y);
    group.appendChild(createSvgElement('rect', { class: 'node-ring', x: x - 4, y: y - 4, width: MAP_NODE.width + 8, height: MAP_NODE.height + 8, rx: 18, ry: 18 }));
    group.appendChild(createSvgElement('rect', { class: 'node-focus-ring', x: x - 7, y: y - 7, width: MAP_NODE.width + 14, height: MAP_NODE.height + 14, rx: 21, ry: 21 }));
    if (mapState.selectedNodeId === node.id) group.classList.add('selected');
@@ -1146,47 +1199,46 @@ function addLogEntry() {
    const stage = document.getElementById('grid-map-stage');
    if (!svg || !stage || mapState.rendered) return;
    stage.innerHTML = '';
-   const defs = createSvgElement('defs');
-   const marker = createSvgElement('marker', { id: 'map-arrowhead', viewBox: '0 0 10 10', refX: '9', refY: '5', markerWidth: '7', markerHeight: '7', orient: 'auto-start-reverse' });
-   marker.appendChild(createSvgElement('path', { d: 'M 0 0 L 10 5 L 0 10 z', fill: '#94a3b8' }));
-   defs.appendChild(marker);
-   stage.appendChild(defs);
 
    const nodesById = GRID_TOPOLOGY.nodes.reduce((acc, node) => {
      acc[node.id] = node;
      return acc;
    }, {});
 
+   [
+    { x1: 496, y1: 223, x2: 585, y2: 223, label: '230 kV bus', x: 540, y: 211 },
+    { x1: 761, y1: 205, x2: 840, y2: 205, label: '13.8 kV feeder bus', x: 801, y: 194 },
+    { x1: 761, y1: 468, x2: 840, y2: 468, label: '13.8 kV feeder bus', x: 801, y: 456 }
+   ].forEach(bus => {
+     stage.appendChild(createSvgElement('line', { class: 'map-busbar', x1: bus.x1, y1: bus.y1, x2: bus.x2, y2: bus.y2, 'aria-hidden': 'true' }));
+     const label = createSvgElement('text', { class: 'map-busbar-label', x: bus.x, y: bus.y, 'aria-hidden': 'true' });
+     label.textContent = bus.label;
+     stage.appendChild(label);
+   });
+
    GRID_TOPOLOGY.edges.forEach(edge => {
      const source = nodesById[edge.source];
       const target = nodesById[edge.target];
       if (!source || !target) return;
-       const start = edgeAnchor(source, target);
-       const end = edgeAnchor(target, source);
+       const points = edgeRoute(edge, source, target);
+       const pathData = routePath(points);
        const edgeStatus = getEdgeStatus(edge, source, target);
        const edgeKey = edge.source + ':' + edge.target;
-       const edgeLine = createSvgElement('line', {
-         class: 'map-edge ' + edgeStatus.className + (mapState.selectedEdgeKey === edgeKey ? ' selected' : ''),
-         x1: start.x,
-         y1: start.y,
-         x2: end.x,
-         y2: end.y,
-         'marker-end': 'url(#map-arrowhead)',
+       const edgeLine = createSvgElement('path', {
+         class: 'map-edge ' + (edge.type || 'distribution') + ' ' + edgeStatus.className + (mapState.selectedEdgeKey === edgeKey ? ' selected' : ''),
+         d: pathData,
          role: 'img',
          'aria-label': edge.label + ', ' + edgeStatus.label,
          'data-edge-key': edgeKey
        });
        stage.appendChild(edgeLine);
-       const edgeHit = createSvgElement('line', {
+       const edgeHit = createSvgElement('path', {
          class: 'map-edge-hit',
-         x1: start.x, y1: start.y, x2: end.x, y2: end.y,
+         d: pathData,
          'data-edge-key': edgeKey,
          'aria-hidden': 'true'
        });
        stage.appendChild(edgeHit);
-       const label = createSvgElement('text', { class: 'map-edge-label', x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8, 'text-anchor': 'middle', 'aria-hidden': 'true' });
-       label.textContent = edge.label + (edgeStatus.className === 'unknown' ? ' · unknown' : edgeStatus.className === 'critical' ? ' · critical' : edgeStatus.className === 'warning' ? ' · warning' : '');
-       stage.appendChild(label);
     });
 
    GRID_TOPOLOGY.nodes.forEach(node => {

--- a/k8s/scenarios/network-block.yaml
+++ b/k8s/scenarios/network-block.yaml
@@ -1,8 +1,8 @@
 # =============================================================================
-# SCENARIO 7: Network Policy Blocking - Meter Service Isolated
+# SCENARIO 7: Network Policy Blocking - Meter Service and Portals Isolated
 # =============================================================================
-# A security policy update gone wrong isolates the meter-service from the
-# grid, blocking all ingress and egress traffic.
+# A security policy update gone wrong isolates the meter-service and the
+# public demo portals from the grid, blocking all ingress and egress traffic.
 #
 # Scenario is intended to test whether SRE Agent can diagnose: Network
 # connectivity issues and service unavailability, and recommend checking network
@@ -12,7 +12,7 @@
 # kubectl apply -f k8s/scenarios/network-block.yaml
 #
 # HOW TO FIX:
-# kubectl delete networkpolicy deny-meter-service -n energy
+# kubectl delete networkpolicy deny-meter-service deny-grid-dashboard deny-ops-console -n energy
 # =============================================================================
 ---
 apiVersion: networking.k8s.io/v1
@@ -40,5 +40,61 @@ spec:
     - Ingress
     - Egress
   # BREAKING CHANGE: No ingress or egress rules = all traffic denied
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-grid-dashboard
+  namespace: energy
+  labels:
+    scenario: network-block
+    sre-demo: breakable
+  annotations:
+    sre.scenario: network-block
+    sre.service: grid-dashboard
+    sre.namespace: energy
+    sre.component: network-policy
+    sre.runbook_id: RB-007-network-block
+    sre.root_cause_category: networking
+    sre.change_source: manual-kubectl
+    sre.version: "2026-05-07"
+spec:
+  podSelector:
+    matchLabels:
+      app: grid-dashboard
+  policyTypes:
+    - Ingress
+    - Egress
+  # BREAKING CHANGE: block the public Grid Dashboard portal.
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-ops-console
+  namespace: energy
+  labels:
+    scenario: network-block
+    sre-demo: breakable
+  annotations:
+    sre.scenario: network-block
+    sre.service: ops-console
+    sre.namespace: energy
+    sre.component: network-policy
+    sre.runbook_id: RB-007-network-block
+    sre.root_cause_category: networking
+    sre.change_source: manual-kubectl
+    sre.version: "2026-05-07"
+spec:
+  podSelector:
+    matchLabels:
+      app: ops-console
+  policyTypes:
+    - Ingress
+    - Egress
+  # BREAKING CHANGE: block the public Ops Console portal.
   ingress: []
   egress: []

--- a/mission-control/backend/src/services/ScenarioService.test.ts
+++ b/mission-control/backend/src/services/ScenarioService.test.ts
@@ -97,6 +97,8 @@ describe('ScenarioService scenario registry', () => {
     ]);
     assert.deepEqual(kubectlCommands, [
       ['delete', 'networkpolicy', 'deny-meter-service', '-n', 'energy', '--ignore-not-found=true'],
+      ['delete', 'networkpolicy', 'deny-grid-dashboard', '-n', 'energy', '--ignore-not-found=true'],
+      ['delete', 'networkpolicy', 'deny-ops-console', '-n', 'energy', '--ignore-not-found=true'],
     ]);
     assert.equal(getScenarios().find(scenario => scenario.name === 'network-block')?.enabled, false);
     assert.equal(getScenarios().find(scenario => scenario.name === 'mongodb-down')?.enabled, true);
@@ -133,6 +135,8 @@ describe('ScenarioService scenario registry', () => {
       ['delete', 'deployment', 'substation-monitor', '-n', 'energy', '--ignore-not-found=true'],
       ['delete', 'deployment', 'grid-health-monitor', '-n', 'energy', '--ignore-not-found=true'],
       ['delete', 'networkpolicy', 'deny-meter-service', '-n', 'energy', '--ignore-not-found=true'],
+      ['delete', 'networkpolicy', 'deny-grid-dashboard', '-n', 'energy', '--ignore-not-found=true'],
+      ['delete', 'networkpolicy', 'deny-ops-console', '-n', 'energy', '--ignore-not-found=true'],
       ['delete', 'deployment', 'grid-zone-config', '-n', 'energy', '--ignore-not-found=true'],
     ]);
     assert.equal(getScenarios().some(scenario => scenario.enabled), false);

--- a/mission-control/backend/src/services/ScenarioService.ts
+++ b/mission-control/backend/src/services/ScenarioService.ts
@@ -29,7 +29,7 @@ const SCENARIO_REGISTRY: ScenarioDefinition[] = [
   { name: 'high-cpu', file: 'high-cpu.yaml', description: 'Grid frequency calculation overload — CPU contention' },
   { name: 'pending-pods', file: 'pending-pods.yaml', description: 'Substation monitor can\'t schedule — Pending pods' },
   { name: 'probe-failure', file: 'probe-failure.yaml', description: 'Grid health monitor misconfigured — Probe failure' },
-  { name: 'network-block', file: 'network-block.yaml', description: 'Meter service isolated by bad security policy — Network block' },
+  { name: 'network-block', file: 'network-block.yaml', description: 'Meter service and public portals isolated by bad security policy — Network block' },
   { name: 'missing-config', file: 'missing-config.yaml', description: 'Grid zone configuration missing — ConfigMap missing' },
   { name: 'mongodb-down', file: 'mongodb-down.yaml', description: 'Meter database outage — Cascading failure' },
   { name: 'service-mismatch', file: 'service-mismatch.yaml', description: 'Meter service routing failure after v2 upgrade — Selector mismatch' },
@@ -53,7 +53,11 @@ const SCENARIO_REPAIR_PLANS: Record<string, ScenarioRepairPlan> = {
   },
   'network-block': {
     applyBase: false,
-    deleteResources: [{ resource: 'networkpolicy', name: 'deny-meter-service', namespace: ENERGY_NAMESPACE }],
+    deleteResources: [
+      { resource: 'networkpolicy', name: 'deny-meter-service', namespace: ENERGY_NAMESPACE },
+      { resource: 'networkpolicy', name: 'deny-grid-dashboard', namespace: ENERGY_NAMESPACE },
+      { resource: 'networkpolicy', name: 'deny-ops-console', namespace: ENERGY_NAMESPACE },
+    ],
   },
   'missing-config': {
     applyBase: false,

--- a/scripts/check-sre-agent-api-rollout.ps1
+++ b/scripts/check-sre-agent-api-rollout.ps1
@@ -182,7 +182,7 @@ try {
 
     if ($apiVersions -notcontains $TargetApiVersion) {
         Write-Status "BLOCKED: Microsoft.App/agents@$TargetApiVersion is not exposed in this subscription yet." 'Yellow'
-        Write-Status "Keep infra/bicep/modules/sre-agent.bicep pinned to 2025-05-01-preview." 'Yellow'
+        Write-Status "Do not deploy the legacy preview API. Wait for provider metadata to expose Microsoft.App/agents@$TargetApiVersion in this subscription." 'Yellow'
         exit 2
     }
 
@@ -205,7 +205,7 @@ try {
     Copy-Item -Path $moduleSource -Destination $candidateModule
 
     $candidateContent = Get-Content -Raw -Path $candidateModule
-    $candidateContent = $candidateContent -replace 'Microsoft\.App/agents@2025-05-01-preview', "Microsoft.App/agents@$TargetApiVersion"
+    $candidateContent = $candidateContent -replace 'Microsoft\.App/agents@[^''\s]+', "Microsoft.App/agents@$TargetApiVersion"
     Set-Content -Path $candidateModule -Value $candidateContent -NoNewline
 
     $agentContext = Get-ExistingSreAgentContext -GroupName $ResourceGroupName -Name $AgentName

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     This script deploys all Azure infrastructure needed for the SRE Agent demo,
     including AKS, Container Registry, Key Vault, observability tools, and
-    Azure SRE Agent (Microsoft.App/agents@2025-05-01-preview).
+    Azure SRE Agent (Microsoft.App/agents@2026-01-01, GA stable channel).
     It uses device code authentication by default for dev container support.
 
 .PARAMETER Location
@@ -75,6 +75,9 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+$SreAgentTargetApiVersion = '2026-01-01'
+$SreAgentLegacyPreviewApiVersion = '2025-05-01-preview'
 
 if ($AksApiServerAuthorizedIpRanges.Count -gt 0) {
     $cidrPattern = '^((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\/([0-9]|[12][0-9]|3[0-2])$'
@@ -535,6 +538,58 @@ function Write-SubscriptionDeploymentFailureSummary {
     }
 }
 
+function Test-AlertWorkspaceReadinessFailure {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$ErrorText
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ErrorText)) {
+        return $false
+    }
+
+    return $ErrorText -match '(?i)deploy-alerts' -and $ErrorText -match '(?i)workspace could not be found'
+}
+
+function Wait-LogAnalyticsWorkspaceReady {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ResourceGroupName,
+
+        [Parameter(Mandatory)]
+        [string]$WorkspaceName,
+
+        [Parameter()]
+        [int]$TimeoutSeconds = 180
+    )
+
+    Write-Host "`n⏳ Azure Monitor could not resolve the new Log Analytics workspace yet." -ForegroundColor Yellow
+    Write-Host "  Waiting for workspace readiness before retrying alert deployment: $WorkspaceName" -ForegroundColor Gray
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $workspaceState = az resource show `
+            --resource-group $ResourceGroupName `
+            --resource-type 'Microsoft.OperationalInsights/workspaces' `
+            --name $WorkspaceName `
+            --query 'properties.provisioningState' `
+            --output tsv 2>$null
+
+        if ($LASTEXITCODE -eq 0 -and $workspaceState -eq 'Succeeded') {
+            Write-Host "  ✅ Log Analytics workspace is provisioned. Giving Azure Monitor a short propagation window..." -ForegroundColor Green
+            Start-Sleep -Seconds 30
+            return $true
+        }
+
+        Start-Sleep -Seconds 10
+    } while ((Get-Date) -lt $deadline)
+
+    Write-Host "  ⚠️  Timed out waiting for Log Analytics workspace readiness." -ForegroundColor Yellow
+    return $false
+}
+
 function Get-DeletedKeyVaultConflict {
     [CmdletBinding()]
     param(
@@ -648,8 +703,9 @@ function Get-SreAgentProviderStatus {
         return [pscustomobject]@{
             RegistrationState  = 'Unknown'
             HasAgentsResource  = $false
-            SupportsPreviewApi = $false
+            SupportsTargetApi  = $false
             DefaultApiVersion  = ''
+            ApiVersions        = @()
         }
     }
 
@@ -660,8 +716,9 @@ function Get-SreAgentProviderStatus {
         return [pscustomobject]@{
             RegistrationState  = 'Unknown'
             HasAgentsResource  = $false
-            SupportsPreviewApi = $false
+            SupportsTargetApi  = $false
             DefaultApiVersion  = ''
+            ApiVersions        = @()
         }
     }
 
@@ -674,8 +731,9 @@ function Get-SreAgentProviderStatus {
     return [pscustomobject]@{
         RegistrationState  = $provider.registrationState
         HasAgentsResource  = $null -ne $agentsResource
-        SupportsPreviewApi = $apiVersions -contains '2025-05-01-preview'
+        SupportsTargetApi  = $apiVersions -contains $SreAgentTargetApiVersion
         DefaultApiVersion  = if ($agentsResource -and $agentsResource.PSObject.Properties.Name -contains 'defaultApiVersion') { $agentsResource.defaultApiVersion } else { '' }
+        ApiVersions        = $apiVersions
     }
 }
 
@@ -755,15 +813,18 @@ if ($deploySreAgent) {
         $sreAgentProvider = Get-SreAgentProviderStatus
     }
 
-    if (-not $sreAgentProvider.HasAgentsResource -or -not $sreAgentProvider.SupportsPreviewApi) {
+    if (-not $sreAgentProvider.HasAgentsResource -or -not $sreAgentProvider.SupportsTargetApi) {
         $deploySreAgent = $false
-        $sreAgentSkipReason = 'Microsoft.App/agents@2025-05-01-preview is not available for this subscription.'
+        $availableApiVersions = if ($sreAgentProvider.ApiVersions.Count -gt 0) { $sreAgentProvider.ApiVersions -join ', ' } else { 'none reported' }
+        $sreAgentSkipReason = "Microsoft.App/agents@$SreAgentTargetApiVersion is not available for this subscription. Not falling back to legacy preview API $SreAgentLegacyPreviewApiVersion. Available versions: $availableApiVersions."
         Write-Host "  ⚠️  $sreAgentSkipReason" -ForegroundColor Yellow
         Write-Host "      Continuing with core infrastructure deployment." -ForegroundColor Gray
     }
     else {
-        $apiVersion = if ($sreAgentProvider.DefaultApiVersion) { $sreAgentProvider.DefaultApiVersion } else { '2025-05-01-preview' }
-        Write-Host "  ✅ Microsoft.App/agents is available (API: $apiVersion)" -ForegroundColor Green
+        Write-Host "  ✅ Microsoft.App/agents is available (API: $SreAgentTargetApiVersion, Stable channel)" -ForegroundColor Green
+        if ($sreAgentProvider.DefaultApiVersion -and $sreAgentProvider.DefaultApiVersion -ne $SreAgentTargetApiVersion) {
+            Write-Host "      Provider default API is $($sreAgentProvider.DefaultApiVersion); deployment remains pinned to $SreAgentTargetApiVersion." -ForegroundColor Gray
+        }
     }
 }
 else {
@@ -788,6 +849,7 @@ else {
 
 # Set variables
 $resourceGroupName = "rg-$WorkloadName-$Location"
+$logAnalyticsWorkspaceName = "log-$WorkloadName"
 $deploymentName = "sre-demo-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
 $bicepFile = Join-Path $PSScriptRoot "..\infra\bicep\main.bicep"
 $parametersFile = Join-Path $PSScriptRoot "..\infra\bicep\main.bicepparam"
@@ -987,7 +1049,7 @@ try {
     )
 
     $deployment = $null
-    for ($attempt = 1; $attempt -le 2; $attempt++) {
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
         $create = Invoke-AzCliJsonArgs -Arguments $createArgs
 
         if ($create.ExitCode -eq 0 -and $create.Json) {
@@ -995,9 +1057,12 @@ try {
             break
         }
 
+        $deploymentErrorText = [System.Collections.Generic.List[string]]::new()
+
         Write-Host "`nAzure CLI deployment command failed." -ForegroundColor Red
         if ($create.Raw) {
             Write-Host "Azure CLI output:`n$($create.Raw.Trim())" -ForegroundColor Red
+            [void]$deploymentErrorText.Add($create.Raw)
         }
 
         # Best-effort: if a deployment record exists, pull structured error details.
@@ -1016,6 +1081,7 @@ try {
             if ($show.Json.properties.error) {
                 Write-Host "`nDeployment error (structured):" -ForegroundColor Yellow
                 Write-Host ($show.Json.properties.error | ConvertTo-Json -Depth 50) -ForegroundColor Yellow
+                [void]$deploymentErrorText.Add(($show.Json.properties.error | ConvertTo-Json -Depth 50))
             }
         }
 
@@ -1030,6 +1096,15 @@ try {
                     continue
                 }
             }
+        }
+
+        if (
+            $attempt -lt 3 -and
+            (Test-AlertWorkspaceReadinessFailure -ErrorText ($deploymentErrorText -join "`n")) -and
+            (Wait-LogAnalyticsWorkspaceReady -ResourceGroupName $resourceGroupName -WorkspaceName $logAnalyticsWorkspaceName)
+        ) {
+            Write-Host "`n🔁 Retrying deployment after Log Analytics workspace propagation..." -ForegroundColor Yellow
+            continue
         }
 
         throw "Deployment failed (see output above)."


### PR DESCRIPTION
## Summary

This PR captures the fixes from the live Azure SRE demo deployment session.

- Adds a retry path for the Azure Monitor scheduled-query alert deployment when the newly-created Log Analytics workspace has not propagated yet.
- Pins the SRE Agent ARM resource to the latest documented GA API, `Microsoft.App/agents@2026-01-01`, with `upgradeChannel: 'Stable'`.
- Updates deployment preflight so future deployments require the target GA API and skip SRE Agent instead of falling back to legacy preview API `2025-05-01-preview` when a subscription has not exposed `2026-01-01` yet.
- Converts the Ops Console Grid Map from a flowchart-like topology into a cleaner electrical one-line style diagram with orthogonal conductors, bus labels, and electrical asset symbols.
- Moves map-facing status language away from raw HTTP responses and toward grid/operator states such as `grid normal`, `fault indicator`, and `outage indicator`, while keeping raw HTTP detail in diagnostic contexts.
- Changes the `network-block` scenario so the live Grid Dashboard and Ops Console portals go down along with meter-service by applying scenario-owned NetworkPolicies.
- Aligns active customer-facing and operational docs with the GA Stable API pin, no-preview-fallback behavior, and updated network-block scenario behavior.

## Why

The Azure deployment failed in `deploy-alerts` because Azure Monitor could not resolve the freshly-created Log Analytics workspace even though the workspace deployment had succeeded. Retrying after workspace readiness and a short propagation delay makes this transient control-plane race recoverable.

The SRE Agent resource was still pinned to an older preview API. Microsoft Learn now documents `Microsoft.App/agents@2026-01-01` as the latest GA template API, so the lab should prefer that and avoid silently deploying an older preview shape. The current demo subscription provider metadata still reports only `2025-05-01-preview`; the deploy script now treats that as a skip condition rather than a fallback.

The Grid Map also needed to read like an electrical grid diagram rather than a service dependency flowchart. The previous map had crossing lines, a non-electrical telemetry link, visible labels under boxes, and raw HTTP 404 statuses on the diagram surface.

The original `network-block` scenario only isolated `meter-service`, so public demo portals stayed online. For the intended live demo effect, the scenario now also isolates `grid-dashboard` and `ops-console`; Mission Control repair deletes all three scenario-owned NetworkPolicies.

## Validation

- Parsed the Ops Console embedded JavaScript with Node `vm.Script`.
- Ran `az bicep build --file infra/bicep/main.bicep --stdout` successfully. Existing linter warning remains for App Insights `connectionString` secure-value handling.
- Parsed `scripts/deploy.ps1` and `scripts/check-sre-agent-api-rollout.ps1` with the PowerShell parser.
- Ran `kubectl apply --dry-run=client -f k8s/base/application.yaml`.
- Ran `kubectl apply --dry-run=client -f k8s/scenarios/network-block.yaml`.
- Ran focused ScenarioService tests with `npx --yes tsx --test src/services/ScenarioService.test.ts`.
- Ran `git diff --check` / `git diff --cached --check`.
- Ran `scripts/check-sre-agent-api-rollout.ps1 -ResourceGroupName rg-srelab-eastus2 -MetadataOnly`; it correctly exits `2` because this subscription currently exposes only `2025-05-01-preview` and refuses legacy preview fallback.
- Applied the manifest to the live AKS namespace and confirmed the `ops-console` rollout completed successfully.
- Applied the updated `network-block` scenario live and confirmed `ops-console` and `grid-dashboard` public endpoints returned no HTTP response while pods stayed Running.