### PR TITLE
Embed real Azure SRE Agent investigations in Mission Control via the supported MCP path

### DIFF
--- a/docs/LOCAL-ANALYST-GOVERNANCE.md
+++ b/docs/LOCAL-ANALYST-GOVERNANCE.md
@@ -92,6 +92,17 @@ Each successful response includes source, collection timestamp, limitations, con
 | Arbitrary file access | source files, hidden logs, local filesystem browsing outside the bounded snapshot | Reject. Use documented state sources only. |
 | Direct Azure SRE Agent automation | private Preview APIs, unverified approval APIs, assumed remediation endpoints | Reject unless there is verified product evidence and a separate governance review. |
 
+> [!NOTE]
+> **Azure SRE Agent is now reachable from Mission Control through a separate, governed surface.**
+>
+> Issue #77 added a supported Azure SRE Agent MCP adapter (see [SRE Agent MCP Integration](SRE-AGENT-MCP-INTEGRATION.md)). It is **not** part of Local Analyst and does not relax any rule on this page:
+>
+> - Local Analyst remains a local, read-only explainer with the single `get_mission_control_state` tool.
+> - The SRE Agent adapter is a distinct backend service, a distinct API namespace (`/api/sre-agent/*`), and a distinct UI panel (`SreAgentPanel.vue`).
+> - Local Analyst output is **never** substituted when the SRE Agent path fails; the UI shows an honest error plus the portal handoff.
+> - The adapter is limited to six allowlisted MCP tools, blocks `investigate_yolo` and every auto-approval path, and never auto-approves a write action.
+> - Approvals remain operator-driven in the Azure SRE Agent portal.
+
 ### Fail-closed default
 
 Local Analyst must fail closed when tool policy cannot prove an action is safe.
@@ -221,6 +232,8 @@ When data is missing, do not infer it:
 | Remediation recommendations | Defers | Owns recommendation flow when portal evidence supports it |
 | Remediation execution | Not allowed | Operator-approved only unless real approval UI/API evidence is captured and separately reviewed |
 | Safe-language enforcement | Owns for analyst responses | Must still follow project safe-language guardrails |
+| Investigation threads via MCP | Not allowed | Owns, through the governed adapter in [SRE Agent MCP Integration](SRE-AGENT-MCP-INTEGRATION.md) |
+| Approving a proposed action | Not allowed | Operator-only, in the Azure SRE Agent portal; Mission Control never auto-approves |
 
 Use this boundary in reviews:
 

--- a/docs/SRE-AGENT-API-RESEARCH.md
+++ b/docs/SRE-AGENT-API-RESEARCH.md
@@ -5,6 +5,23 @@
 > **Date**: 2026-04-27
 > **Status**: Azure SRE Agent is GA. This lab now pins `Microsoft.App/agents@2026-01-01` with `upgradeChannel: 'Stable'`; subscriptions that expose only older preview provider metadata skip SRE Agent deployment instead of falling back.
 
+> [!IMPORTANT]
+> **Superseded in part by [SRE Agent MCP Integration](SRE-AGENT-MCP-INTEGRATION.md) (issue #77), 2026-08-12.**
+>
+> The verdict below — "portal fallback only; direct integration blocked" — was correct for the **REST** surface reviewed in April 2026. Microsoft has since documented the **SRE Agent MCP server**, which provides a supported path for a third-party client to discover agents, create threads, run standard approval-gated investigations, send follow-ups, and read thread state, using the host Azure identity:
+>
+> - <https://learn.microsoft.com/azure/sre-agent/mcp-server>
+> - <https://learn.microsoft.com/azure/sre-agent/setup-mcp-server>
+> - <https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-sre-agent>
+>
+> Mission Control now uses that supported MCP path. The following sections remain accurate and still apply:
+>
+> - §3 (Application Insights `customEvents` as read-only audit evidence) — used for audit correlation.
+> - §6 (API-version and breaking-change risk) — the MCP surface is preview-stage; pin the server version.
+> - §5 (portal fallback) — still the required behaviour whenever MCP is unavailable, and still the source of truth for demo evidence until the embedded path is live-validated.
+>
+> These conclusions are **no longer current**: "Chat/thread/conversation start or send message — Not verified", "Do not build direct Mission Control → SRE Agent chat/thread/message calls", and the blocked status of issue #12. Approve/deny of a proposed action from an external caller remains **not documented**, so Mission Control still routes approvals to the portal.
+
 ## Executive verdict
 
 **Recommendation: use the portal/deep-link fallback for the customer demo; do not implement direct Mission Control → Azure SRE Agent chat/conversation/action API integration yet.**

--- a/docs/SRE-AGENT-MCP-INTEGRATION.md
+++ b/docs/SRE-AGENT-MCP-INTEGRATION.md
@@ -1,0 +1,347 @@
+# Azure SRE Agent MCP Integration (Mission Control)
+
+> **Issue**: [#77 — Embed real SRE Agent investigations in Mission Control via MCP](https://github.com/johnstel/azure-sre-agent-energy-grid/issues/77)
+> **Status**: Implemented against the supported Azure MCP Server `sreagent` tool surface. **Not yet live-validated against an Energy Grid SRE Agent resource** — see [Live validation status](#live-validation-status).
+> **Related docs**: [SRE Agent API Research](SRE-AGENT-API-RESEARCH.md), [Local Analyst Governance](LOCAL-ANALYST-GOVERNANCE.md), [Safe Language Guardrails](SAFE-LANGUAGE-GUARDRAILS.md), [SRE Agent Setup](SRE-AGENT-SETUP.md), [Supportability](SUPPORTABILITY.md)
+
+Mission Control can now start and continue a **real Azure SRE Agent investigation** without leaving the dashboard. This supersedes the "portal handoff only" verdict in [SRE-AGENT-API-RESEARCH.md](SRE-AGENT-API-RESEARCH.md), which predates the SRE Agent MCP server.
+
+---
+
+## 1. Supported architecture
+
+Microsoft documents the SRE Agent tools as part of **Azure MCP Server**, not as a private REST API. Mission Control uses exactly that path.
+
+```
+Mission Control backend (Fastify, Node)
+  └── MCP client (@modelcontextprotocol/sdk, stdio transport)
+        └── child process: npx -y @azure/mcp@latest server start --tool <6 allowlisted tools>
+              ├── control plane (ARM)  → agent discovery            [Reader]
+              └── data plane (*.azuresre.ai) → threads/investigation [SRE Agent Administrator]
+```
+
+Key properties, all documented by Microsoft:
+
+| Property | Value | Source |
+|---|---|---|
+| Transport | stdio child process | [Set up the SRE Agent MCP server](https://learn.microsoft.com/azure/sre-agent/setup-mcp-server) |
+| Launcher | `npx -y @azure/mcp@latest server start` | same |
+| Tool prefix | `sreagent_` | [SRE Agent MCP server](https://learn.microsoft.com/azure/sre-agent/mcp-server) |
+| Authentication | Azure identity available on the host (`az login`, managed identity, env credentials) | same |
+| Interactive auth | **Suppressed in server mode** — you must sign in first | same |
+| Control-plane RBAC | `Reader` on the `Microsoft.App/agents` resource | same |
+| Data-plane RBAC | `SRE Agent Administrator` on the `Microsoft.App/agents` resource | same |
+| Data-plane domain | `*.azuresre.ai` (HTTPS only, endpoint-pinned by the server) | same |
+| Investigation defaults | 20 iterations, 10-minute timeout (`--max-iterations`, `--timeout-seconds`) | same |
+| Server start flags | `--mode`, `--namespace`, `--tool`, `--read-only`, `--transport` | [Azure MCP Server tools](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/) |
+
+**No private or undocumented API is called. The portal is never scraped.**
+
+### Why a child process rather than an embedded library
+
+Azure MCP Server is distributed as an MCP server, not as a Node library. Running it as a stdio child process is the documented integration model for a programmatic client, and it keeps the Azure credential handling inside Microsoft's own component. Mission Control owns the process lifecycle (lazy start, idle shutdown, disposal on backend close).
+
+---
+
+## 2. Allowlisted operations
+
+Mission Control may invoke **exactly six** tools:
+
+| Mission Control operation | Azure MCP Server tool | Read-only |
+|---|---|---|
+| `discover-agents` | `sreagent_agents_list` | yes |
+| `get-agent` | `sreagent_agents_get` | yes |
+| `create-thread` | `sreagent_threads_create` | no |
+| `investigate` | `sreagent_threads_investigate` | no |
+| `follow-up` | `sreagent_threads_send_message` | no |
+| `thread-status` | `sreagent_threads_get` | yes |
+
+Everything else in the `sreagent` namespace — 49 further tools including connector, hook, skill, scheduled-task, workflow, memory, and delete operations — is unreachable.
+
+### `investigate_yolo` is impossible, in three independent layers
+
+Microsoft's own documentation warns that `investigate_yolo` "auto-approves **all** approval gates, including actions that modify your infrastructure (pod deletion, Kubernetes YAML application, scaling, incident state changes)". It is banned here.
+
+1. **Server surface.** The child process is launched with one `--tool` flag per allowlisted tool. The tool is never registered on the server, so it cannot be called even by a compromised caller. Operator-supplied `SRE_AGENT_MCP_ARGS` cannot widen this: tool-exposure flags are stripped from the override.
+2. **Client mapping.** Callers address typed `SreAgentOperation` values; there is no code path that accepts a raw tool name.
+3. **Denylist assertion.** `assertToolAllowed()` runs immediately before every dispatch and rejects `/yolo/i`, `/auto[_-]?approve/i`, `/approve[_-]?all/i`, `/bypass[_-]?approval/i`, and `/no[_-]?confirm/i`, plus an explicit blocked-tool list.
+
+Verified empirically — with the tool filter applied, Azure MCP Server 3.0.0-beta.34 exposes exactly six tools:
+
+```
+TOTAL TOOLS: 6
+sreagent_agents_get            ro=true  destructive=false
+sreagent_agents_list           ro=true  destructive=false
+sreagent_threads_create        ro=false destructive=false
+sreagent_threads_get           ro=true  destructive=false
+sreagent_threads_investigate   ro=false destructive=false
+sreagent_threads_send_message  ro=false destructive=false
+```
+
+Without the filter the same server exposes 55 tools including `sreagent_threads_investigate_yolo`. Preflight re-verifies this at runtime and **fails** if an auto-approval tool ever appears.
+
+### Approval gates are never auto-approved
+
+Standard mode pauses at approval gates. Mission Control surfaces the paused state and directs the operator to the Azure SRE Agent portal to approve. `SreAgentApprovalState.autoApproved` is typed as the literal `false`, so an auto-approving code path would not compile.
+
+---
+
+## 3. Security model
+
+| Control | Implementation |
+|---|---|
+| Credential handling | Host Azure identity only. Mission Control never reads, stores, forwards, or logs a token. No client secret is injected into the child environment. |
+| Browser exposure | The browser receives only typed contracts. Subscription/tenant GUIDs are masked (`11111111-****-****-****-555555`) in identity fields **and in the agent's response prose, citation labels, and approval detail**, because the agent routinely quotes ARM resource IDs. ARM IDs keep their resource group / resource name so the answer stays diagnostic. Citation **URLs** are left navigable so the cited evidence can be opened, so a portal link may still contain a resource path. |
+| Raw tool payloads | Never returned to the browser and never logged. Only parsed, redacted, bounded fields leave the backend. |
+| Redaction | Bearer/Basic headers, JWTs, `key=value` secrets, storage account keys, SAS query parameters, and PEM private keys are stripped from every string that leaves the adapter. |
+| Output bounding | Responses are truncated at `SRE_AGENT_MAX_RESPONSE_CHARS` (default 24,000) with explicit truncation marking. Citations capped at 25, prompts at 8,000 characters. |
+| Input validation | Prompts and thread IDs are validated before any dispatch; scenario starters are limited to the three approved validation scenarios. |
+| Audit | Every request/response/failure emits a structured record with `requester`, `tool`, `target`, `timestamp`, `resultStatus`, `correlationId`, and `redactionNotes`, matching [Local Analyst Governance](LOCAL-ANALYST-GOVERNANCE.md#audit-trail-requirements). Arguments are redacted before logging. |
+| Process lifecycle | Child MCP server is started lazily, shut down after `SRE_AGENT_IDLE_SHUTDOWN_MS` idle (default 5 min), and disposed on backend close. `SIGINT`/`SIGTERM` handlers call `app.close()` so the disposal hook actually runs and no orphaned child keeps an Azure session open. Disposal during a cold server start is handled explicitly. |
+| Persisted state | Only thread references (`threadId`, agent name, scenario, timestamps, status) are persisted. **Prompts and responses are never written to disk** by this adapter. |
+
+---
+
+## 4. Configuration
+
+All configuration is environment-driven. Nothing is hardcoded to a tenant, subscription, or agent.
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `SRE_AGENT_NAME` | **yes** | — | `Microsoft.App/agents` resource name |
+| `SRE_AGENT_SUBSCRIPTION_ID` (or `AZURE_SUBSCRIPTION_ID`) | **yes** | — | Subscription GUID |
+| `SRE_AGENT_RESOURCE_GROUP` | no | — | Narrows discovery |
+| `SRE_AGENT_TENANT_ID` (or `AZURE_TENANT_ID`) | no | — | Cross-tenant agents |
+| `SRE_AGENT_MCP_ENABLED` | no | `true` | Kill switch |
+| `SRE_AGENT_MCP_PACKAGE` | no | `@azure/mcp@latest` | Pin the server version |
+| `SRE_AGENT_MCP_COMMAND` | no | `npx` | Launcher override |
+| `SRE_AGENT_MCP_ARGS` | no | `-y <package> server start` | Base argv override. Tool-exposure flags (`--tool`, `--namespace`, `--mode`) are **stripped**, and the six-tool `--tool` allowlist is always appended. |
+| `SRE_AGENT_REQUEST_TIMEOUT_MS` | no | `120000` | Discovery/follow-up timeout (5s–15min) |
+| `SRE_AGENT_INVESTIGATION_TIMEOUT_MS` | no | `600000` | Investigation timeout (5s–15min) |
+| `SRE_AGENT_MAX_ITERATIONS` | no | `20` | Capped at the documented maximum of 20 |
+| `SRE_AGENT_IDLE_SHUTDOWN_MS` | no | `300000` | Child process idle shutdown |
+| `SRE_AGENT_MAX_RESPONSE_CHARS` | no | `24000` | Output bound (max 100,000) |
+| `SRE_AGENT_PORTAL_URL` | no | `https://sre.azure.com` | Portal handoff target |
+| `AZURE_TOKEN_CREDENTIALS` | no | — | Pins the credential type when several are available |
+
+### Required RBAC
+
+```bash
+OBJECT_ID=$(az ad signed-in-user show --query id -o tsv)
+SCOPE=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.App/agents/<agentName>
+
+az role assignment create --assignee "$OBJECT_ID" --role "Reader" --scope "$SCOPE"
+az role assignment create --assignee "$OBJECT_ID" --role "SRE Agent Administrator" --scope "$SCOPE"
+```
+
+Assign at the agent resource scope, not subscription scope.
+
+---
+
+## 5. API surface
+
+| Method | Route | Purpose |
+|---|---|---|
+| `GET` | `/api/sre-agent/config` | Configuration, masked target, allow/block lists, approved scenario prompts |
+| `GET` | `/api/sre-agent/preflight` | Full preflight (`?skipMcpProbe=true` to skip the ~30s cold-npx probe) |
+| `GET` | `/api/sre-agent/agents` | Agent discovery |
+| `GET` | `/api/sre-agent/threads` | Recorded thread references (restart recovery) |
+| `POST` | `/api/sre-agent/investigations` | Start a standard investigation (`scenarioName` or `prompt`) |
+| `POST` | `/api/sre-agent/investigations/continue` | Follow-up on an existing thread |
+| `GET` | `/api/sre-agent/investigations/:threadId` | Thread status |
+| `POST` | `/api/sre-agent/investigations/cancel` | Cancel an in-flight Mission Control operation |
+
+### Provenance rule
+
+A response is labelled `provenance: 'azure-sre-agent'` **only** when it carries both a resolved agent resource identity and a real thread ID. If either is missing the request fails with `SreAgentProvenanceError` (HTTP 502). Mission Control never claims SRE Agent output it cannot prove.
+
+### Failure contract
+
+Every failure returns:
+
+```jsonc
+{
+  "error": "Azure denied the SRE Agent request (missing RBAC).",
+  "kind": "permission",
+  "remediation": "Assign Reader (control plane) and SRE Agent Administrator (data plane)…",
+  "investigationStarted": false,
+  "localAnalystSubstituted": false,   // always false, asserted in tests
+  "portalHandoff": { "label": "…", "href": "…", "prompt": "…" },
+  "correlationId": "…",
+  "timestamp": "…"
+}
+```
+
+No success-shaped fields (`provenance`, `response`, `thread`) are present on a failure. **Local Analyst output is never substituted.**
+
+---
+
+## 6. Cancellation and restart behaviour
+
+### Cancellation
+
+Azure MCP Server **does not document a server-side stop** for a running investigation. Mission Control therefore:
+
+- registers each logical operation under a correlation ID, covering agent resolution *and* the investigation call;
+- aborts the in-flight MCP request on cancel and performs no automatic retry;
+- states plainly in the API response and the UI that agent-side work already started may continue, and points the operator at the portal.
+
+This limitation is reported honestly rather than presented as a hard stop.
+
+### Backend restart / reconnect
+
+SRE Agent threads live server-side, so a thread survives a Mission Control restart.
+
+- Thread references are persisted atomically to `state/sre-agent-threads.json` (path overridable with `SRE_AGENT_THREAD_STATE_PATH`).
+- After restart, `GET /api/sre-agent/threads` lists them and `GET /api/sre-agent/investigations/:threadId` re-attaches via `sreagent_threads_get`.
+- In-flight *Mission Control* operations do not survive restart; they are aborted on shutdown and the durable thread ID is the recovery handle.
+
+Covered by the test `an in-flight thread survives a backend restart and can be re-attached`.
+
+---
+
+## 7. Response-schema caveat
+
+Microsoft documents the SRE Agent operations and their **inputs**, but not a stable JSON **response** schema for `threads_*`. The parser is therefore tolerant and reports how it interpreted the payload:
+
+| `schemaConfidence` | Meaning |
+|---|---|
+| `structured` | JSON payload with an explicit thread ID |
+| `inferred` | JSON payload; thread ID came from the request context |
+| `text-only` | Non-JSON response; text used verbatim |
+
+Two rules hold regardless of shape:
+
+- a missing thread ID fails the request rather than producing an unattributed answer;
+- **citations are never invented.** When the agent returns none, the UI says so explicitly.
+
+---
+
+## 8. UI separation from Local Analyst
+
+| | Local Analyst | Azure SRE Agent |
+|---|---|---|
+| Component | `AssistantPanel.vue` | `SreAgentPanel.vue` |
+| Eyebrow | "Local analyst · not Azure SRE Agent" | "Azure SRE Agent · cloud agent" |
+| Icon mark | cyan **L** | violet **A** |
+| Accent | cyan | violet |
+| Badge | "Local · read-only" | "Real agent" |
+| Data source | local Mission Control snapshot | real Azure SRE Agent thread |
+| Identity shown | snapshot timestamp | agent name, masked ARM ID, thread ID, elapsed time, status |
+
+The SRE Agent panel always shows the agent name and thread ID beside the response, so an audience can verify the answer came from a real agent resource.
+
+---
+
+## 9. Testing
+
+All tests are deterministic and require no Azure access. `FakeMcpServer` is a **real** MCP server from the official SDK connected over `InMemoryTransport`, so the genuine MCP protocol — tool registration, JSON-RPC dispatch, timeouts, cancellation — is exercised.
+
+```bash
+cd mission-control
+npm test -w backend      # 100 tests
+npm test -w frontend
+npm run lint             # vue-tsc + tsc
+npm run build
+```
+
+Coverage of the safety-critical behaviour:
+
+- `investigate_yolo` unreachable from every typed operation, and every auto-approval spelling rejected;
+- all 22 blocked tools rejected; unknown/empty/near-miss names rejected;
+- the `--tool` allowlist survives an operator argv override;
+- preflight fails if the MCP server ever exposes an auto-approval tool;
+- approval gates surfaced from both structured flags and prose, never auto-approved;
+- responses without a thread ID or agent identity refused;
+- MCP failure returns the portal handoff with `localAnalystSubstituted: false` and no success fields;
+- timeout, cancellation mid-operation, and shutdown-aborts-in-flight;
+- auth / permission / network / not-found / runtime-missing mapped to actionable remediations;
+- raw subscription GUID absent from client payloads; prompts absent from persisted state;
+- backend restart re-attach.
+
+---
+
+## 10. Live validation status
+
+**Not yet performed.** No Energy Grid Azure SRE Agent resource was available to this change, and the task scope prohibits deploying one or touching unrelated resource groups.
+
+What **is** proven:
+
+- the supported architecture, from current first-party documentation;
+- the real Azure MCP Server (3.0.0-beta.34) starts over stdio and exposes exactly the six allowlisted tools under the `--tool` filter, with `investigate_yolo` absent;
+- the full adapter against a protocol-faithful fake MCP server.
+
+What is **not** proven and must be completed before claiming "SRE Agent diagnosed" in a customer demo:
+
+- a real thread ID and cited response from a live agent;
+- a real approval gate pausing in standard mode;
+- correlation of a Mission Control `correlationId` with an SRE Agent audit event.
+
+### Live validation runbook
+
+Run against a real SRE Agent resource. Every step is read-only apart from creating an investigation thread. **Do not run against the AmeriGas resource group.**
+
+```bash
+# 0. Prerequisites: Node.js LTS, Azure CLI, an SRE Agent with provisioningState=Succeeded.
+az login                        # add --tenant <agent-tenant-id> if cross-tenant
+az account set --subscription <sub-id>
+
+# 1. Assign least-privilege RBAC at the agent scope (once).
+OBJECT_ID=$(az ad signed-in-user show --query id -o tsv)
+SCOPE=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.App/agents/<agentName>
+az role assignment create --assignee "$OBJECT_ID" --role "Reader" --scope "$SCOPE"
+az role assignment create --assignee "$OBJECT_ID" --role "SRE Agent Administrator" --scope "$SCOPE"
+
+# 2. Confirm the tool surface excludes investigate_yolo (independent of Mission Control).
+npx -y @azure/mcp@latest server start --namespace sreagent --mode all   # 55 tools, includes yolo
+# Mission Control instead launches with the six --tool flags; preflight asserts this.
+
+# 3. Configure and start Mission Control.
+export SRE_AGENT_NAME=<agentName>
+export SRE_AGENT_SUBSCRIPTION_ID=<sub-id>
+export SRE_AGENT_RESOURCE_GROUP=<rg>
+cd mission-control && npm run build && npm start
+
+# 4. Preflight — expect every check to pass.
+curl -s localhost:3333/api/sre-agent/preflight | jq '.ready, .checks'
+
+# 5. Discovery — capture with IDs already masked by the backend.
+curl -s localhost:3333/api/sre-agent/agents | jq '.selected'
+
+# 6. Cited investigation (Evidence 1). Inject the scenario first: kubectl apply -f k8s/scenarios/oom-killed.yaml
+curl -s -X POST localhost:3333/api/sre-agent/investigations \
+  -H 'content-type: application/json' -d '{"scenarioName":"OOMKilled"}' \
+  | jq '{provenance, status, agent, thread, citationsPresent, citations, correlationId: .metadata.correlationId}'
+
+# 7. Follow-up on the same thread.
+curl -s -X POST localhost:3333/api/sre-agent/investigations/continue \
+  -H 'content-type: application/json' \
+  -d '{"threadId":"<threadId>","prompt":"What memory limit do you recommend?"}' | jq '.thread.id'
+
+# 8. Approval gate (Evidence 2): ask for a remediation that requires approval and confirm
+#    status == "awaiting-approval" and approval.autoApproved == false. Approve in the portal.
+
+# 9. Negative test (Evidence 3): confirm yolo cannot be selected or called.
+curl -s localhost:3333/api/sre-agent/config | jq '.target.allowedTools, .target.blockedTools'
+
+# 10. Audit correlation (Evidence 4): match metadata.correlationId to the SRE Agent
+#     Application Insights customEvents / TraceId per docs/SRE-AGENT-API-RESEARCH.md §3.
+```
+
+Record results in [`docs/EXTERNAL-DEMO-HARDENING.md`](EXTERNAL-DEMO-HARDENING.md) and keep the portal validation workflow authoritative until this runbook has been completed.
+
+---
+
+## 11. Supportability notes
+
+- `@azure/mcp@latest` currently resolves to **3.0.0-beta.34**. Pin `SRE_AGENT_MCP_PACKAGE` to an exact version for a customer demo; `npx` caches aggressively (`rm -rf ~/.npm/_npx` to force an update).
+- The SRE Agent MCP server is a **preview-stage** surface; tool names and response shapes may change. Preflight fails loudly on a missing tool rather than degrading silently.
+- `--read-only` is available on Azure MCP Server but is **not** used here: it would block thread creation and investigation, which are the point of this integration. The narrower `--tool` allowlist is used instead.
+
+---
+
+## Document history
+
+| Date | Version | Change |
+|---|---|---|
+| 2026-08-12 | 1.0 | Initial supported SRE Agent MCP integration for issue #77 |

--- a/docs/SRE-AGENT-MCP-INTEGRATION.md
+++ b/docs/SRE-AGENT-MCP-INTEGRATION.md
@@ -93,7 +93,7 @@ Standard mode pauses at approval gates. Mission Control surfaces the paused stat
 | Credential handling | Host Azure identity only. Mission Control never reads, stores, forwards, or logs a token. No client secret is injected into the child environment. |
 | Browser exposure | The browser receives only typed contracts. Subscription/tenant GUIDs are masked (`11111111-****-****-****-555555`) in identity fields **and in the agent's response prose, citation labels, and approval detail**, because the agent routinely quotes ARM resource IDs. ARM IDs keep their resource group / resource name so the answer stays diagnostic. Citation **URLs** are left navigable so the cited evidence can be opened, so a portal link may still contain a resource path. |
 | Raw tool payloads | Never returned to the browser and never logged. Only parsed, redacted, bounded fields leave the backend. |
-| Redaction | Bearer/Basic headers, JWTs, `key=value` secrets, storage account keys, SAS query parameters, and PEM private keys are stripped from every string that leaves the adapter. |
+| Redaction | Bearer/Basic headers, JWTs, `key=value` secrets, storage account keys, SAS query parameters, and PEM private keys are stripped from every string that leaves the adapter. Child-process stderr uses a **streaming** redactor (`RedactedStreamBuffer`): output is redacted *before* it is length-bounded, only whole lines are committed so a secret marker can never be split, and an unterminated `BEGIN … PRIVATE KEY` sets a sticky suppression state. A naive raw rolling buffer would evict the `-----BEGIN-----` marker of a multi-kilobyte key while its body survived, defeating a later single redaction pass. |
 | Output bounding | Responses are truncated at `SRE_AGENT_MAX_RESPONSE_CHARS` (default 24,000) with explicit truncation marking. Citations capped at 25, prompts at 8,000 characters. |
 | Input validation | Prompts and thread IDs are validated before any dispatch; scenario starters are limited to the three approved validation scenarios. |
 | Audit | Every request/response/failure emits a structured record with `requester`, `tool`, `target`, `timestamp`, `resultStatus`, `correlationId`, and `redactionNotes`, matching [Local Analyst Governance](LOCAL-ANALYST-GOVERNANCE.md#audit-trail-requirements). Arguments are redacted before logging. |
@@ -239,7 +239,7 @@ All tests are deterministic and require no Azure access. `FakeMcpServer` is a **
 
 ```bash
 cd mission-control
-npm test -w backend      # 100 tests
+npm test -w backend      # 113 tests
 npm test -w frontend
 npm run lint             # vue-tsc + tsc
 npm run build
@@ -257,6 +257,11 @@ Coverage of the safety-critical behaviour:
 - timeout, cancellation mid-operation, and shutdown-aborts-in-flight;
 - auth / permission / network / not-found / runtime-missing mapped to actionable remediations;
 - raw subscription GUID absent from client payloads; prompts absent from persisted state;
+- child stderr containing a >2,000-character PEM private key never reaches the normalized
+  error message or the HTTP error body — asserted end to end through the real stderr
+  accumulation path, including the case where the `BEGIN` marker is evicted by later
+  output and the case where the key is still streaming (each test also asserts benign
+  stderr *does* reach the message, so the check cannot pass vacuously);
 - backend restart re-attach.
 
 ---

--- a/docs/SRE-AGENT-SETUP.md
+++ b/docs/SRE-AGENT-SETUP.md
@@ -264,12 +264,31 @@ For symptom-first diagnosis and setup validation, use these links:
 |------|------|
 | Full troubleshooting guide | [Troubleshooting Guide](TROUBLESHOOTING.md) |
 | SRE Agent setup issues | [Troubleshooting → SRE Agent Issues](TROUBLESHOOTING.md#sre-agent-issues) |
+| Mission Control MCP investigations | [Troubleshooting → Mission Control → Azure SRE Agent (MCP)](TROUBLESHOOTING.md#mission-control--azure-sre-agent-mcp-issues) |
 | Public LoadBalancer not responding | [Troubleshooting → Public LoadBalancer](TROUBLESHOOTING.md#public-loadbalancer-not-responding) |
 | Kubernetes service diagnostics | [Kubernetes Service Troubleshooting](KUBERNETES-SERVICE-TROUBLESHOOTING.md) |
 | Cost planning | [Cost Breakdown](COSTS.md) |
 
+## Step 5 (optional): Investigate from Mission Control
+
+Mission Control can start and continue a **real** SRE Agent investigation in-dashboard through the supported Azure MCP Server path, so a presenter does not have to switch to the portal to run a prompt.
+
+```bash
+export SRE_AGENT_NAME=<agentName>
+export SRE_AGENT_SUBSCRIPTION_ID=<subscriptionId>
+export SRE_AGENT_RESOURCE_GROUP=<resourceGroup>   # optional but recommended
+```
+
+Then open the **Investigate with Azure SRE Agent** panel under Controls. It requires **Reader** and **SRE Agent Administrator** on the agent resource (Step 2), Node.js LTS, and outbound access to `*.azuresre.ai`.
+
+Standard, approval-gated mode only: auto-approval (`investigate_yolo`) is blocked in code and absent from the MCP server surface. If MCP is unavailable the panel fails honestly and hands off to the portal — it never substitutes Local Analyst output.
+
+Full details, configuration, safety model, and the live validation runbook: [SRE Agent MCP Integration](SRE-AGENT-MCP-INTEGRATION.md).
+
 ## Additional Resources
 
 - [Azure SRE Agent Documentation](https://learn.microsoft.com/azure/sre-agent/)
+- [SRE Agent MCP server](https://learn.microsoft.com/azure/sre-agent/mcp-server)
+- [Set up the SRE Agent MCP server](https://learn.microsoft.com/azure/sre-agent/setup-mcp-server)
 - [SRE Agent FAQs](https://learn.microsoft.com/azure/sre-agent/faq)
 - [Supported Azure Services](https://learn.microsoft.com/azure/sre-agent/overview#supported-services)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -680,6 +680,35 @@ If this doesn't resolve the issue, see [Supportability Guide -> Restoring Health
 
 ---
 
+## Mission Control → Azure SRE Agent (MCP) Issues
+
+The Mission Control **Investigate with Azure SRE Agent** panel talks to a real Azure SRE Agent through the Azure MCP Server. Start with the built-in preflight, which names the failing control and its fix:
+
+```bash
+curl -s localhost:3333/api/sre-agent/preflight | jq '.ready, .checks'
+```
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Panel shows "Azure SRE Agent is not configured" | `SRE_AGENT_NAME` / `SRE_AGENT_SUBSCRIPTION_ID` unset | Set both, then restart Mission Control. See [SRE Agent MCP Integration §4](SRE-AGENT-MCP-INTEGRATION.md#4-configuration). |
+| `kind: "auth"` — authentication failed | Not signed in; Azure MCP Server suppresses interactive sign-in in server mode | `az login` (add `--tenant <agent-tenant-id>` for a cross-tenant agent), then retry |
+| `kind: "permission"` — 403 | Missing RBAC | Assign **Reader** (control plane) and **SRE Agent Administrator** (data plane) at the `Microsoft.App/agents` scope |
+| `kind: "not-found"` | Wrong agent name/subscription/resource group, or agent not provisioned | Verify config values and that `provisioningState` is `Succeeded` |
+| `kind: "network"` | `*.azuresre.ai` blocked by proxy/firewall | Allow outbound DNS + HTTPS to `*.azuresre.ai` and `management.azure.com` |
+| `kind: "runtime-missing"` | `npx` not on PATH | Install Node.js LTS, or set `SRE_AGENT_MCP_COMMAND` |
+| Preflight: "Azure MCP Server did not expose …" | Stale npx cache or a package version without the `sreagent` namespace | `rm -rf ~/.npm/_npx`, or pin `SRE_AGENT_MCP_PACKAGE` to a known-good version |
+| **Preflight: "Blocked tools were exposed"** | The `--tool` allowlist was not applied | **Do not demo this build.** Mission Control must launch Azure MCP Server with its six `--tool` flags. |
+| First investigation is very slow | Cold `npx` download of the MCP server | Pre-warm with `npx -y @azure/mcp@latest server start --help`, or pin the version |
+| `kind: "timeout"` | Investigation exceeded the configured budget | Narrow the prompt, or raise `SRE_AGENT_INVESTIGATION_TIMEOUT_MS` (max 15 min) |
+| Response shows "no citations" | The agent returned none | Expected. Mission Control never invents citations. |
+| Status stuck at "Awaiting approval" | Standard mode paused at an approval gate | Approve in the SRE Agent portal. Mission Control never auto-approves, by design. |
+| Stop pressed but the agent keeps working | No server-side cancel is documented | Mission Control aborts its request and does not retry; review the thread in the portal |
+| Thread lost after a backend restart | Expected — only the thread reference is durable | `GET /api/sre-agent/threads`, then `GET /api/sre-agent/investigations/:threadId` to re-attach |
+
+> **Never** work around a failure by using Local Analyst output in place of an SRE Agent answer. The failure path deliberately returns `localAnalystSubstituted: false` and a portal handoff.
+
+---
+
 ## Related Documentation
 
 | Document | Use When |
@@ -687,9 +716,10 @@ If this doesn't resolve the issue, see [Supportability Guide -> Restoring Health
 | [Supportability Guide](SUPPORTABILITY.md) | Understanding what's supportable, escalation paths, known limitations |
 | [Breakable Scenarios](BREAKABLE-SCENARIOS.md) | You need to understand or inject a specific failure scenario |
 | [SRE Agent Setup](SRE-AGENT-SETUP.md) | First-time setup, RBAC configuration, portal connection |
+| [SRE Agent MCP Integration](SRE-AGENT-MCP-INTEGRATION.md) | Mission Control's embedded SRE Agent investigations, config, and safety model |
 | [AKS maxPods Runbook](AKS-MAXPODS-MAINTENANCE-RUNBOOK.md) | Node pool replacement for scheduling pressure |
 | [Capability Contracts](CAPABILITY-CONTRACTS.md) | Architecture decisions, telemetry schemas, RBAC matrix |
 
 ---
 
-*Last updated: 2026-05-06 | Maintainer: SRE Lab Team*
+*Last updated: 2026-08-12 | Maintainer: SRE Lab Team*

--- a/mission-control/README.md
+++ b/mission-control/README.md
@@ -9,6 +9,7 @@ A local single-page application for managing the Azure SRE Agent Energy Grid dem
 - **Destroy** — Tear down infrastructure with safety confirmation gate (type "DELETE")
 - **Monitor** — Live pod status grid with auto-refresh and K8s event stream
 - **Ask Copilot** — Local, read-only Copilot SDK explainer for point-in-time Mission Control state snapshots
+- **Investigate with Azure SRE Agent** — Start and continue a **real**, approval-gated Azure SRE Agent investigation through the supported Azure MCP Server path, with agent/thread identity and citations shown in-dashboard ([docs](../docs/SRE-AGENT-MCP-INTEGRATION.md))
 - **Scenarios** — Enable/disable 10 breakable SRE scenarios with one click
 - **Scenario Narration** — Read-only, hideable presenter guidance sourced from structured metadata; it does not show expected Azure SRE Agent responses
 - **Portal Validation** — Track and confirm Azure SRE Agent portal evidence for OOMKilled, MongoDBDown, and ServiceMismatch scenarios
@@ -68,6 +69,14 @@ mission-control/
 | GET | `/api/events` | List K8s events |
 | GET | `/api/inventory` | Full namespace inventory (pods, services, deployments, events) |
 | POST | `/api/assistant/ask` | Ask Copilot about current Mission Control state |
+| GET | `/api/sre-agent/config` | SRE Agent config, masked target, tool allow/block lists, approved prompts |
+| GET | `/api/sre-agent/preflight` | SRE Agent auth/RBAC/network/tool-surface preflight |
+| GET | `/api/sre-agent/agents` | Discover SRE Agent resources |
+| GET | `/api/sre-agent/threads` | Recorded thread references (restart recovery) |
+| POST | `/api/sre-agent/investigations` | Start a standard, approval-gated SRE Agent investigation |
+| POST | `/api/sre-agent/investigations/continue` | Send a follow-up on the same thread |
+| GET | `/api/sre-agent/investigations/:threadId` | Read SRE Agent thread status |
+| POST | `/api/sre-agent/investigations/cancel` | Cancel an in-flight Mission Control SRE Agent operation |
 | GET | `/api/scenarios` | List all 10 scenarios with optional read-only narration metadata |
 | POST | `/api/scenarios/:name/enable` | Apply a breakable scenario |
 | POST | `/api/scenarios/:name/disable` | Revert a scenario |
@@ -141,9 +150,19 @@ This aligns with `docs/SAFE-LANGUAGE-GUARDRAILS.md` and `docs/evidence/wave5-liv
 
 ## Ask Copilot vs. Azure SRE Agent
 
+Mission Control has **two clearly separated assistants**. They are never interchangeable, and one is never used as a fallback for the other.
+
+| | **Ask Copilot** (Local Analyst) | **Investigate with Azure SRE Agent** |
+|---|---|---|
+| What it is | Local, read-only Copilot SDK explainer | The real Azure SRE Agent, via the supported Azure MCP Server path |
+| Data source | One point-in-time local Mission Control snapshot | A live Azure SRE Agent thread |
+| Panel | cyan **L** mark, "Local analyst · not Azure SRE Agent" | violet **A** mark, "Azure SRE Agent · cloud agent" |
+| Proof shown | snapshot timestamp | agent name, masked ARM ID, thread ID, status, elapsed time |
+| Can remediate | No | Recommends only; approvals happen in the SRE Agent portal |
+
 Ask Copilot is a **Technical Preview, local-only Mission Control explainer and triage assistant**. It answers from one explicit point-in-time state snapshot collected by the backend: preflight checks, Kubernetes `energy` namespace pods/services/deployments/events, scenario catalog/status, and job status without raw logs. It may explain state and suggest safe user-triggered next actions, but it does **not** deploy, destroy, repair, run shell commands, read arbitrary files, inspect secrets, or replace Azure SRE Agent.
 
-Azure SRE Agent remains the cloud diagnostic/remediation experience for Azure resources. Use Mission Control's assistant for local demo-state explanation; use Azure SRE Agent for cloud-side investigation.
+Azure SRE Agent remains the cloud diagnostic/remediation experience for Azure resources. Mission Control can now start and continue a real, approval-gated SRE Agent investigation in-dashboard; if that path is unavailable it fails honestly and hands off to the portal rather than showing Ask Copilot output in its place. See [SRE Agent MCP Integration](../docs/SRE-AGENT-MCP-INTEGRATION.md).
 
 ## Requirements
 
@@ -152,11 +171,14 @@ Azure SRE Agent remains the cloud diagnostic/remediation experience for Azure re
 - **Azure CLI** (`az`) — for Azure operations
 - **kubectl** — for K8s monitoring and scenarios
 - **GitHub Copilot CLI auth** — for the Ask Copilot assistant (`copilot --version`, then authenticate locally)
+- **Azure sign-in + SRE Agent RBAC** — optional, for real SRE Agent investigations (`az login`, plus Reader and SRE Agent Administrator on the agent resource)
 
 ## Security
 
 - Backend binds to `127.0.0.1` only (localhost)
 - No `shell: true` — all commands use structured `spawn()` args
 - Ask Copilot is backend-only, read-only, and restricted to a single Mission Control state snapshot tool
+- Azure SRE Agent access is limited to six allowlisted MCP tools; `investigate_yolo` and every auto-approval path are blocked in code and absent from the MCP server surface
+- Azure tokens stay server-side; subscription/tenant IDs are masked and raw tool payloads never reach the browser
 - Destroy requires explicit `"DELETE"` confirmation
 - One destructive job at a time (deploy OR destroy, not both)

--- a/mission-control/backend/package.json
+++ b/mission-control/backend/package.json
@@ -15,6 +15,7 @@
     "@fastify/static": "^9.1.3",
     "@fastify/websocket": "^11.0.0",
     "@github/copilot-sdk": "^0.3.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "fastify": "^5.2.0",
     "pino": "^9.6.0",
     "tree-kill": "^1.2.2"

--- a/mission-control/backend/src/routes/sre-agent.test.ts
+++ b/mission-control/backend/src/routes/sre-agent.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Route-level tests for the SRE Agent API.
+ *
+ * These boot a real Fastify instance with the routes registered against a
+ * fake-MCP-backed service, so request validation, status codes, and the
+ * "never substitute Local Analyst" contract are verified end to end.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerSreAgentRoutes, resolvePrompt } from './sre-agent.js';
+import { loadSreAgentConfig } from '../services/sre-agent/config.js';
+import { FakeMcpServer, fakeAgentPayload, fakeInvestigationPayload } from '../services/sre-agent/fakeMcpServer.js';
+import { SreAgentService } from '../services/sre-agent/SreAgentService.js';
+import { SreAgentOperationDeniedError } from '../services/sre-agent/operations.js';
+
+const SUBSCRIPTION = '11111111-2222-3333-4444-555555555555';
+
+function configuredService(fake: FakeMcpServer): SreAgentService {
+  return new SreAgentService(
+    loadSreAgentConfig({
+      SRE_AGENT_NAME: 'sre-agent-energygrid',
+      SRE_AGENT_SUBSCRIPTION_ID: SUBSCRIPTION,
+      SRE_AGENT_RESOURCE_GROUP: 'rg-srelab-eastus2',
+      SRE_AGENT_REQUEST_TIMEOUT_MS: '5000',
+      SRE_AGENT_INVESTIGATION_TIMEOUT_MS: '5000',
+    }),
+    fake.factory(),
+  );
+}
+
+function happyFake(): FakeMcpServer {
+  return new FakeMcpServer({
+    handlers: {
+      sreagent_agents_list: () => fakeAgentPayload(),
+      sreagent_agents_get: () => fakeAgentPayload(),
+      sreagent_threads_investigate: () => fakeInvestigationPayload(),
+      sreagent_threads_send_message: () => fakeInvestigationPayload(),
+      sreagent_threads_get: () => fakeInvestigationPayload(),
+      sreagent_threads_create: () => fakeInvestigationPayload(),
+    },
+  });
+}
+
+async function withApp(
+  service: SreAgentService,
+  run: (app: ReturnType<typeof Fastify>) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'sre-route-state-'));
+  const previous = process.env['SRE_AGENT_THREAD_STATE_PATH'];
+  process.env['SRE_AGENT_THREAD_STATE_PATH'] = join(dir, 'threads.json');
+
+  const app = Fastify({ logger: false });
+  registerSreAgentRoutes(app, service);
+  await app.ready();
+
+  try {
+    await run(app);
+  } finally {
+    await app.close();
+    await service.shutdown();
+    if (previous === undefined) delete process.env['SRE_AGENT_THREAD_STATE_PATH'];
+    else process.env['SRE_AGENT_THREAD_STATE_PATH'] = previous;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('the config route advertises the allowlist and never exposes a yolo tool', async () => {
+  const fake = happyFake();
+  await withApp(configuredService(fake), async (app) => {
+    const response = await app.inject({ method: 'GET', url: '/api/sre-agent/config' });
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json();
+    assert.equal(body.configured, true);
+    assert.equal(body.target.allowedTools.length, 6);
+    assert.ok(!body.target.allowedTools.some((tool: string) => /yolo/i.test(tool)));
+    assert.ok(body.target.blockedTools.includes('sreagent_threads_investigate_yolo'));
+    assert.ok(!JSON.stringify(body).includes(SUBSCRIPTION), 'raw subscription GUID must not be returned');
+    assert.equal(body.scenarioPrompts.length, 3);
+    for (const prompt of body.scenarioPrompts) {
+      assert.ok(prompt.prompt.length > 0);
+    }
+  });
+  await fake.close();
+});
+
+test('starting an investigation returns a real thread and agent identity', async () => {
+  const fake = happyFake();
+  await withApp(configuredService(fake), async (app) => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/sre-agent/investigations',
+      payload: { scenarioName: 'OOMKilled' },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.provenance, 'azure-sre-agent');
+    assert.equal(body.thread.id, 'thread-0f8a1c2d-9b3e-4c5f-8a7b-6d5e4f3a2b1c');
+    assert.equal(body.agent.name, 'sre-agent-energygrid');
+    assert.equal(body.approval.autoApproved, false);
+    assert.equal(body.metadata.tool, 'sreagent_threads_investigate');
+
+    // The approved scenario prompt was used verbatim — no manual copying required.
+    const investigateCall = fake.calls.find((call) => call.name === 'sreagent_threads_investigate');
+    assert.ok(String(investigateCall?.args['message']).length > 0);
+  });
+  await fake.close();
+});
+
+test('an unapproved scenario name is rejected', async () => {
+  const fake = happyFake();
+  await withApp(configuredService(fake), async (app) => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/sre-agent/investigations',
+      payload: { scenarioName: 'DropProductionDatabase' },
+    });
+
+    assert.equal(response.statusCode, 403);
+    const body = response.json();
+    assert.equal(body.kind, 'denied');
+    assert.equal(body.investigationStarted, false);
+    assert.equal(body.localAnalystSubstituted, false);
+  });
+  await fake.close();
+});
+
+test('a request with neither prompt nor scenario is rejected', async () => {
+  const fake = happyFake();
+  await withApp(configuredService(fake), async (app) => {
+    const response = await app.inject({ method: 'POST', url: '/api/sre-agent/investigations', payload: {} });
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.json().kind, 'denied');
+  });
+  await fake.close();
+});
+
+test('an MCP failure returns an honest error with the portal handoff and no fallback answer', async () => {
+  const fake = new FakeMcpServer({ failConnect: new Error('AuthorizationFailed: 403 Forbidden') });
+  await withApp(configuredService(fake), async (app) => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/sre-agent/investigations',
+      payload: { scenarioName: 'MongoDBDown' },
+    });
+
+    assert.equal(response.statusCode, 403);
+    const body = response.json();
+
+    assert.equal(body.kind, 'permission');
+    assert.equal(body.investigationStarted, false);
+    assert.equal(body.localAnalystSubstituted, false);
+    assert.match(body.remediation, /SRE Agent Administrator/);
+    assert.match(body.portalHandoff.href, /^https:\/\//);
+    assert.match(body.portalHandoff.description, /Local Analyst is not a substitute/i);
+    // The portal handoff carries the prompt so the presenter can continue manually.
+    assert.ok(String(body.portalHandoff.prompt ?? '').length > 0);
+
+    // Critically: no success-shaped fields are present.
+    assert.equal(body.provenance, undefined);
+    assert.equal(body.response, undefined);
+    assert.equal(body.thread, undefined);
+  });
+  await fake.close();
+});
+
+test('an unconfigured backend reports not-configured instead of pretending', async () => {
+  const fake = happyFake();
+  const service = new SreAgentService(loadSreAgentConfig({}), fake.factory());
+
+  await withApp(service, async (app) => {
+    const config = await app.inject({ method: 'GET', url: '/api/sre-agent/config' });
+    assert.equal(config.json().configured, false);
+    assert.ok(config.json().configurationIssues.length > 0);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/sre-agent/investigations',
+      payload: { prompt: 'why are pods restarting' },
+    });
+
+    assert.equal(response.statusCode, 503);
+    assert.equal(response.json().kind, 'not-configured');
+    assert.equal(response.json().localAnalystSubstituted, false);
+  });
+  await fake.close();
+});
+
+test('follow-up requires a valid thread ID', async () => {
+  const fake = happyFake();
+  await withApp(configuredService(fake), async (app) => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/sre-agent/investigations/continue',
+      payload: { threadId: 'nope', prompt: 'next step' },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.json().kind, 'denied');
+  });
+  await fake.close();
+});
+
+test('cancel requires a correlation ID and states the honest limitation', async () => {
+  const fake = happyFake();
+  await withApp(configuredService(fake), async (app) => {
+    const missing = await app.inject({ method: 'POST', url: '/api/sre-agent/investigations/cancel', payload: {} });
+    assert.equal(missing.statusCode, 400);
+
+    const unknown = await app.inject({
+      method: 'POST',
+      url: '/api/sre-agent/investigations/cancel',
+      payload: { correlationId: 'mc-unknown-0001' },
+    });
+    assert.equal(unknown.statusCode, 200);
+    assert.equal(unknown.json().cancelled, false);
+    assert.match(unknown.json().limitation, /does not document a server-side stop/i);
+  });
+  await fake.close();
+});
+
+test('recorded threads are exposed so the UI can re-attach after a restart', async () => {
+  const fake = happyFake();
+  await withApp(configuredService(fake), async (app) => {
+    await app.inject({ method: 'POST', url: '/api/sre-agent/investigations', payload: { scenarioName: 'ServiceMismatch' } });
+
+    const response = await app.inject({ method: 'GET', url: '/api/sre-agent/threads' });
+    assert.equal(response.statusCode, 200);
+    const threads = response.json().threads;
+    assert.equal(threads.length, 1);
+    assert.equal(threads[0].scenarioName, 'ServiceMismatch');
+    assert.equal(threads[0].threadId, 'thread-0f8a1c2d-9b3e-4c5f-8a7b-6d5e4f3a2b1c');
+  });
+  await fake.close();
+});
+
+test('resolvePrompt only seeds prompts from approved scenarios', () => {
+  assert.equal(resolvePrompt({ prompt: '  custom prompt ' }), 'custom prompt');
+  assert.ok(resolvePrompt({ scenarioName: 'OOMKilled' }).length > 0);
+  assert.throws(() => resolvePrompt({}), SreAgentOperationDeniedError);
+  assert.throws(
+    () => resolvePrompt({ scenarioName: 'NotAScenario' as never }),
+    SreAgentOperationDeniedError,
+  );
+});

--- a/mission-control/backend/src/routes/sre-agent.ts
+++ b/mission-control/backend/src/routes/sre-agent.ts
@@ -1,0 +1,227 @@
+/**
+ * REST surface for the Azure SRE Agent MCP integration.
+ *
+ * Every failure path returns `SreAgentErrorResponse`, which explicitly records
+ * `localAnalystSubstituted: false` and carries the portal handoff. Mission Control never
+ * returns a success-shaped body when the real agent could not be reached.
+ *
+ * No Azure token, MCP environment value, or raw tool payload is ever placed in a
+ * response body — only redacted, bounded fields defined by the typed contracts.
+ */
+
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { PORTAL_VALIDATION_SCENARIOS, getScenarioDescription, getScenarioPrompt } from '../services/PortalValidationService.js';
+import { SreAgentOperationDeniedError } from '../services/sre-agent/operations.js';
+import { redactSensitiveText } from '../services/sre-agent/redaction.js';
+import { collectSreAgentPreflight } from '../services/sre-agent/preflight.js';
+import { SreAgentMcpError } from '../services/sre-agent/SreAgentMcpClient.js';
+import {
+  SreAgentNotConfiguredError,
+  SreAgentProvenanceError,
+  SreAgentService,
+} from '../services/sre-agent/SreAgentService.js';
+import type {
+  ContinueSreAgentInvestigationRequest,
+  PortalValidationScenarioName,
+  SreAgentErrorResponse,
+  SreAgentFailureKind,
+  SreAgentScenarioPrompt,
+  StartSreAgentInvestigationRequest,
+} from '../types/index.js';
+
+let sharedService: SreAgentService | undefined;
+
+export function getSreAgentService(): SreAgentService {
+  sharedService ??= new SreAgentService();
+  return sharedService;
+}
+
+/** Test seam so integration tests can inject a fake-MCP-backed service. */
+export function setSreAgentServiceForTesting(service: SreAgentService | undefined): void {
+  sharedService = service;
+}
+
+export function registerSreAgentRoutes(app: FastifyInstance, service: SreAgentService = getSreAgentService()): void {
+  app.get('/api/sre-agent/config', async (_req, reply) =>
+    reply.send({
+      configured: service.configuration.configured,
+      enabled: service.configuration.enabled,
+      configurationIssues: [...service.configuration.configurationIssues],
+      target: service.targetSummary(),
+      portalHandoff: service.portalHandoff(),
+      scenarioPrompts: buildScenarioPrompts(),
+    }),
+  );
+
+  app.get<{ Querystring: { skipMcpProbe?: string } }>('/api/sre-agent/preflight', async (req, reply) => {
+    try {
+      const skipMcpProbe = req.query?.skipMcpProbe === 'true';
+      return reply.send(await collectSreAgentPreflight(service, { skipMcpProbe }));
+    } catch (error) {
+      return sendSreAgentError(reply, service, error);
+    }
+  });
+
+  app.get('/api/sre-agent/agents', async (_req, reply) => {
+    try {
+      return reply.send(await service.discoverAgents());
+    } catch (error) {
+      return sendSreAgentError(reply, service, error);
+    }
+  });
+
+  app.get('/api/sre-agent/threads', async (_req, reply) => {
+    try {
+      return reply.send({ threads: await service.listRecordedThreads() });
+    } catch (error) {
+      return sendSreAgentError(reply, service, error);
+    }
+  });
+
+  app.post<{ Body: StartSreAgentInvestigationRequest }>('/api/sre-agent/investigations', async (req, reply) => {
+    let prompt: string | undefined;
+    try {
+      const body = req.body ?? {};
+      prompt = resolvePrompt(body);
+      const investigation = await service.startInvestigation({ ...body, prompt });
+      return reply.send(investigation);
+    } catch (error) {
+      return sendSreAgentError(reply, service, error, prompt);
+    }
+  });
+
+  app.post<{ Body: ContinueSreAgentInvestigationRequest }>('/api/sre-agent/investigations/continue', async (req, reply) => {
+    try {
+      const body = req.body ?? ({} as ContinueSreAgentInvestigationRequest);
+      return reply.send(await service.continueInvestigation(body));
+    } catch (error) {
+      return sendSreAgentError(reply, service, error, req.body?.prompt);
+    }
+  });
+
+  app.get<{ Params: { threadId: string } }>('/api/sre-agent/investigations/:threadId', async (req, reply) => {
+    try {
+      return reply.send(await service.getThreadStatus(req.params.threadId));
+    } catch (error) {
+      return sendSreAgentError(reply, service, error);
+    }
+  });
+
+  app.post<{ Body: { correlationId?: string } }>('/api/sre-agent/investigations/cancel', async (req, reply) => {
+    const correlationId = req.body?.correlationId;
+    if (typeof correlationId !== 'string' || !correlationId.trim()) {
+      return reply.status(400).send(
+        buildErrorResponse(service, 'denied', 'A correlationId is required to cancel an operation.', 'Send the correlationId returned when the investigation started.'),
+      );
+    }
+
+    const cancelled = service.cancel(correlationId.trim());
+    return reply.send({
+      cancelled,
+      correlationId: correlationId.trim(),
+      message: cancelled
+        ? 'Mission Control aborted the in-flight request and will not retry it.'
+        : 'No matching in-flight Mission Control operation was found; it may have already completed.',
+      limitation:
+        'Azure MCP Server does not document a server-side stop for a running investigation. Agent-side work already started may continue; review the thread in the SRE Agent portal.',
+      timestamp: new Date().toISOString(),
+    });
+  });
+}
+
+function buildScenarioPrompts(): SreAgentScenarioPrompt[] {
+  return PORTAL_VALIDATION_SCENARIOS.map((scenarioName) => ({
+    scenarioName,
+    title: getScenarioDescription(scenarioName),
+    prompt: getScenarioPrompt(scenarioName),
+  }));
+}
+
+/**
+ * Resolves the prompt from either an approved scenario starter or an explicit operator
+ * prompt. Only the three validated scenarios may seed a prompt automatically.
+ */
+export function resolvePrompt(body: StartSreAgentInvestigationRequest): string {
+  const explicit = typeof body.prompt === 'string' ? body.prompt.trim() : '';
+  if (explicit) return explicit;
+
+  const scenarioName = body.scenarioName;
+  if (!scenarioName) {
+    throw new SreAgentOperationDeniedError('Provide a prompt or an approved scenarioName to start an investigation.');
+  }
+
+  if (!(PORTAL_VALIDATION_SCENARIOS as readonly string[]).includes(scenarioName)) {
+    throw new SreAgentOperationDeniedError(
+      `Scenario '${scenarioName}' is not an approved SRE Agent starter scenario (${PORTAL_VALIDATION_SCENARIOS.join(', ')}).`,
+    );
+  }
+
+  return getScenarioPrompt(scenarioName as PortalValidationScenarioName);
+}
+
+export function buildErrorResponse(
+  service: SreAgentService,
+  kind: SreAgentFailureKind,
+  error: string,
+  remediation: string,
+  prompt?: string,
+): SreAgentErrorResponse {
+  return {
+    error,
+    kind,
+    remediation,
+    investigationStarted: false,
+    localAnalystSubstituted: false,
+    portalHandoff: service.portalHandoff(prompt),
+    correlationId: `mc-${Date.now().toString(36)}`,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function sendSreAgentError(
+  reply: FastifyReply,
+  service: SreAgentService,
+  error: unknown,
+  prompt?: string,
+) {
+  if (error instanceof SreAgentNotConfiguredError) {
+    return reply.status(error.statusCode).send(buildErrorResponse(service, 'not-configured', error.message, error.remediation, prompt));
+  }
+
+  if (error instanceof SreAgentOperationDeniedError) {
+    return reply
+      .status(error.statusCode)
+      .send(
+        buildErrorResponse(
+          service,
+          'denied',
+          error.message,
+          'Mission Control only permits agent discovery, standard investigation, follow-up, and status reads.',
+          prompt,
+        ),
+      );
+  }
+
+  if (error instanceof SreAgentProvenanceError) {
+    return reply.status(error.statusCode).send(buildErrorResponse(service, error.kind, error.message, error.remediation, prompt));
+  }
+
+  if (error instanceof SreAgentMcpError) {
+    return reply.status(error.statusCode).send(buildErrorResponse(service, error.kind, error.message, error.remediation, prompt));
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return reply
+    .status(503)
+    .send(
+      buildErrorResponse(
+        service,
+        'unknown',
+        // Defense in depth: this branch handles errors that bypassed normalization, so
+        // redact and bound before the text reaches the browser.
+        `The Azure SRE Agent request failed: ${redactSensitiveText(message).slice(0, 500)}`,
+        'Verify Azure sign-in, RBAC, and network access, then retry. Use the portal handoff if the failure persists.',
+        prompt,
+      ),
+    );
+}

--- a/mission-control/backend/src/server.ts
+++ b/mission-control/backend/src/server.ts
@@ -17,6 +17,7 @@ import { registerPortalValidationRoutes } from './routes/portal-validations.js';
 import { registerAnalystRoutes } from './routes/analyst.js';
 import { registerIncidentRoutes } from './routes/incidents.js';
 import { registerRehearsalRoutes } from './routes/rehearsals.js';
+import { getSreAgentService, registerSreAgentRoutes } from './routes/sre-agent.js';
 import { addScenarioJsonBodyCompatibility } from './utils/jsonBodyCompatibility.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -88,6 +89,13 @@ async function start() {
   registerAnalystRoutes(app);
   registerIncidentRoutes(app);
   registerRehearsalRoutes(app);
+  registerSreAgentRoutes(app);
+
+  // The SRE Agent adapter owns a child MCP server process; stop it with the backend so
+  // no orphaned process keeps an Azure session open after shutdown.
+  app.addHook('onClose', async () => {
+    await getSreAgentService().shutdown();
+  });
 
   // SPA fallback — must be after API routes
   if (existsSync(frontendDist)) {
@@ -98,6 +106,21 @@ async function start() {
 
   await app.listen({ port: PORT, host: HOST });
   app.log.info(`Mission Control backend listening on http://${HOST}:${PORT}`);
+
+  // Fastify only runs onClose hooks from app.close(), so without these handlers the
+  // SRE Agent MCP child process would survive a Ctrl-C and keep an Azure session open.
+  let shuttingDown = false;
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      app.log.info(`Received ${signal}; shutting down Mission Control backend`);
+      app
+        .close()
+        .catch((err) => logger.error(err, 'Error during Mission Control shutdown'))
+        .finally(() => process.exit(0));
+    });
+  }
 
   // Auto-open browser in production mode (when serving built frontend)
   if (existsSync(frontendDist) && !process.env.NO_OPEN) {

--- a/mission-control/backend/src/services/sre-agent/SreAgentMcpClient.ts
+++ b/mission-control/backend/src/services/sre-agent/SreAgentMcpClient.ts
@@ -16,7 +16,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { buildChildEnv, type SreAgentConfig } from './config.js';
 import { assertToolAllowed, type SreAgentToolName } from './operations.js';
-import { redactSensitiveText } from './redaction.js';
+import { RedactedStreamBuffer, redactSensitiveText } from './redaction.js';
 import { logger } from '../../utils/logger.js';
 
 export type McpTransportFactory = (config: SreAgentConfig) => Promise<Transport> | Transport;
@@ -81,7 +81,12 @@ export class SreAgentMcpClient {
   private idleTimer?: NodeJS.Timeout;
   private inFlight = 0;
   private disposed = false;
-  private lastStderr = '';
+  /**
+   * Child stderr is accumulated through a redaction-safe streaming buffer rather than a
+   * raw rolling window: a raw window can evict a `-----BEGIN … PRIVATE KEY-----` marker
+   * while key body survives, defeating a later single redaction pass.
+   */
+  private readonly stderrBuffer = new RedactedStreamBuffer();
 
   constructor(
     private readonly config: SreAgentConfig,
@@ -207,19 +212,17 @@ export class SreAgentMcpClient {
     return client;
   }
 
-  /** Buffers a bounded tail of child stderr to explain startup failures. */
+  /** Buffers a bounded, redaction-safe tail of child stderr to explain startup failures. */
   private captureStderr(transport: Transport): void {
     // Reset per transport so stale output from a previous failed process is never
     // attributed to a later, unrelated failure.
-    this.lastStderr = '';
+    this.stderrBuffer.reset();
 
     const stderr = (transport as StdioClientTransport).stderr;
     if (!stderr || typeof stderr.on !== 'function') return;
 
     stderr.on('data', (chunk: Buffer | string) => {
-      // Buffer raw and redact once on read, so a secret straddling a chunk boundary is
-      // still matched by the redaction rules.
-      this.lastStderr = `${this.lastStderr}${String(chunk)}`.slice(-2_000);
+      this.stderrBuffer.append(String(chunk));
     });
   }
 
@@ -276,7 +279,7 @@ export class SreAgentMcpClient {
     const errorCode: string | number | undefined = (error as { code?: string | number })?.code;
     const message = redactSensitiveText(rawMessage);
     const normalized = message.toLowerCase();
-    const stderrHint = redactSensitiveText(this.lastStderr).trim();
+    const stderrHint = this.stderrBuffer.snapshot();
 
     if (options?.signal?.aborted || err?.name === 'AbortError' || normalized.includes('aborted')) {
       return new SreAgentMcpError(

--- a/mission-control/backend/src/services/sre-agent/SreAgentMcpClient.ts
+++ b/mission-control/backend/src/services/sre-agent/SreAgentMcpClient.ts
@@ -1,0 +1,383 @@
+/**
+ * Lifecycle-managed MCP client for the Azure MCP Server `sreagent` tool surface.
+ *
+ * Responsibilities:
+ *  - own the child process / transport lifecycle (lazy start, idle shutdown, disposal);
+ *  - enforce the tool allowlist immediately before every dispatch;
+ *  - apply per-call timeouts and cooperative cancellation;
+ *  - normalise transport failures into actionable, redacted errors.
+ *
+ * The transport is injected through `McpTransportFactory` so tests can run the real MCP
+ * protocol against an in-memory fake server without spawning `npx`.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { buildChildEnv, type SreAgentConfig } from './config.js';
+import { assertToolAllowed, type SreAgentToolName } from './operations.js';
+import { redactSensitiveText } from './redaction.js';
+import { logger } from '../../utils/logger.js';
+
+export type McpTransportFactory = (config: SreAgentConfig) => Promise<Transport> | Transport;
+
+/** JSON-RPC error code the MCP SDK raises when a request exceeds its timeout. */
+const MCP_REQUEST_TIMEOUT_CODE = -32001;
+
+export interface McpToolCallOptions {
+  readonly timeoutMs: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface McpToolCallResult {
+  /** Concatenated text content blocks, before bounding. */
+  readonly text: string;
+  readonly isError: boolean;
+  readonly structuredContent?: unknown;
+}
+
+export type SreAgentFailureKind =
+  | 'not-configured'
+  | 'auth'
+  | 'permission'
+  | 'not-found'
+  | 'network'
+  | 'timeout'
+  | 'cancelled'
+  | 'runtime-missing'
+  | 'protocol'
+  | 'denied'
+  | 'unknown';
+
+export class SreAgentMcpError extends Error {
+  readonly kind: SreAgentFailureKind;
+  readonly statusCode: number;
+  readonly remediation: string;
+
+  constructor(kind: SreAgentFailureKind, message: string, remediation: string, statusCode = 503) {
+    super(message);
+    this.name = 'SreAgentMcpError';
+    this.kind = kind;
+    this.remediation = remediation;
+    this.statusCode = statusCode;
+  }
+}
+
+/** Default transport: spawn Azure MCP Server over stdio with the tool allowlist applied. */
+export const createStdioTransport: McpTransportFactory = (config) =>
+  new StdioClientTransport({
+    command: config.command,
+    args: [...config.args],
+    env: buildChildEnv(config),
+    // 'pipe' keeps child diagnostics out of Mission Control's stdout, which would
+    // otherwise corrupt operator-facing logs and could leak environment detail.
+    stderr: 'pipe',
+  });
+
+export class SreAgentMcpClient {
+  private client?: Client;
+  private transport?: Transport;
+  private connecting?: Promise<Client>;
+  private idleTimer?: NodeJS.Timeout;
+  private inFlight = 0;
+  private disposed = false;
+  private lastStderr = '';
+
+  constructor(
+    private readonly config: SreAgentConfig,
+    private readonly transportFactory: McpTransportFactory = createStdioTransport,
+  ) {}
+
+  /** True when a live MCP session is currently held. */
+  get connected(): boolean {
+    return this.client !== undefined;
+  }
+
+  async listToolNames(): Promise<string[]> {
+    const client = await this.connect();
+    const { tools } = await client.listTools();
+    return tools.map((tool) => tool.name).sort();
+  }
+
+  /**
+   * Dispatches an allowlisted tool call.
+   *
+   * `assertToolAllowed` runs here — not only at the caller — so that every path into the
+   * MCP server is gated even if a future caller forgets.
+   */
+  async callTool(
+    toolName: SreAgentToolName,
+    args: Record<string, unknown>,
+    options: McpToolCallOptions,
+  ): Promise<McpToolCallResult> {
+    assertToolAllowed(toolName);
+
+    if (options.signal?.aborted) {
+      throw new SreAgentMcpError('cancelled', 'The SRE Agent operation was cancelled before it started.', 'Start a new investigation when ready.', 499);
+    }
+
+    const client = await this.connect();
+    this.inFlight += 1;
+    this.clearIdleTimer();
+
+    try {
+      const result = await client.callTool(
+        { name: toolName, arguments: args },
+        undefined,
+        {
+          timeout: options.timeoutMs,
+          ...(options.signal ? { signal: options.signal } : {}),
+        },
+      );
+
+      return normalizeToolResult(result);
+    } catch (error) {
+      throw this.normalizeError(error, options);
+    } finally {
+      this.inFlight = Math.max(0, this.inFlight - 1);
+      this.scheduleIdleShutdown();
+    }
+  }
+
+  /** Establishes (or reuses) a session. Concurrent callers share one connect attempt. */
+  private async connect(): Promise<Client> {
+    if (this.disposed) {
+      throw new SreAgentMcpError('protocol', 'The SRE Agent MCP client has been shut down.', 'Restart Mission Control to reconnect.', 503);
+    }
+    if (this.client) return this.client;
+    if (this.connecting) return this.connecting;
+
+    this.connecting = this.establish().finally(() => {
+      this.connecting = undefined;
+    });
+
+    return this.connecting;
+  }
+
+  private async establish(): Promise<Client> {
+    const client = new Client(
+      { name: 'mission-control-sre-agent', version: '1.0.0' },
+      { capabilities: {} },
+    );
+
+    let transport: Transport;
+    try {
+      transport = await this.transportFactory(this.config);
+    } catch (error) {
+      throw this.normalizeError(error);
+    }
+
+    this.captureStderr(transport);
+
+    transport.onerror = (error: Error) => {
+      logger.warn({ err: redactSensitiveText(error.message) }, 'SRE Agent MCP transport error');
+    };
+    transport.onclose = () => {
+      // Drop the cached session so the next call reconnects instead of using a dead pipe.
+      if (this.transport === transport) {
+        this.client = undefined;
+        this.transport = undefined;
+      }
+    };
+
+    try {
+      await client.connect(transport);
+    } catch (error) {
+      await safeClose(transport);
+      throw this.normalizeError(error);
+    }
+
+    // dispose() may have been called while the child process was starting (a cold npx
+    // start takes seconds). Without this re-check the freshly connected transport would
+    // be cached on a disposed client and never closed, orphaning the child process.
+    if (this.disposed) {
+      await client.close().catch(() => undefined);
+      await safeClose(transport);
+      throw new SreAgentMcpError(
+        'protocol',
+        'The SRE Agent MCP client was shut down while the server was starting.',
+        'Restart Mission Control to reconnect.',
+        503,
+      );
+    }
+
+    this.client = client;
+    this.transport = transport;
+    this.scheduleIdleShutdown();
+    return client;
+  }
+
+  /** Buffers a bounded tail of child stderr to explain startup failures. */
+  private captureStderr(transport: Transport): void {
+    // Reset per transport so stale output from a previous failed process is never
+    // attributed to a later, unrelated failure.
+    this.lastStderr = '';
+
+    const stderr = (transport as StdioClientTransport).stderr;
+    if (!stderr || typeof stderr.on !== 'function') return;
+
+    stderr.on('data', (chunk: Buffer | string) => {
+      // Buffer raw and redact once on read, so a secret straddling a chunk boundary is
+      // still matched by the redaction rules.
+      this.lastStderr = `${this.lastStderr}${String(chunk)}`.slice(-2_000);
+    });
+  }
+
+  private scheduleIdleShutdown(): void {
+    this.clearIdleTimer();
+    if (this.inFlight > 0 || !this.client || this.disposed) return;
+
+    this.idleTimer = setTimeout(() => {
+      if (this.inFlight === 0) {
+        void this.disconnect();
+      }
+    }, this.config.idleShutdownMs);
+    this.idleTimer.unref?.();
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = undefined;
+    }
+  }
+
+  /** Tears down the current session without permanently disabling the client. */
+  async disconnect(): Promise<void> {
+    this.clearIdleTimer();
+    const client = this.client;
+    const transport = this.transport;
+    this.client = undefined;
+    this.transport = undefined;
+
+    if (client) {
+      await client.close().catch(() => undefined);
+    }
+    if (transport) {
+      await safeClose(transport);
+    }
+  }
+
+  /** Permanently shuts the client down; used on backend shutdown. */
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    // Wait for any in-flight connect to settle so its transport is disconnected too,
+    // rather than being established moments after we tear down.
+    await this.connecting?.catch(() => undefined);
+    await this.disconnect();
+  }
+
+  private normalizeError(error: unknown, options?: McpToolCallOptions): SreAgentMcpError {
+    if (error instanceof SreAgentMcpError) return error;
+
+    const err = error as NodeJS.ErrnoException;
+    const rawMessage = err?.message ?? String(error);
+    // MCP protocol errors carry a numeric JSON-RPC code; Node system errors carry a string code.
+    const errorCode: string | number | undefined = (error as { code?: string | number })?.code;
+    const message = redactSensitiveText(rawMessage);
+    const normalized = message.toLowerCase();
+    const stderrHint = redactSensitiveText(this.lastStderr).trim();
+
+    if (options?.signal?.aborted || err?.name === 'AbortError' || normalized.includes('aborted')) {
+      return new SreAgentMcpError(
+        'cancelled',
+        'The SRE Agent operation was cancelled.',
+        'The in-flight request was aborted. Any agent-side work already started continues in the SRE Agent portal.',
+        499,
+      );
+    }
+
+    if (errorCode === 'ENOENT') {
+      return new SreAgentMcpError(
+        'runtime-missing',
+        `Could not launch the Azure MCP Server (command '${this.config.command}' not found).`,
+        'Install Node.js LTS so npx is on PATH, or set SRE_AGENT_MCP_COMMAND to a valid launcher.',
+        503,
+      );
+    }
+
+    if (normalized.includes('timeout') || normalized.includes('timed out') || errorCode === MCP_REQUEST_TIMEOUT_CODE) {
+      return new SreAgentMcpError(
+        'timeout',
+        'The SRE Agent operation did not complete before the Mission Control timeout.',
+        'Retry with a narrower prompt, or continue the investigation in the SRE Agent portal.',
+        504,
+      );
+    }
+
+    if (/401|unauthor|not signed in|no.*credential|interactive.*suppress|defaultazurecredential/i.test(message)) {
+      return new SreAgentMcpError(
+        'auth',
+        'Azure authentication failed for the SRE Agent MCP server.',
+        'Run `az login` (add `--tenant <agent-tenant-id>` if the agent is in another tenant), then retry.',
+        401,
+      );
+    }
+
+    if (/403|forbidden|not authorized|authorizationfailed|does not have authorization/i.test(message)) {
+      return new SreAgentMcpError(
+        'permission',
+        'Azure denied the SRE Agent request (missing RBAC).',
+        'Assign Reader (control plane) and SRE Agent Administrator (data plane) on the Microsoft.App/agents resource.',
+        403,
+      );
+    }
+
+    if (/404|not found|resourcenotfound|no agent endpoint/i.test(message)) {
+      return new SreAgentMcpError(
+        'not-found',
+        'The configured SRE Agent resource or thread was not found.',
+        'Confirm SRE_AGENT_NAME, SRE_AGENT_SUBSCRIPTION_ID, and SRE_AGENT_RESOURCE_GROUP, and that provisioningState is Succeeded.',
+        404,
+      );
+    }
+
+    if (/enotfound|econnrefused|eai_again|etimedout|econnreset|network|dns|proxy|azuresre\.ai/i.test(message)) {
+      return new SreAgentMcpError(
+        'network',
+        'Mission Control could not reach the SRE Agent data-plane endpoint.',
+        'Allow outbound HTTPS to *.azuresre.ai and management.azure.com, then retry.',
+        503,
+      );
+    }
+
+    const detail = stderrHint ? `${message} (server: ${stderrHint.slice(-300)})` : message;
+    return new SreAgentMcpError(
+      'unknown',
+      `The SRE Agent MCP server request failed: ${detail}`,
+      'Check Azure sign-in, RBAC, and network access, then retry. Use the SRE Agent portal handoff if the failure persists.',
+      503,
+    );
+  }
+}
+
+async function safeClose(transport: Transport): Promise<void> {
+  try {
+    await transport.close();
+  } catch {
+    // Closing a already-dead transport is not actionable.
+  }
+}
+
+/** Flattens MCP content blocks into plain text plus any structured payload. */
+export function normalizeToolResult(result: unknown): McpToolCallResult {
+  const record = (result ?? {}) as Record<string, unknown>;
+  const content = Array.isArray(record.content) ? record.content : [];
+
+  const text = content
+    .map((block) => {
+      const entry = block as Record<string, unknown>;
+      if (entry?.type === 'text' && typeof entry.text === 'string') return entry.text;
+      if (typeof entry?.text === 'string') return entry.text;
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+
+  return {
+    text,
+    isError: record.isError === true,
+    structuredContent: record.structuredContent,
+  };
+}

--- a/mission-control/backend/src/services/sre-agent/SreAgentService.test.ts
+++ b/mission-control/backend/src/services/sre-agent/SreAgentService.test.ts
@@ -1,0 +1,704 @@
+/**
+ * Integration tests for the SRE Agent adapter.
+ *
+ * These run the real MCP protocol (official SDK client + server) over
+ * `InMemoryTransport` against `FakeMcpServer`. No `npx`, no Azure, no network.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadSreAgentConfig, type SreAgentConfig } from './config.js';
+import { FakeMcpServer, fakeAgentPayload, fakeInvestigationPayload } from './fakeMcpServer.js';
+import { SreAgentMcpClient, SreAgentMcpError } from './SreAgentMcpClient.js';
+import {
+  SreAgentNotConfiguredError,
+  SreAgentProvenanceError,
+  SreAgentService,
+  normalizePrompt,
+  normalizeThreadId,
+} from './SreAgentService.js';
+import { SreAgentOperationDeniedError } from './operations.js';
+import { collectSreAgentPreflight } from './preflight.js';
+
+const SUBSCRIPTION = '11111111-2222-3333-4444-555555555555';
+const AGENT_NAME = 'sre-agent-energygrid';
+const THREAD_ID = 'thread-0f8a1c2d-9b3e-4c5f-8a7b-6d5e4f3a2b1c';
+
+function testConfig(overrides: Record<string, string> = {}): SreAgentConfig {
+  return loadSreAgentConfig({
+    SRE_AGENT_NAME: AGENT_NAME,
+    SRE_AGENT_SUBSCRIPTION_ID: SUBSCRIPTION,
+    SRE_AGENT_RESOURCE_GROUP: 'rg-srelab-eastus2',
+    SRE_AGENT_REQUEST_TIMEOUT_MS: '5000',
+    SRE_AGENT_INVESTIGATION_TIMEOUT_MS: '5000',
+    ...overrides,
+  });
+}
+
+function happyHandlers(investigationOverrides: Record<string, unknown> = {}) {
+  return {
+    sreagent_agents_list: () => fakeAgentPayload(),
+    sreagent_agents_get: () => fakeAgentPayload(),
+    sreagent_threads_investigate: () => fakeInvestigationPayload(investigationOverrides),
+    sreagent_threads_send_message: () => fakeInvestigationPayload(investigationOverrides),
+    sreagent_threads_get: () => fakeInvestigationPayload(investigationOverrides),
+    sreagent_threads_create: () => fakeInvestigationPayload(investigationOverrides),
+  };
+}
+
+/** Isolates the durable thread-reference file per test. */
+async function withThreadState<T>(run: () => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'sre-thread-state-'));
+  const previous = process.env['SRE_AGENT_THREAD_STATE_PATH'];
+  process.env['SRE_AGENT_THREAD_STATE_PATH'] = join(dir, 'threads.json');
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env['SRE_AGENT_THREAD_STATE_PATH'];
+    else process.env['SRE_AGENT_THREAD_STATE_PATH'] = previous;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// --- happy path: real provenance --------------------------------------------
+
+test('a completed investigation carries real agent and thread identity', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const investigation = await service.startInvestigation({ prompt: 'Why are meter-service pods restarting?' });
+
+      assert.equal(investigation.provenance, 'azure-sre-agent');
+      assert.equal(investigation.status, 'completed');
+      assert.equal(investigation.thread.id, THREAD_ID);
+      assert.equal(investigation.agent.name, AGENT_NAME);
+      assert.equal(investigation.agent.location, 'eastus2');
+      assert.equal(investigation.agent.provisioningState, 'Succeeded');
+      assert.equal(investigation.agent.endpointHost, 'sre-agent-energygrid.eastus2.azuresre.ai');
+      assert.match(investigation.response, /OOMKilled/);
+      assert.equal(investigation.approval.autoApproved, false);
+      assert.equal(investigation.metadata.tool, 'sreagent_threads_investigate');
+      assert.ok(investigation.metadata.elapsedMs >= 0);
+      assert.ok(investigation.metadata.correlationId.length > 0);
+
+      // Only the allowlisted tools were touched, and never yolo.
+      assert.deepEqual(fake.calledToolNames, ['sreagent_agents_get', 'sreagent_threads_investigate']);
+      assert.ok(!fake.calledToolNames.some((name) => /yolo/i.test(name)));
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('agent ARM ID and subscription are masked before leaving the backend', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const investigation = await service.startInvestigation({ prompt: 'status check' });
+      const serialized = JSON.stringify(investigation);
+
+      assert.ok(!serialized.includes(SUBSCRIPTION), 'raw subscription GUID leaked to the client payload');
+      assert.ok(investigation.agent.armIdMasked?.includes('agents/sre-agent-energygrid'));
+      assert.ok(investigation.agent.subscriptionIdMasked?.includes('****'));
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('identifiers quoted by the agent in prose and citations are masked too', async () => {
+  await withThreadState(async () => {
+    const armId = `/subscriptions/${SUBSCRIPTION}/resourceGroups/rg-srelab-eastus2/providers/Microsoft.ContainerService/managedClusters/aks-demo`;
+    const fake = new FakeMcpServer({
+      handlers: happyHandlers({
+        response: `Root cause: the AKS cluster ${armId} has a 128Mi memory limit. Subscription ${SUBSCRIPTION} is affected.`,
+        citations: [{ title: `AKS resource ${armId}`, source: 'Azure Resource Graph' }],
+        approvalMessage: `Approval required to scale ${armId}.`,
+        approvalRequired: true,
+      }),
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const investigation = await service.startInvestigation({ prompt: 'why' });
+      const serialized = JSON.stringify(investigation);
+
+      // The whole client payload — response prose, citation labels and approval detail.
+      assert.ok(!serialized.includes(SUBSCRIPTION), 'subscription GUID leaked in the response payload');
+      assert.ok(!investigation.response.includes(SUBSCRIPTION));
+      assert.ok(!investigation.citations[0]?.label.includes(SUBSCRIPTION));
+      assert.ok(!(investigation.approval.detail ?? '').includes(SUBSCRIPTION));
+
+      // Diagnostic value is preserved.
+      assert.match(investigation.response, /managedClusters\/aks-demo/);
+      assert.match(investigation.response, /128Mi/);
+      assert.match(investigation.citations[0]?.label ?? '', /aks-demo/);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('citations are rendered when present and reported absent when not', async () => {
+  await withThreadState(async () => {
+    const withCitations = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), withCitations.factory());
+    try {
+      const investigation = await service.startInvestigation({ prompt: 'why' });
+      assert.equal(investigation.citationsPresent, true);
+      assert.equal(investigation.citations.length, 2);
+      assert.equal(investigation.citations[0]?.label, 'KubePodInventory — meter-service restarts');
+      assert.equal(investigation.citations[0]?.url, 'https://portal.azure.com/#logs');
+      assert.equal(investigation.citations[0]?.source, 'Log Analytics');
+    } finally {
+      await service.shutdown();
+      await withCitations.close();
+    }
+
+    const withoutCitations = new FakeMcpServer({ handlers: happyHandlers({ citations: [] }) });
+    const bare = new SreAgentService(testConfig(), withoutCitations.factory());
+    try {
+      const investigation = await bare.startInvestigation({ prompt: 'why' });
+      assert.equal(investigation.citationsPresent, false);
+      assert.deepEqual(investigation.citations, []);
+    } finally {
+      await bare.shutdown();
+      await withoutCitations.close();
+    }
+  });
+});
+
+// --- approval gates ----------------------------------------------------------
+
+test('standard mode surfaces an approval gate and never auto-approves', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      handlers: happyHandlers({
+        approvalRequired: true,
+        approvalMessage: 'Approval required to restart the meter-service deployment.',
+        response: 'I can restart the deployment, but this action requires your approval.',
+      }),
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const investigation = await service.startInvestigation({ prompt: 'fix meter-service' });
+
+      assert.equal(investigation.status, 'awaiting-approval');
+      assert.equal(investigation.approval.required, true);
+      assert.equal(investigation.approval.autoApproved, false);
+      assert.match(investigation.approval.detail ?? '', /Approval required/);
+      assert.ok(
+        investigation.metadata.limitations.some((entry) => /never auto-approves/i.test(entry)),
+        'limitations must state that Mission Control never auto-approves',
+      );
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('an approval gate is detected from prose when no structured flag is present', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      handlers: happyHandlers({ response: 'I have a remediation ready. Approval is required before I proceed.' }),
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const investigation = await service.startInvestigation({ prompt: 'fix it' });
+      assert.equal(investigation.status, 'awaiting-approval');
+      assert.equal(investigation.approval.required, true);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+// --- provenance enforcement --------------------------------------------------
+
+test('a response without a thread ID is refused rather than attributed to SRE Agent', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      handlers: {
+        ...happyHandlers(),
+        sreagent_threads_investigate: () => ({ status: 200, results: { response: 'Some answer with no thread.' } }),
+      },
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      await assert.rejects(
+        () => service.startInvestigation({ prompt: 'why' }),
+        (error: unknown) => {
+          assert.ok(error instanceof SreAgentProvenanceError);
+          assert.match(error.message, /without a thread ID/i);
+          return true;
+        },
+      );
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('an unresolvable agent resource is refused rather than assumed', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      handlers: { ...happyHandlers(), sreagent_agents_get: () => ({ status: 200, results: [] }) },
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      await assert.rejects(() => service.startInvestigation({ prompt: 'why' }), SreAgentProvenanceError);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('a tool error is surfaced as a failure, never as a successful investigation', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      handlers: { sreagent_agents_get: () => fakeAgentPayload() },
+      toolNames: ['sreagent_agents_get', 'sreagent_threads_investigate'],
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      // No handler registered for investigate -> fake server returns isError.
+      await assert.rejects(() => service.startInvestigation({ prompt: 'why' }), SreAgentMcpError);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+// --- follow-up and thread continuity ----------------------------------------
+
+test('a follow-up continues the same thread', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const first = await service.startInvestigation({ prompt: 'why are pods restarting?' });
+      const followUp = await service.continueInvestigation({ threadId: first.thread.id, prompt: 'what should we change?' });
+
+      assert.equal(followUp.thread.id, first.thread.id);
+      assert.equal(followUp.metadata.tool, 'sreagent_threads_send_message');
+
+      const sendCall = fake.calls.find((call) => call.name === 'sreagent_threads_send_message');
+      assert.equal(sendCall?.args['thread-id'], THREAD_ID);
+      assert.equal(sendCall?.args['message'], 'what should we change?');
+      assert.equal(sendCall?.args['agent'], AGENT_NAME);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('a follow-up echoing no thread ID still resolves to the requested thread', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      handlers: {
+        ...happyHandlers(),
+        sreagent_threads_send_message: () => ({ status: 200, results: { response: 'Scale the memory limit to 256Mi.' } }),
+      },
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const followUp = await service.continueInvestigation({ threadId: THREAD_ID, prompt: 'next step?' });
+      assert.equal(followUp.thread.id, THREAD_ID);
+      assert.match(followUp.response, /256Mi/);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+// --- backend restart / reconnect --------------------------------------------
+
+test('an in-flight thread survives a backend restart and can be re-attached', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const first = new SreAgentService(testConfig(), fake.factory());
+
+    let threadId: string;
+    try {
+      const investigation = await first.startInvestigation(
+        { prompt: 'why are pods restarting?', scenarioName: 'OOMKilled' },
+        undefined,
+      );
+      threadId = investigation.thread.id;
+
+      const recorded = await first.listRecordedThreads();
+      assert.equal(recorded.length, 1);
+      assert.equal(recorded[0]?.threadId, threadId);
+      assert.equal(recorded[0]?.scenarioName, 'OOMKilled');
+    } finally {
+      // Simulate a backend restart: dispose the client and the child transport.
+      await first.shutdown();
+    }
+
+    const restarted = new SreAgentService(testConfig(), fake.factory());
+    try {
+      const recorded = await restarted.listRecordedThreads();
+      assert.equal(recorded[0]?.threadId, threadId);
+
+      // The thread lives server-side, so status can be read on a brand-new session.
+      const status = await restarted.getThreadStatus(threadId);
+      assert.equal(status.thread.id, threadId);
+      assert.equal(status.provenance, 'azure-sre-agent');
+      assert.equal(status.metadata.tool, 'sreagent_threads_get');
+    } finally {
+      await restarted.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('thread references persist to disk without leaking prompts or secrets', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      await service.startInvestigation({ prompt: 'password=hunter2 investigate meter-service' });
+      const raw = await readFile(process.env['SRE_AGENT_THREAD_STATE_PATH']!, 'utf8');
+      assert.ok(!raw.includes('hunter2'), 'prompt content must not be persisted');
+      assert.ok(raw.includes(THREAD_ID));
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+// --- timeout and cancellation ------------------------------------------------
+
+test('an operation that exceeds the timeout fails as a timeout, not a result', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers(), hangMs: 5_000 });
+    const service = new SreAgentService(testConfig({ SRE_AGENT_REQUEST_TIMEOUT_MS: '5000' }), fake.factory());
+
+    try {
+      await assert.rejects(
+        () => service.getConfiguredAgent(AbortSignal.timeout(250)),
+        (error: unknown) => {
+          assert.ok(error instanceof SreAgentMcpError);
+          assert.ok(['timeout', 'cancelled'].includes(error.kind), `unexpected kind ${error.kind}`);
+          return true;
+        },
+      );
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('cancel aborts the in-flight operation and reports the honest limitation', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers(), hangMs: 5_000 });
+    const service = new SreAgentService(testConfig(), fake.factory());
+    const correlationId = 'mc-cancel-test-0001';
+
+    try {
+      const pending = service.startInvestigation({ prompt: 'long investigation', correlationId });
+
+      // Wait until the investigate call is actually in flight before cancelling.
+      await waitUntil(() => service.activeOperationIds().includes(correlationId), 3_000);
+      assert.equal(service.cancel(correlationId), true);
+
+      await assert.rejects(pending, (error: unknown) => {
+        assert.ok(error instanceof SreAgentMcpError);
+        assert.equal(error.kind, 'cancelled');
+        return true;
+      });
+
+      // A second cancel is a no-op, not an error.
+      assert.equal(service.cancel(correlationId), false);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('shutdown aborts every in-flight operation', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers(), hangMs: 5_000 });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    const pending = service.startInvestigation({ prompt: 'long investigation', correlationId: 'mc-shutdown-0001' });
+    await waitUntil(() => service.activeOperationIds().length > 0, 3_000);
+
+    await service.shutdown();
+    await assert.rejects(pending);
+    await fake.close();
+  });
+});
+
+test('disposing while the MCP server is still starting does not orphan the transport', async () => {
+  const fake = new FakeMcpServer({ handlers: happyHandlers() });
+  const slowFactory = async (config: SreAgentConfig) => {
+    // Simulate a cold `npx @azure/mcp` start that takes time to come up.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    return fake.factory()(config);
+  };
+
+  const client = new SreAgentMcpClient(testConfig(), slowFactory);
+  const pending = client.listToolNames();
+
+  // Dispose mid-connect.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  await client.dispose();
+
+  await assert.rejects(pending);
+  assert.equal(client.connected, false, 'a disposed client must not cache a live session');
+
+  // A disposed client stays disposed and cannot start another child process.
+  await assert.rejects(() => client.listToolNames(), SreAgentMcpError);
+  assert.equal(client.connected, false);
+
+  await fake.close();
+});
+
+// --- failure modes -----------------------------------------------------------
+
+test('an unconfigured adapter refuses every operation with actionable guidance', async () => {
+  const service = new SreAgentService(loadSreAgentConfig({}), new FakeMcpServer().factory());
+
+  await assert.rejects(() => service.discoverAgents(), SreAgentNotConfiguredError);
+  await assert.rejects(() => service.startInvestigation({ prompt: 'why' }), SreAgentNotConfiguredError);
+  await assert.rejects(() => service.continueInvestigation({ threadId: THREAD_ID, prompt: 'why' }), SreAgentNotConfiguredError);
+  await assert.rejects(() => service.getThreadStatus(THREAD_ID), SreAgentNotConfiguredError);
+
+  const handoff = service.portalHandoff('prompt text');
+  assert.match(handoff.description, /Local Analyst is not a substitute/i);
+  assert.equal(handoff.prompt, 'prompt text');
+  await service.shutdown();
+});
+
+test('a transport that cannot start produces an actionable runtime error', async () => {
+  await withThreadState(async () => {
+    const enoent = Object.assign(new Error('spawn npx ENOENT'), { code: 'ENOENT' });
+    const fake = new FakeMcpServer({ failConnect: enoent });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      await assert.rejects(
+        () => service.discoverAgents(),
+        (error: unknown) => {
+          assert.ok(error instanceof SreAgentMcpError);
+          assert.equal(error.kind, 'runtime-missing');
+          assert.match(error.remediation, /Node\.js/);
+          return true;
+        },
+      );
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('auth, permission, and network failures map to actionable remediations', async () => {
+  const cases: Array<{ message: string; kind: string; remediation: RegExp }> = [
+    { message: 'AADSTS700082 401 Unauthorized', kind: 'auth', remediation: /az login/ },
+    { message: 'AuthorizationFailed: 403 Forbidden', kind: 'permission', remediation: /SRE Agent Administrator/ },
+    { message: 'getaddrinfo ENOTFOUND agent.azuresre.ai', kind: 'network', remediation: /azuresre\.ai/ },
+    { message: 'ResourceNotFound: 404 no agent endpoint', kind: 'not-found', remediation: /SRE_AGENT_NAME/ },
+  ];
+
+  for (const testCase of cases) {
+    await withThreadState(async () => {
+      const fake = new FakeMcpServer({ failConnect: new Error(testCase.message) });
+      const service = new SreAgentService(testConfig(), fake.factory());
+      try {
+        await assert.rejects(
+          () => service.discoverAgents(),
+          (error: unknown) => {
+            assert.ok(error instanceof SreAgentMcpError, `expected SreAgentMcpError for ${testCase.message}`);
+            assert.equal(error.kind, testCase.kind);
+            assert.match(error.remediation, testCase.remediation);
+            return true;
+          },
+        );
+      } finally {
+        await service.shutdown();
+        await fake.close();
+      }
+    });
+  }
+});
+
+// --- input validation --------------------------------------------------------
+
+test('prompts and thread IDs are validated before any MCP dispatch', () => {
+  assert.throws(() => normalizePrompt(''), SreAgentOperationDeniedError);
+  assert.throws(() => normalizePrompt('   '), SreAgentOperationDeniedError);
+  assert.throws(() => normalizePrompt(undefined), SreAgentOperationDeniedError);
+  assert.throws(() => normalizePrompt('x'.repeat(8_001)), SreAgentOperationDeniedError);
+  assert.equal(normalizePrompt('  investigate  '), 'investigate');
+
+  assert.throws(() => normalizeThreadId(''), SreAgentOperationDeniedError);
+  assert.throws(() => normalizeThreadId('short'), SreAgentOperationDeniedError);
+  assert.throws(() => normalizeThreadId('bad id with spaces'), SreAgentOperationDeniedError);
+  assert.equal(normalizeThreadId(` ${THREAD_ID} `), THREAD_ID);
+});
+
+// --- preflight ---------------------------------------------------------------
+
+test('preflight proves the MCP surface excludes every auto-approval tool', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const result = await collectSreAgentPreflight(service, {
+        runner: async () => ({ stdout: JSON.stringify({ id: SUBSCRIPTION, name: 'demo-sub' }), stderr: '' }),
+        resolveHost: async () => true,
+      });
+
+      const blockedCheck = result.checks.find((check) => check.name === 'Auto-approval tools blocked');
+      assert.equal(blockedCheck?.status, 'pass');
+      assert.match(blockedCheck?.message ?? '', /investigate_yolo/);
+
+      assert.equal(result.checks.find((check) => check.name === 'Azure MCP Server tool surface')?.status, 'pass');
+      assert.equal(result.checks.find((check) => check.name === 'SRE Agent discovery')?.status, 'pass');
+      assert.equal(result.checks.find((check) => check.name === 'SRE Agent data-plane reachability')?.status, 'pass');
+      assert.equal(result.ready, true);
+      assert.ok(!result.target.allowedTools.some((tool) => /yolo/i.test(tool)));
+      assert.ok(result.target.blockedTools.includes('sreagent_threads_investigate_yolo'));
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('preflight fails loudly if the MCP server ever exposes an auto-approval tool', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      toolNames: [...['sreagent_agents_get', 'sreagent_agents_list', 'sreagent_threads_create', 'sreagent_threads_get', 'sreagent_threads_investigate', 'sreagent_threads_send_message'], 'sreagent_threads_investigate_yolo'],
+      handlers: happyHandlers(),
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const result = await collectSreAgentPreflight(service, {
+        runner: async () => ({ stdout: JSON.stringify({ id: SUBSCRIPTION, name: 'demo-sub' }), stderr: '' }),
+        resolveHost: async () => true,
+      });
+
+      const blockedCheck = result.checks.find((check) => check.name === 'Auto-approval tools blocked');
+      assert.equal(blockedCheck?.status, 'fail');
+      assert.match(blockedCheck?.message ?? '', /sreagent_threads_investigate_yolo/);
+      assert.equal(result.ready, false);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('preflight reports an actionable failure when Azure sign-in is missing', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const result = await collectSreAgentPreflight(service, {
+        runner: async () => {
+          throw new Error('Please run "az login" to setup account.');
+        },
+        resolveHost: async () => true,
+        skipMcpProbe: true,
+      });
+
+      const signIn = result.checks.find((check) => check.name === 'Azure sign-in');
+      assert.equal(signIn?.status, 'fail');
+      assert.match(signIn?.remediation ?? '', /az login/);
+      assert.equal(result.ready, false);
+      assert.match(result.portalHandoff.description, /Local Analyst is not a substitute/i);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('preflight surfaces a missing data-plane route as a firewall action', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({ handlers: happyHandlers() });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const result = await collectSreAgentPreflight(service, {
+        runner: async () => ({ stdout: JSON.stringify({ id: SUBSCRIPTION, name: 'demo-sub' }), stderr: '' }),
+        resolveHost: async () => false,
+      });
+
+      const reachability = result.checks.find((check) => check.name === 'SRE Agent data-plane reachability');
+      assert.equal(reachability?.status, 'fail');
+      assert.match(reachability?.remediation ?? '', /azuresre\.ai/);
+      assert.equal(result.ready, false);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('preflight reports a missing agent without inventing one', async () => {
+  await withThreadState(async () => {
+    const fake = new FakeMcpServer({
+      handlers: { ...happyHandlers(), sreagent_agents_list: () => ({ status: 200, results: [] }) },
+    });
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      const result = await collectSreAgentPreflight(service, {
+        runner: async () => ({ stdout: JSON.stringify({ id: SUBSCRIPTION, name: 'demo-sub' }), stderr: '' }),
+        resolveHost: async () => true,
+      });
+
+      const discovery = result.checks.find((check) => check.name === 'SRE Agent discovery');
+      assert.equal(discovery?.status, 'fail');
+      assert.match(discovery?.message ?? '', /No SRE Agent resources were visible/);
+      assert.equal(result.ready, false);
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Condition was not met before the timeout');
+}

--- a/mission-control/backend/src/services/sre-agent/SreAgentService.test.ts
+++ b/mission-control/backend/src/services/sre-agent/SreAgentService.test.ts
@@ -10,6 +10,8 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import Fastify from 'fastify';
+import { registerSreAgentRoutes } from '../../routes/sre-agent.js';
 import { loadSreAgentConfig, type SreAgentConfig } from './config.js';
 import { FakeMcpServer, fakeAgentPayload, fakeInvestigationPayload } from './fakeMcpServer.js';
 import { SreAgentMcpClient, SreAgentMcpError } from './SreAgentMcpClient.js';
@@ -702,3 +704,154 @@ async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<v
   }
   throw new Error('Condition was not met before the timeout');
 }
+
+// --- stderr leak regression (end to end through the real error path) ----------
+//
+// Exercises the real chain: child stderr stream -> SreAgentMcpClient stderr
+// accumulation -> normalizeError -> SreAgentMcpError.message -> HTTP body.
+//
+// Reproduces the verified leak in which a >2,000-character PEM had its
+// `-----BEGIN …-----` marker evicted from the raw rolling buffer while key body
+// survived, so the final single redaction pass had no marker to match.
+//
+// Each test also asserts that BENIGN stderr text *does* reach the message, which
+// proves the assertion is not vacuous: the hint path really is carrying stderr.
+
+const STDERR_TAIL_MARKER = 'INFO: continuing startup diagnostics';
+
+function longPemChunk(bodyLines = 60): string {
+  const body = Array.from(
+    { length: bodyLines },
+    (_, i) => `SECRETLINE${String(i).padStart(3, '0')}0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`,
+  ).join('\n');
+  return `-----BEGIN RSA PRIVATE KEY-----\n${body}\n-----END RSA PRIVATE KEY-----\n`;
+}
+
+function stderrLeakFake(stderrChunks: readonly string[]): FakeMcpServer {
+  return new FakeMcpServer({
+    handlers: {
+      sreagent_agents_get: () => fakeAgentPayload(),
+      // Generic failure so normalizeError falls through to the branch that appends
+      // the stderr hint to the operator-visible message.
+      sreagent_agents_list: () => {
+        throw new Error('agent listing exploded');
+      },
+    },
+    stderrChunks,
+  });
+}
+
+/** Establishes the transport and lets buffered stderr flow before the failing call. */
+async function primeStderr(service: SreAgentService): Promise<void> {
+  await service.getConfiguredAgent();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+test('a >2000-char PEM on child stderr never reaches the normalized error message', async () => {
+  await withThreadState(async () => {
+    const pem = longPemChunk();
+    assert.ok(pem.length > 2_000, 'PEM must exceed the retention window to reproduce the leak');
+
+    const fake = stderrLeakFake([pem, `${STDERR_TAIL_MARKER}...\n`.repeat(80)]);
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      await primeStderr(service);
+      await assert.rejects(
+        () => service.discoverAgents(),
+        (error: unknown) => {
+          assert.ok(error instanceof SreAgentMcpError);
+          const text = `${error.message} ${error.remediation}`;
+          assert.ok(!text.includes('SECRETLINE'), `private key body leaked into the error: ${text}`);
+          assert.ok(!text.includes('-----BEGIN RSA PRIVATE KEY-----'));
+          // Non-vacuity: stderr really did reach the message.
+          assert.ok(text.includes(STDERR_TAIL_MARKER), 'stderr hint was not exercised at all');
+          return true;
+        },
+      );
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('a >2000-char PEM on child stderr never reaches the HTTP error body', async () => {
+  const pem = longPemChunk();
+  const fake = stderrLeakFake([pem, `${STDERR_TAIL_MARKER}...\n`.repeat(80)]);
+  const service = new SreAgentService(testConfig(), fake.factory());
+  const dir = await mkdtemp(join(tmpdir(), 'sre-stderr-http-'));
+  const previous = process.env['SRE_AGENT_THREAD_STATE_PATH'];
+  process.env['SRE_AGENT_THREAD_STATE_PATH'] = join(dir, 'threads.json');
+
+  const app = Fastify({ logger: false });
+  registerSreAgentRoutes(app, service);
+  await app.ready();
+
+  try {
+    await primeStderr(service);
+    const response = await app.inject({ method: 'GET', url: '/api/sre-agent/agents' });
+    const body = response.body;
+
+    assert.ok(!body.includes('SECRETLINE'), `private key body reached the HTTP response: ${body}`);
+    assert.ok(!body.includes('-----BEGIN RSA PRIVATE KEY-----'));
+    assert.ok(body.includes(STDERR_TAIL_MARKER), 'stderr hint was not exercised at all');
+    assert.equal(response.json().localAnalystSubstituted, false);
+  } finally {
+    await app.close();
+    await service.shutdown();
+    await fake.close();
+    if (previous === undefined) delete process.env['SRE_AGENT_THREAD_STATE_PATH'];
+    else process.env['SRE_AGENT_THREAD_STATE_PATH'] = previous;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('an unterminated PEM still streaming on stderr never reaches the error message', async () => {
+  await withThreadState(async () => {
+    const fake = stderrLeakFake([
+      `${STDERR_TAIL_MARKER}...\n`,
+      '-----BEGIN OPENSSH PRIVATE KEY-----\n',
+      'SECRETLINE000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'.repeat(60),
+    ]);
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      await primeStderr(service);
+      await assert.rejects(
+        () => service.discoverAgents(),
+        (error: unknown) => {
+          assert.ok(error instanceof SreAgentMcpError);
+          assert.ok(!error.message.includes('SECRETLINE'), 'streaming key body leaked');
+          assert.ok(error.message.includes('[REDACTED-PRIVATE-KEY]'), 'stderr hint was not exercised at all');
+          return true;
+        },
+      );
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});
+
+test('benign stderr diagnostics still reach the error message', async () => {
+  await withThreadState(async () => {
+    const fake = stderrLeakFake(['npm warn deprecated example@1.0.0: please upgrade\n']);
+    const service = new SreAgentService(testConfig(), fake.factory());
+
+    try {
+      await primeStderr(service);
+      await assert.rejects(
+        () => service.discoverAgents(),
+        (error: unknown) => {
+          assert.ok(error instanceof SreAgentMcpError);
+          assert.match(error.message, /npm warn deprecated/);
+          return true;
+        },
+      );
+    } finally {
+      await service.shutdown();
+      await fake.close();
+    }
+  });
+});

--- a/mission-control/backend/src/services/sre-agent/SreAgentService.ts
+++ b/mission-control/backend/src/services/sre-agent/SreAgentService.ts
@@ -1,0 +1,745 @@
+/**
+ * Typed adapter between Mission Control and the Azure SRE Agent MCP server.
+ *
+ * Guarantees enforced here:
+ *  - Only the six allowlisted operations are reachable; `investigate_yolo` and every
+ *    auto-approval path are impossible (see `operations.ts` for the three layers).
+ *  - A response is only labelled `provenance: 'azure-sre-agent'` when it carries a real
+ *    agent resource identity AND a real thread ID. Otherwise the call fails honestly.
+ *  - Local Analyst output is never substituted for an SRE Agent response.
+ *  - All output is redacted and length-bounded before leaving the backend.
+ *  - Every operation is auditable and cancellable.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { logger } from '../../utils/logger.js';
+import { isSreAgentUsable, loadSreAgentConfig, type SreAgentConfig } from './config.js';
+import {
+  ALLOWED_SRE_AGENT_TOOLS,
+  BLOCKED_SRE_AGENT_TOOLS,
+  isReadOnlySreAgentOperation,
+  resolveOperationTool,
+  SreAgentOperationDeniedError,
+  type SreAgentOperation,
+} from './operations.js';
+import {
+  SreAgentMcpClient,
+  SreAgentMcpError,
+  type McpTransportFactory,
+} from './SreAgentMcpClient.js';
+import { boundText, maskArmId, maskGuid, maskIdentifiers, redactForAudit, redactSensitiveText } from './redaction.js';
+import { parseAgentList, parseThreadResponse, type ParsedAgentSummary } from './responseParser.js';
+import type {
+  ContinueSreAgentInvestigationRequest,
+  SreAgentActiveThreadRecord,
+  SreAgentCitation,
+  SreAgentDiscoveryResponse,
+  SreAgentIdentity,
+  SreAgentInvestigation,
+  SreAgentInvestigationStatus,
+  SreAgentPortalHandoff,
+  SreAgentTargetSummary,
+  StartSreAgentInvestigationRequest,
+} from '../../types/index.js';
+
+const RESPONSE_LIMITATIONS = Object.freeze([
+  'Standard investigation mode only: Mission Control never auto-approves an SRE Agent action.',
+  'Approval gates are resolved by an operator in the Azure SRE Agent portal, not in Mission Control.',
+  'Azure MCP Server response schemas are not contractual; field extraction is best-effort and labelled by schemaConfidence.',
+  'Cancellation aborts the Mission Control request; agent-side work already started may continue server-side.',
+]);
+
+export class SreAgentNotConfiguredError extends Error {
+  readonly statusCode = 503;
+  readonly kind = 'not-configured' as const;
+  readonly remediation: string;
+
+  constructor(message: string, remediation: string) {
+    super(message);
+    this.name = 'SreAgentNotConfiguredError';
+    this.remediation = remediation;
+  }
+}
+
+/**
+ * Raised when the MCP call succeeded but the payload lacks the identity needed to
+ * honestly attribute the answer to Azure SRE Agent.
+ */
+export class SreAgentProvenanceError extends Error {
+  readonly statusCode = 502;
+  readonly kind = 'protocol' as const;
+  readonly remediation =
+    'Mission Control will not label a response as Azure SRE Agent output without a real agent resource and thread ID. Run the investigation in the SRE Agent portal and capture evidence there.';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'SreAgentProvenanceError';
+  }
+}
+
+interface ActiveOperation {
+  readonly controller: AbortController;
+  readonly operation: SreAgentOperation;
+  readonly startedAt: number;
+  readonly threadId?: string;
+}
+
+export class SreAgentService {
+  private readonly client: SreAgentMcpClient;
+  private readonly activeOperations = new Map<string, ActiveOperation>();
+  private cachedAgent?: SreAgentIdentity;
+  private threadStateQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly config: SreAgentConfig = loadSreAgentConfig(),
+    transportFactory?: McpTransportFactory,
+  ) {
+    this.client = new SreAgentMcpClient(this.config, transportFactory);
+  }
+
+  get configuration(): SreAgentConfig {
+    return this.config;
+  }
+
+  /** Masked, screen-share-safe summary of what Mission Control is pointed at. */
+  targetSummary(): SreAgentTargetSummary {
+    return {
+      ...(this.config.agentName ? { agentName: this.config.agentName } : {}),
+      ...(maskGuid(this.config.subscriptionId) ? { subscriptionIdMasked: maskGuid(this.config.subscriptionId) } : {}),
+      ...(this.config.resourceGroup ? { resourceGroup: this.config.resourceGroup } : {}),
+      ...(maskGuid(this.config.tenantId) ? { tenantIdMasked: maskGuid(this.config.tenantId) } : {}),
+      serverPackage: this.config.serverPackage,
+      allowedTools: [...ALLOWED_SRE_AGENT_TOOLS],
+      blockedTools: [...BLOCKED_SRE_AGENT_TOOLS],
+    };
+  }
+
+  portalHandoff(prompt?: string): SreAgentPortalHandoff {
+    return {
+      label: 'Open Azure SRE Agent portal',
+      href: this.config.portalUrl,
+      description:
+        'Mission Control could not complete a supported SRE Agent MCP investigation. Run the prompt directly in the Azure SRE Agent portal and capture evidence there. Local Analyst is not a substitute.',
+      ...(prompt ? { prompt } : {}),
+    };
+  }
+
+  /** Lists SRE Agent resources and resolves the configured target. */
+  async discoverAgents(signal?: AbortSignal, correlationId = normalizeCorrelationId()): Promise<SreAgentDiscoveryResponse> {
+    this.assertUsable();
+
+    return this.withCancellableOperation('discover-agents', 'discover-agents', signal, undefined, async (linked) => {
+      const args: Record<string, unknown> = {};
+      if (this.config.subscriptionId) args['subscription'] = this.config.subscriptionId;
+      if (this.config.resourceGroup) args['resource-group'] = this.config.resourceGroup;
+      if (this.config.tenantId) args['tenant'] = this.config.tenantId;
+
+      const result = await this.invoke('discover-agents', args, {
+        timeoutMs: this.config.requestTimeoutMs,
+        signal: linked,
+        correlationId,
+      });
+
+      const agents = parseAgentList(result.text, result.structuredContent).map((agent) => toIdentity(agent));
+      const selected = agents.find(
+        (agent) => agent.name.toLowerCase() === (this.config.agentName ?? '').toLowerCase(),
+      );
+
+      if (selected) this.cachedAgent = selected;
+
+      return {
+        configured: true,
+        agents,
+        ...(selected ? { selected } : {}),
+        target: this.targetSummary(),
+        collectedAt: new Date().toISOString(),
+      };
+    });
+  }
+
+  /**
+   * Resolves the configured agent's identity, using `sreagent_agents_get`.
+   * Required before any thread operation so provenance can be proven.
+   *
+   * When called from within a larger operation, the caller passes its linked signal and
+   * correlation ID so cancellation and audit records cover this phase too.
+   */
+  async getConfiguredAgent(
+    signal?: AbortSignal,
+    refresh = false,
+    correlationId = normalizeCorrelationId(),
+  ): Promise<SreAgentIdentity> {
+    this.assertUsable();
+    if (this.cachedAgent && !refresh) return this.cachedAgent;
+
+    const args: Record<string, unknown> = { agent: this.config.agentName };
+    if (this.config.subscriptionId) args['subscription'] = this.config.subscriptionId;
+    if (this.config.resourceGroup) args['resource-group'] = this.config.resourceGroup;
+    if (this.config.tenantId) args['tenant'] = this.config.tenantId;
+
+    const result = await this.invoke('get-agent', args, {
+      timeoutMs: this.config.requestTimeoutMs,
+      ...(signal ? { signal } : {}),
+      correlationId,
+    });
+
+    const [agent] = parseAgentList(result.text, result.structuredContent);
+    if (!agent?.name) {
+      throw new SreAgentProvenanceError(
+        `Azure MCP Server did not return an identifiable SRE Agent resource for '${this.config.agentName}'.`,
+      );
+    }
+
+    this.cachedAgent = toIdentity(agent);
+    return this.cachedAgent;
+  }
+
+  /**
+   * Starts a real investigation thread in standard (approval-gated) mode.
+   *
+   * Uses `sreagent_threads_investigate`, which runs the documented multi-step loop and
+   * pauses at approval gates. `investigate_yolo` is unreachable by construction.
+   *
+   * The whole operation — agent resolution plus the investigation call — is registered
+   * under one correlation ID so `cancel()` stops all of it.
+   */
+  async startInvestigation(
+    request: StartSreAgentInvestigationRequest & { prompt: string },
+    signal?: AbortSignal,
+  ): Promise<SreAgentInvestigation> {
+    this.assertUsable();
+
+    const prompt = normalizePrompt(request.prompt);
+    const correlationId = normalizeCorrelationId(request.correlationId);
+    const startedAt = new Date();
+
+    const investigation = await this.withCancellableOperation(
+      correlationId,
+      'investigate',
+      signal,
+      undefined,
+      async (linked) => {
+        const agent = await this.getConfiguredAgent(linked, false, correlationId);
+
+        const args: Record<string, unknown> = {
+          agent: this.config.agentName,
+          message: prompt,
+          'max-iterations': this.config.maxIterations,
+          'timeout-seconds': Math.floor(this.config.investigationTimeoutMs / 1000),
+        };
+        if (this.config.subscriptionId) args['subscription'] = this.config.subscriptionId;
+        if (this.config.resourceGroup) args['resource-group'] = this.config.resourceGroup;
+        if (this.config.tenantId) args['tenant'] = this.config.tenantId;
+
+        const result = await this.invoke('investigate', args, {
+          timeoutMs: this.config.investigationTimeoutMs,
+          signal: linked,
+          correlationId,
+        });
+
+        return this.buildInvestigation({
+          operation: 'investigate',
+          agent,
+          rawText: result.text,
+          structuredContent: result.structuredContent,
+          isError: result.isError,
+          startedAt,
+          correlationId,
+        });
+      },
+    );
+
+    await this.recordThread(investigation, request.scenarioName);
+    return investigation;
+  }
+
+  /** Continues an existing thread with an operator follow-up prompt. */
+  async continueInvestigation(
+    request: ContinueSreAgentInvestigationRequest,
+    signal?: AbortSignal,
+  ): Promise<SreAgentInvestigation> {
+    this.assertUsable();
+
+    const threadId = normalizeThreadId(request.threadId);
+    const prompt = normalizePrompt(request.prompt);
+    const correlationId = normalizeCorrelationId(request.correlationId);
+    const startedAt = new Date();
+
+    const investigation = await this.withCancellableOperation(
+      correlationId,
+      'follow-up',
+      signal,
+      threadId,
+      async (linked) => {
+        const agent = await this.getConfiguredAgent(linked, false, correlationId);
+
+        const args: Record<string, unknown> = {
+          agent: this.config.agentName,
+          'thread-id': threadId,
+          message: prompt,
+        };
+        if (this.config.subscriptionId) args['subscription'] = this.config.subscriptionId;
+        if (this.config.resourceGroup) args['resource-group'] = this.config.resourceGroup;
+        if (this.config.tenantId) args['tenant'] = this.config.tenantId;
+
+        const result = await this.invoke('follow-up', args, {
+          timeoutMs: this.config.requestTimeoutMs,
+          signal: linked,
+          correlationId,
+        });
+
+        return this.buildInvestigation({
+          operation: 'follow-up',
+          agent,
+          rawText: result.text,
+          structuredContent: result.structuredContent,
+          isError: result.isError,
+          startedAt,
+          correlationId,
+          // The thread ID is already proven by the caller's prior turn; the follow-up
+          // response is not required to echo it.
+          fallbackThreadId: threadId,
+        });
+      },
+    );
+
+    await this.recordThread(investigation);
+    return investigation;
+  }
+
+  /**
+   * Reads current thread state. This is how an in-flight investigation is re-attached
+   * after a Mission Control backend restart: the thread lives server-side, so the
+   * durable thread ID is sufficient to resume.
+   */
+  async getThreadStatus(threadId: string, signal?: AbortSignal): Promise<SreAgentInvestigation> {
+    this.assertUsable();
+
+    const normalizedThreadId = normalizeThreadId(threadId);
+    const correlationId = normalizeCorrelationId();
+    const startedAt = new Date();
+
+    return this.withCancellableOperation(
+      correlationId,
+      'thread-status',
+      signal,
+      normalizedThreadId,
+      async (linked) => {
+        const agent = await this.getConfiguredAgent(linked, false, correlationId);
+
+        const args: Record<string, unknown> = {
+          agent: this.config.agentName,
+          'thread-id': normalizedThreadId,
+        };
+        if (this.config.subscriptionId) args['subscription'] = this.config.subscriptionId;
+        if (this.config.resourceGroup) args['resource-group'] = this.config.resourceGroup;
+        if (this.config.tenantId) args['tenant'] = this.config.tenantId;
+
+        const result = await this.invoke('thread-status', args, {
+          timeoutMs: this.config.requestTimeoutMs,
+          signal: linked,
+          correlationId,
+        });
+
+        return this.buildInvestigation({
+          operation: 'thread-status',
+          agent,
+          rawText: result.text,
+          structuredContent: result.structuredContent,
+          isError: result.isError,
+          startedAt,
+          correlationId,
+          fallbackThreadId: normalizedThreadId,
+        });
+      },
+    );
+  }
+
+  /**
+   * Cancels an in-flight Mission Control operation.
+   *
+   * Azure MCP Server does not document a server-side cancel/stop for a running
+   * investigation, so this aborts the Mission Control request and prevents further
+   * proxying and retries. Agent-side work already started may continue; the UI and docs
+   * say so rather than implying a hard stop.
+   */
+  cancel(correlationId: string): boolean {
+    const active = this.activeOperations.get(correlationId);
+    if (!active) return false;
+
+    active.controller.abort();
+    this.activeOperations.delete(correlationId);
+    logger.info(
+      { correlationId, operation: active.operation, event: 'sre-agent.cancel' },
+      'SRE Agent operation cancelled by operator',
+    );
+    return true;
+  }
+
+  /** Correlation IDs of operations currently in flight. */
+  activeOperationIds(): string[] {
+    return [...this.activeOperations.keys()];
+  }
+
+  async listTools(): Promise<string[]> {
+    this.assertUsable();
+    return this.client.listToolNames();
+  }
+
+  async shutdown(): Promise<void> {
+    for (const [id, active] of this.activeOperations) {
+      active.controller.abort();
+      this.activeOperations.delete(id);
+    }
+    await this.client.dispose();
+  }
+
+  private assertUsable(): void {
+    if (isSreAgentUsable(this.config)) return;
+
+    const issues = this.config.configurationIssues;
+    throw new SreAgentNotConfiguredError(
+      'The Azure SRE Agent MCP integration is not configured.',
+      issues.length > 0 ? issues.join(' ') : 'Set SRE_AGENT_NAME and SRE_AGENT_SUBSCRIPTION_ID, then restart Mission Control.',
+    );
+  }
+
+  /** Single dispatch path: allowlist check, audit logging, and signal propagation. */
+  private async invoke(
+    operation: SreAgentOperation,
+    args: Record<string, unknown>,
+    options: { timeoutMs: number; signal?: AbortSignal; correlationId?: string; threadId?: string },
+  ) {
+    const toolName = resolveOperationTool(operation);
+    const correlationId = options.correlationId ?? normalizeCorrelationId();
+
+    this.audit({
+      event: 'sre-agent.request',
+      operation,
+      tool: toolName,
+      correlationId,
+      readOnly: isReadOnlySreAgentOperation(operation),
+      args,
+    });
+
+    try {
+      const result = await this.client.callTool(toolName, args, {
+        timeoutMs: options.timeoutMs,
+        ...(options.signal ? { signal: options.signal } : {}),
+      });
+
+      this.audit({
+        event: 'sre-agent.response',
+        operation,
+        tool: toolName,
+        correlationId,
+        resultStatus: result.isError ? 'failed' : 'allowed',
+        bytes: result.text.length,
+      });
+
+      return result;
+    } catch (error) {
+      this.audit({
+        event: 'sre-agent.failure',
+        operation,
+        tool: toolName,
+        correlationId,
+        resultStatus: error instanceof SreAgentMcpError ? error.kind : 'failed',
+        message: error instanceof Error ? redactSensitiveText(error.message) : 'unknown',
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Registers one cancellable logical operation under `correlationId` and runs `body`
+   * with a linked signal.
+   *
+   * Cancellation is scoped to the whole operation — including agent resolution — so an
+   * operator pressing Stop during the discovery phase actually stops the work, rather
+   * than only the final MCP call.
+   */
+  private async withCancellableOperation<T>(
+    correlationId: string,
+    operation: SreAgentOperation,
+    externalSignal: AbortSignal | undefined,
+    threadId: string | undefined,
+    body: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    const controller = new AbortController();
+    let detachExternal: (() => void) | undefined;
+
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        controller.abort();
+      } else {
+        const onAbort = () => controller.abort();
+        externalSignal.addEventListener('abort', onAbort, { once: true });
+        // Detached in `finally` so a long-lived caller signal that never aborts does not
+        // accumulate listeners (and references to completed operations) over time.
+        detachExternal = () => externalSignal.removeEventListener('abort', onAbort);
+      }
+    }
+
+    this.activeOperations.set(correlationId, {
+      controller,
+      operation,
+      startedAt: Date.now(),
+      ...(threadId ? { threadId } : {}),
+    });
+
+    try {
+      return await body(controller.signal);
+    } finally {
+      detachExternal?.();
+      this.activeOperations.delete(correlationId);
+    }
+  }
+
+  /**
+   * Builds the response contract and enforces the provenance rule.
+   * Throws rather than returning an unverified "SRE Agent" answer.
+   */
+  private buildInvestigation(input: {
+    operation: SreAgentOperation;
+    agent: SreAgentIdentity;
+    rawText: string;
+    structuredContent?: unknown;
+    isError: boolean;
+    startedAt: Date;
+    correlationId: string;
+    fallbackThreadId?: string;
+  }): SreAgentInvestigation {
+    const parsed = parseThreadResponse(input.rawText, input.structuredContent);
+    const threadId = parsed.threadId ?? input.fallbackThreadId;
+
+    if (input.isError) {
+      throw new SreAgentMcpError(
+        'unknown',
+        `Azure SRE Agent returned an error: ${boundText(parsed.messageText || input.rawText, 1_000).text}`,
+        'Review the message, then retry or continue in the SRE Agent portal.',
+        502,
+      );
+    }
+
+    if (!threadId) {
+      throw new SreAgentProvenanceError(
+        'Azure MCP Server returned a response without a thread ID, so Mission Control cannot prove it came from a real SRE Agent thread.',
+      );
+    }
+
+    if (!input.agent.name) {
+      throw new SreAgentProvenanceError('Mission Control could not resolve the SRE Agent resource identity for this response.');
+    }
+
+    const completedAt = new Date();
+    const known = {
+      ...(this.config.subscriptionId ? { subscriptionId: this.config.subscriptionId } : {}),
+      ...(this.config.tenantId ? { tenantId: this.config.tenantId } : {}),
+    };
+    // The agent quotes ARM IDs in prose, so mask identifiers in the response body and
+    // citation labels — not only in the structured identity fields.
+    const bounded = boundText(maskIdentifiers(parsed.messageText, known), this.config.maxResponseChars);
+    const citations = parsed.citations.slice(0, 25).map(
+      (citation): SreAgentCitation => ({
+        label: maskIdentifiers(redactSensitiveText(citation.label), known).slice(0, 300),
+        // Citation URLs are left navigable so the operator can open the cited evidence;
+        // they are already restricted to http(s) by the parser.
+        ...(citation.url ? { url: citation.url } : {}),
+        ...(citation.source ? { source: redactSensitiveText(citation.source).slice(0, 120) } : {}),
+      }),
+    );
+
+    return {
+      provenance: 'azure-sre-agent',
+      status: deriveStatus(parsed.approvalRequired, parsed.statusHint),
+      agent: input.agent,
+      thread: {
+        id: threadId,
+        createdAt: input.startedAt.toISOString(),
+        portalUrl: this.config.portalUrl,
+      },
+      response: bounded.text,
+      citations,
+      citationsPresent: citations.length > 0,
+      approval: {
+        required: parsed.approvalRequired,
+        ...(parsed.approvalDetail
+          ? { detail: maskIdentifiers(redactSensitiveText(parsed.approvalDetail), known).slice(0, 800) }
+          : {}),
+        autoApproved: false,
+      },
+      metadata: {
+        operation: input.operation,
+        tool: resolveOperationTool(input.operation),
+        startedAt: input.startedAt.toISOString(),
+        completedAt: completedAt.toISOString(),
+        elapsedMs: completedAt.getTime() - input.startedAt.getTime(),
+        truncated: bounded.truncated,
+        schemaConfidence: parsed.schemaConfidence,
+        serverPackage: this.config.serverPackage,
+        correlationId: input.correlationId,
+        limitations: [...RESPONSE_LIMITATIONS],
+      },
+    };
+  }
+
+  /** Audit record shaped to match docs/LOCAL-ANALYST-GOVERNANCE.md requirements. */
+  private audit(entry: Record<string, unknown>): void {
+    const { args, ...rest } = entry;
+    logger.info(
+      {
+        ...rest,
+        requester: process.env['USER'] ?? 'local-operator',
+        target: this.config.agentName ?? 'unconfigured',
+        timestamp: new Date().toISOString(),
+        redactionNotes: 'Prompt and payload fields redacted and bounded before logging.',
+        ...(args ? { args: redactForAudit(args) } : {}),
+      },
+      'SRE Agent MCP audit',
+    );
+  }
+
+  // --- durable thread references (survive a backend restart) ---------------
+
+  private async recordThread(
+    investigation: SreAgentInvestigation,
+    scenarioName?: StartSreAgentInvestigationRequest['scenarioName'],
+  ): Promise<void> {
+    const record: SreAgentActiveThreadRecord = {
+      threadId: investigation.thread.id,
+      agentName: investigation.agent.name,
+      ...(scenarioName ? { scenarioName } : {}),
+      startedAt: investigation.thread.createdAt,
+      updatedAt: new Date().toISOString(),
+      lastStatus: investigation.status,
+      correlationId: investigation.metadata.correlationId,
+    };
+
+    await this.withThreadStateLock(async () => {
+      const threads = await readThreadState();
+      const existingIndex = threads.findIndex((entry) => entry.threadId === record.threadId);
+      if (existingIndex >= 0) {
+        const existing = threads[existingIndex]!;
+        threads[existingIndex] = { ...existing, ...record, startedAt: existing.startedAt };
+      } else {
+        threads.push(record);
+      }
+      await writeThreadState(threads.slice(-25));
+    }).catch((error) => {
+      logger.warn(
+        { err: error instanceof Error ? redactSensitiveText(error.message) : 'unknown' },
+        'Failed to persist SRE Agent thread reference',
+      );
+    });
+  }
+
+  async listRecordedThreads(): Promise<SreAgentActiveThreadRecord[]> {
+    return readThreadState();
+  }
+
+  private async withThreadStateLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.threadStateQueue;
+    let release!: () => void;
+    this.threadStateQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+function toIdentity(agent: ParsedAgentSummary): SreAgentIdentity {
+  return {
+    name: agent.name ?? '',
+    ...(maskArmId(agent.armId) ? { armIdMasked: maskArmId(agent.armId) } : {}),
+    ...(agent.resourceGroup ? { resourceGroup: agent.resourceGroup } : {}),
+    ...(maskGuid(agent.subscriptionId) ? { subscriptionIdMasked: maskGuid(agent.subscriptionId) } : {}),
+    ...(agent.location ? { location: agent.location } : {}),
+    ...(agent.provisioningState ? { provisioningState: agent.provisioningState } : {}),
+    ...(agent.endpointHost ? { endpointHost: agent.endpointHost } : {}),
+  };
+}
+
+function deriveStatus(approvalRequired: boolean, statusHint?: string): SreAgentInvestigationStatus {
+  if (approvalRequired) return 'awaiting-approval';
+  if (statusHint && /running|in[_-]?progress|active/i.test(statusHint)) return 'running';
+  if (statusHint && /cancel/i.test(statusHint)) return 'cancelled';
+  if (statusHint && /fail|error/i.test(statusHint)) return 'failed';
+  return 'completed';
+}
+
+const MAX_PROMPT_CHARS = 8_000;
+
+export function normalizePrompt(prompt: unknown): string {
+  if (typeof prompt !== 'string') {
+    throw new SreAgentOperationDeniedError('An investigation prompt is required.');
+  }
+  const trimmed = prompt.trim();
+  if (!trimmed) {
+    throw new SreAgentOperationDeniedError('An investigation prompt is required.');
+  }
+  if (trimmed.length > MAX_PROMPT_CHARS) {
+    throw new SreAgentOperationDeniedError(`Investigation prompts are limited to ${MAX_PROMPT_CHARS} characters.`);
+  }
+  return trimmed;
+}
+
+export function normalizeThreadId(threadId: unknown): string {
+  if (typeof threadId !== 'string' || !threadId.trim()) {
+    throw new SreAgentOperationDeniedError('A thread ID is required.');
+  }
+  const trimmed = threadId.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(trimmed)) {
+    throw new SreAgentOperationDeniedError('The supplied thread ID is not a valid SRE Agent thread identifier.');
+  }
+  return trimmed;
+}
+
+function normalizeCorrelationId(correlationId?: string): string {
+  if (typeof correlationId === 'string' && /^[A-Za-z0-9._:-]{8,128}$/.test(correlationId.trim())) {
+    return correlationId.trim();
+  }
+  return randomUUID();
+}
+
+// --- thread state persistence ------------------------------------------------
+
+function getThreadStatePath(): string {
+  const override = process.env['SRE_AGENT_THREAD_STATE_PATH'];
+  if (override) return override;
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', '..', '..', 'state', 'sre-agent-threads.json');
+}
+
+async function readThreadState(): Promise<SreAgentActiveThreadRecord[]> {
+  const path = getThreadStatePath();
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as { threads?: SreAgentActiveThreadRecord[] };
+    return Array.isArray(parsed.threads) ? parsed.threads : [];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    return [];
+  }
+}
+
+async function writeThreadState(threads: SreAgentActiveThreadRecord[]): Promise<void> {
+  const path = getThreadStatePath();
+  await mkdir(dirname(path), { recursive: true });
+  const temp = join(dirname(path), `${basename(path)}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(temp, JSON.stringify({ threads, updatedAt: new Date().toISOString() }, null, 2), 'utf8');
+    await rename(temp, path);
+  } catch (error) {
+    await rm(temp, { force: true });
+    throw error;
+  }
+}

--- a/mission-control/backend/src/services/sre-agent/config.ts
+++ b/mission-control/backend/src/services/sre-agent/config.ts
@@ -1,0 +1,248 @@
+/**
+ * Environment-driven configuration for the Azure SRE Agent MCP adapter.
+ *
+ * Nothing here is hardcoded to a specific tenant, subscription, or agent: an operator
+ * configures the target through environment variables. When required configuration is
+ * missing the adapter reports `configured: false` with actionable guidance instead of
+ * guessing, so Mission Control can fail honestly to the portal handoff.
+ *
+ * Secrets are never read into this config. The adapter reuses the host Azure identity
+ * (`az login`) exactly as Azure MCP Server documents, and no token ever reaches it.
+ */
+
+import { buildToolFilterArgs } from './operations.js';
+
+export interface SreAgentConfig {
+  /** True when the minimum configuration for a real agent target is present. */
+  readonly configured: boolean;
+  readonly enabled: boolean;
+  readonly agentName?: string;
+  readonly subscriptionId?: string;
+  readonly resourceGroup?: string;
+  readonly tenantId?: string;
+  /** Executable used to launch the Azure MCP Server child process. */
+  readonly command: string;
+  readonly args: readonly string[];
+  /** npm spec used for the child server, surfaced for supportability/version pinning. */
+  readonly serverPackage: string;
+  readonly portalUrl: string;
+  readonly requestTimeoutMs: number;
+  readonly investigationTimeoutMs: number;
+  readonly maxIterations: number;
+  readonly idleShutdownMs: number;
+  readonly maxResponseChars: number;
+  /** Optional AZURE_TOKEN_CREDENTIALS pin passed through to the child process. */
+  readonly tokenCredential?: string;
+  /** Reasons the adapter is not usable, in operator-actionable form. */
+  readonly configurationIssues: readonly string[];
+}
+
+const DEFAULT_SERVER_PACKAGE = '@azure/mcp@latest';
+const DEFAULT_PORTAL_URL = 'https://sre.azure.com';
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+const DEFAULT_INVESTIGATION_TIMEOUT_MS = 600_000;
+const DEFAULT_MAX_ITERATIONS = 20;
+const DEFAULT_IDLE_SHUTDOWN_MS = 300_000;
+const DEFAULT_MAX_RESPONSE_CHARS = 24_000;
+
+const MIN_REQUEST_TIMEOUT_MS = 5_000;
+const MAX_REQUEST_TIMEOUT_MS = 900_000;
+const MIN_ITERATIONS = 1;
+const MAX_ITERATIONS = 20;
+const MAX_RESPONSE_CHARS_CEILING = 100_000;
+
+/** Azure resource names: letters, digits, hyphens, underscores, periods. */
+const AGENT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,88}[A-Za-z0-9_]$|^[A-Za-z0-9]$/;
+const RESOURCE_GROUP_PATTERN = /^[A-Za-z0-9._()-]{1,90}$/;
+const GUID_PATTERN = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+type Env = Record<string, string | undefined>;
+
+function readString(env: Env, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const raw = env[key];
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      return raw.trim();
+    }
+  }
+  return undefined;
+}
+
+function readBoundedInt(env: Env, keys: string[], fallback: number, min: number, max: number): number {
+  const raw = readString(env, keys);
+  if (raw === undefined) return fallback;
+  if (!/^\d+$/.test(raw)) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) return fallback;
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function readBoolean(env: Env, keys: string[], fallback: boolean): boolean {
+  const raw = readString(env, keys)?.toLowerCase();
+  if (raw === undefined) return fallback;
+  if (['1', 'true', 'yes', 'on', 'enabled'].includes(raw)) return true;
+  if (['0', 'false', 'no', 'off', 'disabled'].includes(raw)) return false;
+  return fallback;
+}
+
+/**
+ * Splits an operator-supplied argv override on whitespace. Deliberately simple: the
+ * child process is spawned without a shell, so there is no shell-injection surface,
+ * and complex quoting is not a supported configuration.
+ *
+ * Tool-exposure flags are stripped so an override cannot widen the child server's tool
+ * surface past the allowlist appended by `loadSreAgentConfig`.
+ */
+function parseArgs(raw: string | undefined): { args: string[]; removed: string[] } | undefined {
+  if (!raw) return undefined;
+  const parts = raw.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return undefined;
+
+  const args: string[] = [];
+  const removed: string[] = [];
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index]!;
+    const flag = part.split('=')[0]!.toLowerCase();
+
+    if (TOOL_SURFACE_FLAGS.has(flag)) {
+      removed.push(part);
+      // Drop a following value token too (e.g. `--tool sreagent_threads_investigate_yolo`).
+      if (!part.includes('=') && parts[index + 1] && !parts[index + 1]!.startsWith('-')) {
+        removed.push(parts[index + 1]!);
+        index += 1;
+      }
+      continue;
+    }
+
+    args.push(part);
+  }
+
+  return { args, removed };
+}
+
+/** Flags that control which tools the child MCP server exposes. */
+const TOOL_SURFACE_FLAGS = new Set(['--tool', '--namespace', '--mode', '-t', '-n']);
+
+export function loadSreAgentConfig(env: Env = process.env): SreAgentConfig {
+  const issues: string[] = [];
+
+  const agentName = readString(env, ['SRE_AGENT_NAME', 'AZURE_SRE_AGENT_NAME']);
+  const subscriptionId = readString(env, [
+    'SRE_AGENT_SUBSCRIPTION_ID',
+    'AZURE_SUBSCRIPTION_ID',
+    'SRE_AGENT_SUBSCRIPTION',
+  ]);
+  const resourceGroup = readString(env, ['SRE_AGENT_RESOURCE_GROUP', 'AZURE_SRE_AGENT_RESOURCE_GROUP']);
+  const tenantId = readString(env, ['SRE_AGENT_TENANT_ID', 'AZURE_TENANT_ID']);
+
+  if (!agentName) {
+    issues.push('Set SRE_AGENT_NAME to the Microsoft.App/agents resource name Mission Control should target.');
+  } else if (!AGENT_NAME_PATTERN.test(agentName)) {
+    issues.push('SRE_AGENT_NAME must be a valid Azure resource name (letters, digits, hyphen, underscore, period).');
+  }
+
+  if (!subscriptionId) {
+    issues.push('Set SRE_AGENT_SUBSCRIPTION_ID (or AZURE_SUBSCRIPTION_ID) to the subscription that contains the SRE Agent.');
+  } else if (!GUID_PATTERN.test(subscriptionId)) {
+    issues.push('SRE_AGENT_SUBSCRIPTION_ID must be a subscription GUID.');
+  }
+
+  if (resourceGroup && !RESOURCE_GROUP_PATTERN.test(resourceGroup)) {
+    issues.push('SRE_AGENT_RESOURCE_GROUP must be a valid Azure resource group name.');
+  }
+
+  if (tenantId && !GUID_PATTERN.test(tenantId)) {
+    issues.push('SRE_AGENT_TENANT_ID must be a tenant GUID.');
+  }
+
+  const serverPackage = readString(env, ['SRE_AGENT_MCP_PACKAGE']) ?? DEFAULT_SERVER_PACKAGE;
+  const command = readString(env, ['SRE_AGENT_MCP_COMMAND']) ?? 'npx';
+  const override = parseArgs(readString(env, ['SRE_AGENT_MCP_ARGS']));
+
+  // Advisory, not blocking: the flags are stripped, so the configuration is still safe.
+  const advisories: string[] =
+    override && override.removed.length > 0
+      ? [
+          `SRE_AGENT_MCP_ARGS may not set tool-exposure flags; ignored: ${override.removed.join(' ')}. Mission Control always pins the child server to its six allowlisted tools.`,
+        ]
+      : [];
+
+  // Always append the tool filter so the child server cannot expose investigate_yolo,
+  // even when an operator overrides the base argv (tool-exposure flags are stripped above).
+  const baseArgs = override?.args ?? ['-y', serverPackage, 'server', 'start'];
+  const args = [...baseArgs, ...buildToolFilterArgs()];
+
+  const requestTimeoutMs = readBoundedInt(
+    env,
+    ['SRE_AGENT_REQUEST_TIMEOUT_MS'],
+    DEFAULT_REQUEST_TIMEOUT_MS,
+    MIN_REQUEST_TIMEOUT_MS,
+    MAX_REQUEST_TIMEOUT_MS,
+  );
+  const investigationTimeoutMs = readBoundedInt(
+    env,
+    ['SRE_AGENT_INVESTIGATION_TIMEOUT_MS'],
+    DEFAULT_INVESTIGATION_TIMEOUT_MS,
+    MIN_REQUEST_TIMEOUT_MS,
+    MAX_REQUEST_TIMEOUT_MS,
+  );
+
+  const configured = issues.length === 0;
+  const enabled = readBoolean(env, ['SRE_AGENT_MCP_ENABLED', 'SRE_AGENT_ENABLED'], true);
+
+  if (configured && !enabled) {
+    issues.push('SRE Agent MCP integration is disabled by SRE_AGENT_MCP_ENABLED=false.');
+  }
+
+  return {
+    configured,
+    enabled,
+    agentName,
+    subscriptionId,
+    resourceGroup,
+    tenantId,
+    command,
+    args,
+    serverPackage,
+    portalUrl: readString(env, ['SRE_AGENT_PORTAL_URL']) ?? DEFAULT_PORTAL_URL,
+    requestTimeoutMs,
+    investigationTimeoutMs,
+    maxIterations: readBoundedInt(env, ['SRE_AGENT_MAX_ITERATIONS'], DEFAULT_MAX_ITERATIONS, MIN_ITERATIONS, MAX_ITERATIONS),
+    idleShutdownMs: readBoundedInt(env, ['SRE_AGENT_IDLE_SHUTDOWN_MS'], DEFAULT_IDLE_SHUTDOWN_MS, 10_000, 3_600_000),
+    maxResponseChars: readBoundedInt(
+      env,
+      ['SRE_AGENT_MAX_RESPONSE_CHARS'],
+      DEFAULT_MAX_RESPONSE_CHARS,
+      1_000,
+      MAX_RESPONSE_CHARS_CEILING,
+    ),
+    tokenCredential: readString(env, ['AZURE_TOKEN_CREDENTIALS']),
+    configurationIssues: Object.freeze([...issues, ...advisories]),
+  };
+}
+
+/** True when the adapter may attempt a real MCP call. */
+export function isSreAgentUsable(config: SreAgentConfig): boolean {
+  return config.configured && config.enabled;
+}
+
+/**
+ * Builds the child-process environment.
+ *
+ * The Azure MCP Server authenticates with the host Azure identity, so the child inherits
+ * the parent environment. We deliberately do not inject client secrets or tokens.
+ */
+export function buildChildEnv(config: SreAgentConfig, env: Env = process.env): Record<string, string> {
+  const childEnv: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === 'string') childEnv[key] = value;
+  }
+
+  if (config.subscriptionId) childEnv['AZURE_SUBSCRIPTION_ID'] = config.subscriptionId;
+  if (config.tenantId) childEnv['AZURE_TENANT_ID'] = config.tenantId;
+  if (config.tokenCredential) childEnv['AZURE_TOKEN_CREDENTIALS'] = config.tokenCredential;
+
+  return childEnv;
+}

--- a/mission-control/backend/src/services/sre-agent/fakeMcpServer.ts
+++ b/mission-control/backend/src/services/sre-agent/fakeMcpServer.ts
@@ -10,6 +10,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { PassThrough } from 'node:stream';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { McpTransportFactory } from './SreAgentMcpClient.js';
 import { ALLOWED_SRE_AGENT_TOOLS } from './operations.js';
@@ -30,6 +31,12 @@ export interface FakeMcpServerOptions {
   readonly hangMs?: number;
   /** Fails `connect()`, to exercise transport startup failure. */
   readonly failConnect?: Error;
+  /**
+   * Attaches a `stderr` stream to the transport (as StdioClientTransport does) and
+   * writes these chunks to it in order as soon as the transport is created. Used to
+   * exercise the real stderr accumulation path that feeds error messages.
+   */
+  readonly stderrChunks?: readonly string[];
 }
 
 export class FakeMcpServer {
@@ -56,6 +63,17 @@ export class FakeMcpServer {
       const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
       const server = this.buildServer();
       await server.connect(serverTransport);
+
+      // Mirror StdioClientTransport's `stderr` so the client's real stderr
+      // accumulation path is exercised end to end.
+      if (this.options.stderrChunks) {
+        const stderr = new PassThrough();
+        Object.defineProperty(clientTransport, 'stderr', { value: stderr, configurable: true });
+        // Emit synchronously after the client attaches its listener.
+        queueMicrotask(() => {
+          for (const chunk of this.options.stderrChunks ?? []) stderr.write(chunk);
+        });
+      }
 
       this.servers.push(server);
       this.transports.push(serverTransport);

--- a/mission-control/backend/src/services/sre-agent/fakeMcpServer.ts
+++ b/mission-control/backend/src/services/sre-agent/fakeMcpServer.ts
@@ -1,0 +1,151 @@
+/**
+ * Deterministic fake Azure MCP Server for tests.
+ *
+ * This is a real MCP server (from the official SDK) wired to the client through
+ * `InMemoryTransport`, so tests exercise the genuine MCP protocol — tool registration,
+ * JSON-RPC dispatch, timeouts, and cancellation — without spawning `npx` or touching
+ * Azure. Scenarios can register handlers per tool, simulate hangs, and record calls.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { McpTransportFactory } from './SreAgentMcpClient.js';
+import { ALLOWED_SRE_AGENT_TOOLS } from './operations.js';
+
+export interface FakeToolCall {
+  readonly name: string;
+  readonly args: Record<string, unknown>;
+}
+
+export type FakeToolHandler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+export interface FakeMcpServerOptions {
+  /** Tool names the fake server advertises. Defaults to the Mission Control allowlist. */
+  readonly toolNames?: readonly string[];
+  /** Per-tool handlers returning either a raw string or a JSON-serialisable object. */
+  readonly handlers?: Record<string, FakeToolHandler>;
+  /** When set, every call blocks for this long, to exercise timeout and cancellation. */
+  readonly hangMs?: number;
+  /** Fails `connect()`, to exercise transport startup failure. */
+  readonly failConnect?: Error;
+}
+
+export class FakeMcpServer {
+  readonly calls: FakeToolCall[] = [];
+  private readonly servers: Server[] = [];
+  private readonly transports: Transport[] = [];
+
+  constructor(private readonly options: FakeMcpServerOptions = {}) {}
+
+  get toolNames(): readonly string[] {
+    return this.options.toolNames ?? ALLOWED_SRE_AGENT_TOOLS;
+  }
+
+  /** Correlation-free view of which tools were invoked, in order. */
+  get calledToolNames(): string[] {
+    return this.calls.map((call) => call.name);
+  }
+
+  /** Transport factory to inject into SreAgentMcpClient / SreAgentService. */
+  factory(): McpTransportFactory {
+    return async () => {
+      if (this.options.failConnect) throw this.options.failConnect;
+
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+      const server = this.buildServer();
+      await server.connect(serverTransport);
+
+      this.servers.push(server);
+      this.transports.push(serverTransport);
+      return clientTransport;
+    };
+  }
+
+  private buildServer(): Server {
+    const server = new Server({ name: 'fake-azure-mcp', version: '0.0.0-test' }, { capabilities: { tools: {} } });
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.toolNames.map((name) => ({
+        name,
+        description: `Fake ${name}`,
+        inputSchema: { type: 'object' as const, properties: {}, additionalProperties: true },
+      })),
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+      const name = request.params.name;
+      const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+      this.calls.push({ name, args });
+
+      if (this.options.hangMs) {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, this.options.hangMs);
+          timer.unref?.();
+          extra.signal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timer);
+              reject(new Error('Request aborted by client'));
+            },
+            { once: true },
+          );
+        });
+      }
+
+      const handler = this.options.handlers?.[name];
+      if (!handler) {
+        return { content: [{ type: 'text' as const, text: `No fake handler registered for ${name}` }], isError: true };
+      }
+
+      const payload = await handler(args);
+      const text = typeof payload === 'string' ? payload : JSON.stringify(payload);
+      return { content: [{ type: 'text' as const, text }] };
+    });
+
+    return server;
+  }
+
+  async close(): Promise<void> {
+    for (const server of this.servers.splice(0)) {
+      await server.close().catch(() => undefined);
+    }
+    this.transports.splice(0);
+  }
+}
+
+/** Canonical agent payload matching the documented `sreagent_agents_*` result fields. */
+export function fakeAgentPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 200,
+    results: [
+      {
+        name: 'sre-agent-energygrid',
+        id: '/subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/rg-srelab-eastus2/providers/Microsoft.App/agents/sre-agent-energygrid',
+        location: 'eastus2',
+        resourceGroup: 'rg-srelab-eastus2',
+        provisioningState: 'Succeeded',
+        endpoint: 'https://sre-agent-energygrid.eastus2.azuresre.ai',
+        ...overrides,
+      },
+    ],
+  };
+}
+
+/** Canonical investigation payload with a thread ID and citations. */
+export function fakeInvestigationPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 200,
+    results: {
+      threadId: 'thread-0f8a1c2d-9b3e-4c5f-8a7b-6d5e4f3a2b1c',
+      response:
+        'meter-service pods in namespace energy are being OOMKilled. Container memory limit is 128Mi while working set peaks at 190Mi during smart-meter ingest bursts.',
+      citations: [
+        { title: 'KubePodInventory — meter-service restarts', url: 'https://portal.azure.com/#logs', source: 'Log Analytics' },
+        { title: 'AKS container events', source: 'Azure Monitor' },
+      ],
+      ...overrides,
+    },
+  };
+}

--- a/mission-control/backend/src/services/sre-agent/operations.test.ts
+++ b/mission-control/backend/src/services/sre-agent/operations.test.ts
@@ -1,0 +1,294 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ALLOWED_SRE_AGENT_TOOLS,
+  BLOCKED_SRE_AGENT_TOOLS,
+  SRE_AGENT_OPERATIONS,
+  SreAgentOperationDeniedError,
+  assertToolAllowed,
+  buildToolFilterArgs,
+  isReadOnlySreAgentOperation,
+  resolveOperationTool,
+} from './operations.js';
+import { loadSreAgentConfig, buildChildEnv, isSreAgentUsable } from './config.js';
+import { boundText, maskArmId, maskGuid, maskIdentifiers, redactForAudit, redactSensitiveText } from './redaction.js';
+
+// --- investigate_yolo / auto-approval must be impossible ---------------------
+
+test('investigate_yolo can never be resolved from a typed operation', () => {
+  for (const operation of SRE_AGENT_OPERATIONS) {
+    const tool = resolveOperationTool(operation);
+    assert.ok(!/yolo/i.test(tool), `${operation} resolved to a yolo tool`);
+  }
+
+  const resolved = SRE_AGENT_OPERATIONS.map((operation) => resolveOperationTool(operation));
+  assert.ok(!resolved.includes('sreagent_threads_investigate_yolo' as never));
+});
+
+test('assertToolAllowed rejects investigate_yolo and every auto-approval spelling', () => {
+  const forbidden = [
+    'sreagent_threads_investigate_yolo',
+    'sreagent_threads_investigate_YOLO',
+    'sreagent_threads_yolo',
+    'sreagent_auto_approve',
+    'sreagent_auto-approval',
+    'sreagent_approve_all',
+    'sreagent_bypass_approval',
+    'sreagent_no_confirm',
+  ];
+
+  for (const tool of forbidden) {
+    assert.throws(() => assertToolAllowed(tool), SreAgentOperationDeniedError, `${tool} was not blocked`);
+  }
+});
+
+test('assertToolAllowed rejects destructive and configuration-mutating tools', () => {
+  for (const tool of BLOCKED_SRE_AGENT_TOOLS) {
+    assert.throws(() => assertToolAllowed(tool), SreAgentOperationDeniedError, `${tool} was not blocked`);
+  }
+});
+
+test('assertToolAllowed rejects unknown, empty, and near-miss tool names', () => {
+  for (const tool of ['', '   ', 'sreagent_threads_delete_all', 'azmcp_storage_account_list', 'sreagent']) {
+    assert.throws(() => assertToolAllowed(tool), SreAgentOperationDeniedError);
+  }
+});
+
+test('resolveOperationTool rejects unsupported operation names', () => {
+  for (const operation of ['investigate-yolo', 'yolo', 'delete-thread', 'approve', '']) {
+    assert.throws(() => resolveOperationTool(operation), SreAgentOperationDeniedError);
+  }
+});
+
+test('the allowlist is exactly the six supported operations', () => {
+  assert.equal(ALLOWED_SRE_AGENT_TOOLS.length, 6);
+  assert.deepEqual([...ALLOWED_SRE_AGENT_TOOLS], [
+    'sreagent_agents_get',
+    'sreagent_agents_list',
+    'sreagent_threads_create',
+    'sreagent_threads_get',
+    'sreagent_threads_investigate',
+    'sreagent_threads_send_message',
+  ]);
+});
+
+test('read-only operations never include investigation or follow-up', () => {
+  assert.ok(isReadOnlySreAgentOperation('discover-agents'));
+  assert.ok(isReadOnlySreAgentOperation('thread-status'));
+  assert.ok(!isReadOnlySreAgentOperation('investigate'));
+  assert.ok(!isReadOnlySreAgentOperation('follow-up'));
+});
+
+// --- server surface lockdown -------------------------------------------------
+
+test('child MCP server argv restricts the server to the allowlisted tools', () => {
+  const args = buildToolFilterArgs();
+  assert.equal(args.filter((arg) => arg === '--tool').length, ALLOWED_SRE_AGENT_TOOLS.length);
+  assert.ok(!args.some((arg) => /yolo/i.test(arg)));
+  for (const tool of ALLOWED_SRE_AGENT_TOOLS) {
+    assert.ok(args.includes(tool));
+  }
+});
+
+test('the tool filter is appended even when an operator overrides the base argv', () => {
+  const config = loadSreAgentConfig({
+    SRE_AGENT_NAME: 'agent-x',
+    SRE_AGENT_SUBSCRIPTION_ID: '11111111-2222-3333-4444-555555555555',
+    SRE_AGENT_MCP_ARGS: '-y @azure/mcp@1.2.3 server start',
+  });
+
+  assert.ok(config.args.includes('--tool'));
+  assert.ok(config.args.includes('sreagent_threads_investigate'));
+  assert.ok(!config.args.some((arg) => /yolo/i.test(arg)));
+  assert.equal(config.args.filter((arg) => arg === '--tool').length, 6);
+});
+
+test('an argv override cannot widen the child server tool surface', () => {
+  const config = loadSreAgentConfig({
+    SRE_AGENT_NAME: 'agent-x',
+    SRE_AGENT_SUBSCRIPTION_ID: '11111111-2222-3333-4444-555555555555',
+    SRE_AGENT_MCP_ARGS:
+      '-y @azure/mcp@latest server start --tool sreagent_threads_investigate_yolo --namespace sreagent --mode all',
+  });
+
+  // The override is still usable, but the tool-widening flags are stripped.
+  assert.equal(config.configured, true);
+  assert.ok(!config.args.some((arg) => /yolo/i.test(arg)));
+  assert.ok(!config.args.includes('--namespace'));
+  assert.ok(!config.args.includes('--mode'));
+  assert.ok(!config.args.includes('all'));
+  assert.equal(config.args.filter((arg) => arg === '--tool').length, 6);
+  assert.ok(config.configurationIssues.some((issue) => issue.includes('tool-exposure flags')));
+});
+
+// --- configuration -----------------------------------------------------------
+
+test('configuration is unusable without an agent name and subscription', () => {
+  const config = loadSreAgentConfig({});
+  assert.equal(config.configured, false);
+  assert.equal(isSreAgentUsable(config), false);
+  assert.ok(config.configurationIssues.some((issue) => issue.includes('SRE_AGENT_NAME')));
+  assert.ok(config.configurationIssues.some((issue) => issue.includes('SRE_AGENT_SUBSCRIPTION_ID')));
+});
+
+test('configuration rejects a malformed subscription GUID', () => {
+  const config = loadSreAgentConfig({ SRE_AGENT_NAME: 'agent-x', SRE_AGENT_SUBSCRIPTION_ID: 'not-a-guid' });
+  assert.equal(config.configured, false);
+  assert.ok(config.configurationIssues.some((issue) => issue.includes('subscription GUID')));
+});
+
+test('configuration can be explicitly disabled', () => {
+  const config = loadSreAgentConfig({
+    SRE_AGENT_NAME: 'agent-x',
+    SRE_AGENT_SUBSCRIPTION_ID: '11111111-2222-3333-4444-555555555555',
+    SRE_AGENT_MCP_ENABLED: 'false',
+  });
+  assert.equal(config.configured, true);
+  assert.equal(config.enabled, false);
+  assert.equal(isSreAgentUsable(config), false);
+});
+
+test('configuration bounds timeouts, iterations, and output size', () => {
+  const config = loadSreAgentConfig({
+    SRE_AGENT_NAME: 'agent-x',
+    SRE_AGENT_SUBSCRIPTION_ID: '11111111-2222-3333-4444-555555555555',
+    SRE_AGENT_MAX_ITERATIONS: '9999',
+    SRE_AGENT_REQUEST_TIMEOUT_MS: '1',
+    SRE_AGENT_MAX_RESPONSE_CHARS: '999999999',
+  });
+
+  assert.equal(config.maxIterations, 20);
+  assert.equal(config.requestTimeoutMs, 5_000);
+  assert.equal(config.maxResponseChars, 100_000);
+});
+
+test('child environment carries no injected secrets and pins the configured target', () => {
+  const config = loadSreAgentConfig({
+    SRE_AGENT_NAME: 'agent-x',
+    SRE_AGENT_SUBSCRIPTION_ID: '11111111-2222-3333-4444-555555555555',
+    SRE_AGENT_TENANT_ID: '99999999-8888-7777-6666-555555555555',
+  });
+
+  const childEnv = buildChildEnv(config, { PATH: '/usr/bin' });
+  assert.equal(childEnv['AZURE_SUBSCRIPTION_ID'], '11111111-2222-3333-4444-555555555555');
+  assert.equal(childEnv['AZURE_TENANT_ID'], '99999999-8888-7777-6666-555555555555');
+  assert.equal(childEnv['AZURE_CLIENT_SECRET'], undefined);
+  assert.equal(childEnv['PATH'], '/usr/bin');
+});
+
+// --- redaction and bounding --------------------------------------------------
+
+test('redaction strips bearer tokens, JWTs, keys, and connection-string secrets', () => {
+  const input = [
+    'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+    'password=hunter2seekrit',
+    'client_secret: abc123def456ghi',
+    'AccountKey=Zm9vYmFyYmF6cXV4',
+    'api-key = 9f8e7d6c5b4a3210',
+  ].join('\n');
+
+  const output = redactSensitiveText(input);
+  assert.ok(!output.includes('hunter2seekrit'));
+  assert.ok(!output.includes('abc123def456ghi'));
+  assert.ok(!output.includes('Zm9vYmFyYmF6cXV4'));
+  assert.ok(!output.includes('9f8e7d6c5b4a3210'));
+  assert.ok(!/eyJhbGciOiJIUzI1NiJ9\.[A-Za-z0-9_-]+\./.test(output));
+  assert.ok(output.includes('[REDACTED]'));
+});
+
+test('redaction removes PEM private keys entirely', () => {
+  const output = redactSensitiveText('-----BEGIN RSA PRIVATE KEY-----\nMIIEabc\n-----END RSA PRIVATE KEY-----');
+  assert.equal(output, '[REDACTED-PRIVATE-KEY]');
+});
+
+test('redaction removes an unterminated PEM block so truncated key material cannot leak', () => {
+  const output = redactSensitiveText('leading text -----BEGIN EC PRIVATE KEY-----\nMIIEsecretKeyMaterialHere');
+  assert.ok(!output.includes('MIIEsecretKeyMaterialHere'));
+  assert.ok(output.includes('[REDACTED-PRIVATE-KEY]'));
+  assert.ok(output.startsWith('leading text '));
+});
+
+test('bounded output truncates explicitly instead of silently', () => {
+  const bounded = boundText('x'.repeat(500), 100);
+  assert.equal(bounded.truncated, true);
+  assert.equal(bounded.originalLength, 500);
+  assert.ok(bounded.text.includes('Mission Control truncated this response'));
+
+  const short = boundText('all good', 100);
+  assert.equal(short.truncated, false);
+  assert.equal(short.text, 'all good');
+});
+
+test('GUIDs and ARM IDs are masked for display and evidence packs', () => {
+  assert.equal(maskGuid('11111111-2222-3333-4444-555555555555'), '11111111-****-****-****-555555');
+  assert.equal(maskGuid('nope'), '[redacted]');
+  assert.equal(maskGuid(undefined), undefined);
+
+  const masked = maskArmId(
+    '/subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/rg-srelab/providers/Microsoft.App/agents/agent-x',
+  );
+  assert.ok(!masked?.includes('11111111-2222-3333-4444-555555555555'));
+  assert.ok(masked?.includes('rg-srelab'));
+  assert.ok(masked?.includes('agents/agent-x'));
+});
+
+test('audit redaction masks sensitive keys and bounds depth and size', () => {
+  const audited = redactForAudit({
+    message: 'investigate meter-service',
+    access_token: 'super-secret-value',
+    nested: { authorization: 'Bearer abc', keep: 'visible' },
+    long: 'y'.repeat(900),
+  }) as Record<string, any>;
+
+  assert.equal(audited['access_token'], '[REDACTED]');
+  assert.equal(audited['nested']['authorization'], '[REDACTED]');
+  assert.equal(audited['nested']['keep'], 'visible');
+  assert.ok(String(audited['long']).endsWith('…[truncated]'));
+  assert.equal(audited['message'], 'investigate meter-service');
+});
+
+test('audit redaction masks subscription and tenant identifiers', () => {
+  // Mission Control streams backend logs to an on-screen terminal during demos, so
+  // these identifiers must never appear unmasked in an audit record.
+  const audited = redactForAudit({
+    agent: 'sre-agent-energygrid',
+    subscription: '11111111-2222-3333-4444-555555555555',
+    tenant: '99999999-8888-7777-6666-555555555555',
+    'resource-group': 'rg-srelab-eastus2',
+  }) as Record<string, any>;
+
+  assert.equal(audited['subscription'], '11111111-****-****-****-555555');
+  assert.equal(audited['tenant'], '99999999-****-****-****-555555');
+  assert.equal(audited['agent'], 'sre-agent-energygrid');
+  assert.equal(audited['resource-group'], 'rg-srelab-eastus2');
+  assert.ok(!JSON.stringify(audited).includes('11111111-2222-3333-4444-555555555555'));
+});
+
+test('identifier masking removes subscription and tenant GUIDs from agent prose', () => {
+  const known = {
+    subscriptionId: '11111111-2222-3333-4444-555555555555',
+    tenantId: '99999999-8888-7777-6666-555555555555',
+  };
+
+  const text = [
+    'Root cause on /subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/rg-srelab/providers/Microsoft.ContainerService/managedClusters/aks-demo',
+    'subscription id: 11111111-2222-3333-4444-555555555555',
+    'tenantId=99999999-8888-7777-6666-555555555555',
+    'bare reference 11111111-2222-3333-4444-555555555555 in prose',
+  ].join('\n');
+
+  const masked = maskIdentifiers(text, known);
+
+  assert.ok(!masked.includes('11111111-2222-3333-4444-555555555555'), 'subscription GUID leaked');
+  assert.ok(!masked.includes('99999999-8888-7777-6666-555555555555'), 'tenant GUID leaked');
+  // Diagnostic context is preserved.
+  assert.ok(masked.includes('rg-srelab'));
+  assert.ok(masked.includes('managedClusters/aks-demo'));
+  assert.ok(masked.includes('11111111-****-****-****-555555'));
+});
+
+test('identifier masking handles an unknown subscription in an ARM path', () => {
+  const masked = maskIdentifiers('/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/rg');
+  assert.ok(!masked.includes('abcdef12-3456-7890-abcd-ef1234567890'));
+  assert.ok(masked.includes('/resourceGroups/rg'));
+});

--- a/mission-control/backend/src/services/sre-agent/operations.test.ts
+++ b/mission-control/backend/src/services/sre-agent/operations.test.ts
@@ -11,7 +11,7 @@ import {
   resolveOperationTool,
 } from './operations.js';
 import { loadSreAgentConfig, buildChildEnv, isSreAgentUsable } from './config.js';
-import { boundText, maskArmId, maskGuid, maskIdentifiers, redactForAudit, redactSensitiveText } from './redaction.js';
+import { boundText, maskArmId, maskGuid, maskIdentifiers, redactForAudit, redactSegment, redactSensitiveText, RedactedStreamBuffer } from './redaction.js';
 
 // --- investigate_yolo / auto-approval must be impossible ---------------------
 
@@ -291,4 +291,127 @@ test('identifier masking handles an unknown subscription in an ARM path', () => 
   const masked = maskIdentifiers('/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/rg');
   assert.ok(!masked.includes('abcdef12-3456-7890-abcd-ef1234567890'));
   assert.ok(masked.includes('/resourceGroups/rg'));
+});
+
+// --- streaming stderr redaction (regression: raw rolling-buffer secret leak) ---
+//
+// The previous implementation accumulated RAW stderr with `.slice(-2_000)` and redacted
+// once on read. A PEM private key longer than the window had its BEGIN marker evicted
+// while key body survived, so the final redaction pass had no marker to match and raw
+// key material reached the error message and the UI.
+
+/** Builds a PEM block whose body alone exceeds the 2,000-character retention window. */
+function buildLongPem(bodyLines = 60): string {
+  const body = Array.from(
+    { length: bodyLines },
+    (_, i) => `SECRETLINE${String(i).padStart(3, '0')}0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`,
+  ).join('\n');
+  return `-----BEGIN RSA PRIVATE KEY-----\n${body}\n-----END RSA PRIVATE KEY-----\n`;
+}
+
+test('streaming stderr buffer keeps no key material when the BEGIN marker is evicted', () => {
+  const pem = buildLongPem();
+  assert.ok(pem.length > 2_000, 'the PEM must exceed the retention window for this regression');
+
+  const buffer = new RedactedStreamBuffer();
+  buffer.append(pem);
+  // Enough ordinary diagnostics to push the marker out of a 2,000-char raw window.
+  buffer.append('INFO: continuing startup diagnostics...\n'.repeat(80));
+
+  const snapshot = buffer.snapshot();
+  assert.ok(!snapshot.includes('SECRETLINE'), 'private key body reached the stderr hint');
+  assert.ok(!snapshot.includes('-----BEGIN RSA PRIVATE KEY-----'));
+  assert.ok(snapshot.includes('INFO: continuing startup diagnostics'), 'diagnostics should survive');
+});
+
+test('streaming stderr buffer drops key body split across many chunks', () => {
+  const buffer = new RedactedStreamBuffer();
+  // Marker and body arrive in separate writes, as a real pipe delivers them.
+  buffer.append('-----BEGIN OPENSSH PRIVATE KEY-----\n');
+  for (let i = 0; i < 60; i += 1) {
+    buffer.append(`SECRETLINE${String(i).padStart(3, '0')}0123456789abcdefghijklmnopqrstuvwxyz\n`);
+  }
+  buffer.append('-----END OPENSSH PRIVATE KEY-----\n');
+  buffer.append('npm warn deprecated something@1.0.0\n');
+
+  const snapshot = buffer.snapshot();
+  assert.ok(!snapshot.includes('SECRETLINE'), 'key body leaked across chunk boundaries');
+  assert.ok(snapshot.includes('npm warn deprecated'));
+});
+
+test('streaming stderr buffer suppresses an unterminated key that is still streaming', () => {
+  const buffer = new RedactedStreamBuffer();
+  buffer.append('-----BEGIN EC PRIVATE KEY-----\n');
+  buffer.append('SECRETLINE000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'.repeat(50));
+
+  const snapshot = buffer.snapshot();
+  assert.ok(!snapshot.includes('SECRETLINE'));
+  assert.ok(snapshot.includes('[REDACTED-PRIVATE-KEY]'));
+});
+
+test('streaming stderr buffer resumes normal output after the key ends', () => {
+  const buffer = new RedactedStreamBuffer();
+  buffer.append(buildLongPem(10));
+  buffer.append('ERROR: agent endpoint unreachable\n');
+
+  const snapshot = buffer.snapshot();
+  assert.ok(!snapshot.includes('SECRETLINE'));
+  assert.ok(snapshot.includes('ERROR: agent endpoint unreachable'));
+});
+
+test('streaming stderr buffer bounds a newline-free flood without splitting a marker', () => {
+  const buffer = new RedactedStreamBuffer();
+  // No newlines at all, then a marker arriving in two separate writes across the
+  // forced-commit boundary.
+  buffer.append('x'.repeat(9_000));
+  buffer.append('-----BEGIN RSA PRI');
+  buffer.append('VATE KEY-----SECRETBODYMATERIAL');
+
+  const snapshot = buffer.snapshot();
+  assert.ok(!snapshot.includes('SECRETBODYMATERIAL'), 'marker split across writes let body through');
+  assert.ok(snapshot.length <= 2_000);
+});
+
+test('streaming stderr buffer still redacts ordinary single-line secrets', () => {
+  const buffer = new RedactedStreamBuffer();
+  buffer.append('config loaded password=hunter2seekrit\n');
+  buffer.append('Authorization: Bearer abcdefghijklmnopqrstuvwxyz012345\n');
+
+  const snapshot = buffer.snapshot();
+  assert.ok(!snapshot.includes('hunter2seekrit'));
+  assert.ok(!snapshot.includes('abcdefghijklmnopqrstuvwxyz012345'));
+  assert.ok(snapshot.includes('[REDACTED]'));
+});
+
+test('streaming stderr buffer redacts a secret split across a chunk boundary', () => {
+  const buffer = new RedactedStreamBuffer();
+  buffer.append('starting up password=hunt');
+  buffer.append('er2seekrit trailing\n');
+
+  const snapshot = buffer.snapshot();
+  assert.ok(!snapshot.includes('hunter2seekrit'), 'secret straddling two chunks leaked');
+});
+
+test('streaming stderr buffer output stays bounded and resets between transports', () => {
+  const buffer = new RedactedStreamBuffer();
+  buffer.append('noise line that is reasonably long\n'.repeat(500));
+  assert.ok(buffer.snapshot().length <= 2_000);
+
+  buffer.reset();
+  assert.equal(buffer.snapshot(), '');
+});
+
+test('redactSegment carries private-key state across segments', () => {
+  const first = redactSegment('-----BEGIN RSA PRIVATE KEY-----\nSECRETLINE000\n', false);
+  assert.equal(first.insideSecret, true);
+  assert.ok(!first.text.includes('SECRETLINE'));
+
+  const second = redactSegment('SECRETLINE001\nSECRETLINE002\n', first.insideSecret);
+  assert.equal(second.insideSecret, true);
+  assert.equal(second.text, '');
+
+  const third = redactSegment('SECRETLINE003\n-----END RSA PRIVATE KEY-----\nready\n', second.insideSecret);
+  assert.equal(third.insideSecret, false);
+  assert.ok(!third.text.includes('SECRETLINE'));
+  assert.ok(third.text.includes('ready'));
 });

--- a/mission-control/backend/src/services/sre-agent/operations.ts
+++ b/mission-control/backend/src/services/sre-agent/operations.ts
@@ -1,0 +1,165 @@
+/**
+ * Strict operation allowlist for the Azure SRE Agent MCP adapter.
+ *
+ * Mission Control may only invoke the six Azure MCP Server tools named here. The
+ * allowlist is enforced in three independent layers so that no single mistake can
+ * widen the blast radius:
+ *
+ *   1. Server surface  — the Azure MCP Server child process is launched with one
+ *                        `--tool <name>` flag per allowlisted tool, so unlisted
+ *                        tools (including `sreagent_threads_investigate_yolo`) are
+ *                        never registered on the server at all.
+ *   2. Client mapping  — callers address operations by typed `SreAgentOperation`
+ *                        names and can never pass a raw tool name.
+ *   3. Denylist assert — an explicit blocked-pattern check rejects auto-approval
+ *                        and destructive tool names even if layers 1 and 2 regress.
+ *
+ * Verified against Azure MCP Server 3.0.0-beta.34 (`sreagent` namespace).
+ */
+
+export const SRE_AGENT_OPERATIONS = [
+  'discover-agents',
+  'get-agent',
+  'create-thread',
+  'investigate',
+  'follow-up',
+  'thread-status',
+] as const;
+
+export type SreAgentOperation = (typeof SRE_AGENT_OPERATIONS)[number];
+
+/** Typed operation -> exact Azure MCP Server tool name. This map is the only way to reach a tool. */
+export const SRE_AGENT_OPERATION_TOOLS = {
+  'discover-agents': 'sreagent_agents_list',
+  'get-agent': 'sreagent_agents_get',
+  'create-thread': 'sreagent_threads_create',
+  investigate: 'sreagent_threads_investigate',
+  'follow-up': 'sreagent_threads_send_message',
+  'thread-status': 'sreagent_threads_get',
+} as const satisfies Record<SreAgentOperation, string>;
+
+export type SreAgentToolName = (typeof SRE_AGENT_OPERATION_TOOLS)[SreAgentOperation];
+
+/** Every tool the child MCP server is permitted to expose, sorted for deterministic argv. */
+export const ALLOWED_SRE_AGENT_TOOLS: readonly SreAgentToolName[] = Object.freeze(
+  Object.values(SRE_AGENT_OPERATION_TOOLS).slice().sort(),
+) as readonly SreAgentToolName[];
+
+/** Operations that never mutate agent or Azure state. */
+export const READ_ONLY_SRE_AGENT_OPERATIONS: readonly SreAgentOperation[] = Object.freeze([
+  'discover-agents',
+  'get-agent',
+  'thread-status',
+]);
+
+/**
+ * Tools that are permanently forbidden regardless of configuration.
+ *
+ * `sreagent_threads_investigate_yolo` auto-approves every approval gate — including
+ * infrastructure mutation — and is explicitly out of scope for this demo. The rest are
+ * destructive or configuration-mutating tools Mission Control has no reason to call.
+ */
+export const BLOCKED_SRE_AGENT_TOOLS: readonly string[] = Object.freeze([
+  'sreagent_threads_investigate_yolo',
+  'sreagent_threads_delete',
+  'sreagent_agents_create',
+  'sreagent_agents_delete',
+  'sreagent_agents_tools_create',
+  'sreagent_skills_create',
+  'sreagent_skills_delete',
+  'sreagent_connectors_create_kusto',
+  'sreagent_connectors_create_mcp',
+  'sreagent_connectors_delete',
+  'sreagent_hooks_delete',
+  'sreagent_hooks_thread_activate',
+  'sreagent_hooks_thread_deactivate',
+  'sreagent_workflows_apply',
+  'sreagent_docs_memories_add',
+  'sreagent_docs_memories_delete',
+  'sreagent_commonprompts_create',
+  'sreagent_commonprompts_delete',
+  'sreagent_scheduledtasks_create',
+  'sreagent_scheduledtasks_delete',
+  'sreagent_incidents_setup_pagerduty',
+  'sreagent_incidents_setup_servicenow',
+]);
+
+/**
+ * Substrings that indicate an auto-approval or approval-bypassing capability.
+ * Matched case-insensitively against any requested tool name.
+ */
+const BLOCKED_TOOL_PATTERNS: readonly RegExp[] = Object.freeze([
+  /yolo/i,
+  /auto[_-]?approve/i,
+  /auto[_-]?approval/i,
+  /approve[_-]?all/i,
+  /bypass[_-]?approval/i,
+  /no[_-]?confirm/i,
+]);
+
+export class SreAgentOperationDeniedError extends Error {
+  readonly statusCode = 403;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'SreAgentOperationDeniedError';
+  }
+}
+
+export function isSreAgentOperation(value: unknown): value is SreAgentOperation {
+  return typeof value === 'string' && (SRE_AGENT_OPERATIONS as readonly string[]).includes(value);
+}
+
+export function isReadOnlySreAgentOperation(operation: SreAgentOperation): boolean {
+  return READ_ONLY_SRE_AGENT_OPERATIONS.includes(operation);
+}
+
+/**
+ * Fail-closed guard applied to every tool name immediately before dispatch.
+ * Throws rather than returning a boolean so a missing check cannot silently pass.
+ */
+export function assertToolAllowed(toolName: string): asserts toolName is SreAgentToolName {
+  const normalized = typeof toolName === 'string' ? toolName.trim() : '';
+
+  if (!normalized) {
+    throw new SreAgentOperationDeniedError('An empty SRE Agent tool name is not allowlisted.');
+  }
+
+  for (const pattern of BLOCKED_TOOL_PATTERNS) {
+    if (pattern.test(normalized)) {
+      throw new SreAgentOperationDeniedError(
+        `SRE Agent tool '${normalized}' is permanently blocked: Mission Control never runs auto-approval or approval-bypassing investigations.`,
+      );
+    }
+  }
+
+  if (BLOCKED_SRE_AGENT_TOOLS.includes(normalized)) {
+    throw new SreAgentOperationDeniedError(
+      `SRE Agent tool '${normalized}' is permanently blocked: Mission Control only performs discovery, standard investigation, follow-up, and status reads.`,
+    );
+  }
+
+  if (!(ALLOWED_SRE_AGENT_TOOLS as readonly string[]).includes(normalized)) {
+    throw new SreAgentOperationDeniedError(
+      `SRE Agent tool '${normalized}' is not on the Mission Control allowlist (${ALLOWED_SRE_AGENT_TOOLS.join(', ')}).`,
+    );
+  }
+}
+
+/** Resolves a typed operation to its allowlisted tool name, or throws. */
+export function resolveOperationTool(operation: string): SreAgentToolName {
+  if (!isSreAgentOperation(operation)) {
+    throw new SreAgentOperationDeniedError(
+      `SRE Agent operation '${operation}' is not supported. Allowed operations: ${SRE_AGENT_OPERATIONS.join(', ')}.`,
+    );
+  }
+
+  const toolName = SRE_AGENT_OPERATION_TOOLS[operation];
+  assertToolAllowed(toolName);
+  return toolName;
+}
+
+/** argv fragment that constrains the child MCP server to the allowlisted tools only. */
+export function buildToolFilterArgs(): string[] {
+  return ALLOWED_SRE_AGENT_TOOLS.flatMap((tool) => ['--tool', tool]);
+}

--- a/mission-control/backend/src/services/sre-agent/preflight.ts
+++ b/mission-control/backend/src/services/sre-agent/preflight.ts
@@ -1,0 +1,364 @@
+/**
+ * Preflight checks for the Azure SRE Agent MCP path.
+ *
+ * Each check answers one question an operator can act on before a demo:
+ * configuration, Azure sign-in, Node/npx runtime, MCP server surface, agent discovery,
+ * RBAC, and `*.azuresre.ai` reachability. Failures are reported with a concrete
+ * remediation rather than a generic "unavailable".
+ *
+ * Checks are read-only and must never mutate Azure or agent state.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { isSreAgentUsable, type SreAgentConfig } from './config.js';
+import { ALLOWED_SRE_AGENT_TOOLS, BLOCKED_SRE_AGENT_TOOLS } from './operations.js';
+import { maskGuid, redactSensitiveText } from './redaction.js';
+import { SreAgentMcpError } from './SreAgentMcpClient.js';
+import type { SreAgentService } from './SreAgentService.js';
+import type {
+  SreAgentPreflightCheck,
+  SreAgentPreflightResult,
+} from '../../types/index.js';
+
+const exec = promisify(execFile);
+
+const AZ_TIMEOUT_MS = 15_000;
+const TOOL_LIST_TIMEOUT_MS = 120_000;
+const NETWORK_TIMEOUT_MS = 10_000;
+
+/** Data-plane suffix documented for SRE Agent endpoints. */
+export const SRE_AGENT_DATA_PLANE_SUFFIX = 'azuresre.ai';
+
+type CommandRunner = (command: string, args: string[], timeoutMs: number) => Promise<{ stdout: string; stderr: string }>;
+
+const defaultRunner: CommandRunner = async (command, args, timeoutMs) => {
+  const { stdout, stderr } = await exec(command, args, { timeout: timeoutMs, maxBuffer: 4 * 1024 * 1024 });
+  return { stdout: String(stdout), stderr: String(stderr) };
+};
+
+export interface SreAgentPreflightOptions {
+  /** Skips the MCP tool-list probe, which can take ~30s on a cold npx cache. */
+  readonly skipMcpProbe?: boolean;
+  readonly runner?: CommandRunner;
+  /** Injected for tests; defaults to a real DNS lookup of the agent endpoint host. */
+  readonly resolveHost?: (host: string) => Promise<boolean>;
+}
+
+async function defaultResolveHost(host: string): Promise<boolean> {
+  const { lookup } = await import('node:dns/promises');
+  try {
+    await lookup(host);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function collectSreAgentPreflight(
+  service: SreAgentService,
+  options: SreAgentPreflightOptions = {},
+): Promise<SreAgentPreflightResult> {
+  const config = service.configuration;
+  const runner = options.runner ?? defaultRunner;
+  const resolveHost = options.resolveHost ?? defaultResolveHost;
+  const checks: SreAgentPreflightCheck[] = [];
+
+  checks.push(configurationCheck(config));
+
+  const azAccount = await azAccountCheck(runner, config);
+  checks.push(azAccount.check);
+
+  if (!isSreAgentUsable(config)) {
+    return finalize(service, checks, config);
+  }
+
+  if (options.skipMcpProbe) {
+    checks.push({
+      name: 'Azure MCP Server tool surface',
+      status: 'skipped',
+      message: 'MCP probe skipped by request.',
+      remediation: 'Re-run preflight without skipMcpProbe to verify the allowlisted tool surface.',
+    });
+    return finalize(service, checks, config);
+  }
+
+  const toolCheck = await mcpToolSurfaceCheck(service, config);
+  checks.push(...toolCheck);
+
+  // Only attempt discovery when the transport itself came up.
+  if (toolCheck.every((check) => check.status !== 'fail')) {
+    const discovery = await agentDiscoveryCheck(service, config);
+    checks.push(discovery.check);
+
+    if (discovery.endpointHost) {
+      checks.push(await endpointReachabilityCheck(discovery.endpointHost, resolveHost));
+    } else {
+      checks.push({
+        name: 'SRE Agent data-plane reachability',
+        status: 'warn',
+        message: `Agent endpoint host was not reported, so *.${SRE_AGENT_DATA_PLANE_SUFFIX} reachability could not be verified.`,
+        remediation: `Allow outbound HTTPS to *.${SRE_AGENT_DATA_PLANE_SUFFIX} and confirm the agent is fully provisioned.`,
+      });
+    }
+  }
+
+  return finalize(service, checks, config);
+}
+
+function configurationCheck(config: SreAgentConfig): SreAgentPreflightCheck {
+  if (!config.configured) {
+    return {
+      name: 'SRE Agent configuration',
+      status: 'fail',
+      message: 'Mission Control has no configured Azure SRE Agent target.',
+      remediation: config.configurationIssues.join(' '),
+    };
+  }
+  if (!config.enabled) {
+    return {
+      name: 'SRE Agent configuration',
+      status: 'fail',
+      message: 'The SRE Agent MCP integration is disabled by configuration.',
+      remediation: 'Set SRE_AGENT_MCP_ENABLED=true and restart Mission Control.',
+    };
+  }
+  return {
+    name: 'SRE Agent configuration',
+    status: 'pass',
+    message: `Targeting agent '${config.agentName}' in subscription ${maskGuid(config.subscriptionId)}${
+      config.resourceGroup ? ` (resource group ${config.resourceGroup})` : ''
+    }.`,
+  };
+}
+
+async function azAccountCheck(
+  runner: CommandRunner,
+  config: SreAgentConfig,
+): Promise<{ check: SreAgentPreflightCheck }> {
+  try {
+    const { stdout } = await runner('az', ['account', 'show', '--output', 'json'], AZ_TIMEOUT_MS);
+    const account = JSON.parse(stdout) as { id?: string; name?: string; tenantId?: string };
+
+    if (config.tenantId && account.tenantId && account.tenantId.toLowerCase() !== config.tenantId.toLowerCase()) {
+      return {
+        check: {
+          name: 'Azure sign-in',
+          status: 'warn',
+          message: `Signed in to tenant ${maskGuid(account.tenantId)}, but SRE_AGENT_TENANT_ID is ${maskGuid(config.tenantId)}.`,
+          // Preflight output is pasted into issues and evidence packs, so the raw GUID
+          // is never interpolated here; the operator reads it from their own config.
+          remediation: 'Run: az login --tenant "$SRE_AGENT_TENANT_ID"',
+        },
+      };
+    }
+
+    if (config.subscriptionId && account.id && account.id.toLowerCase() !== config.subscriptionId.toLowerCase()) {
+      return {
+        check: {
+          name: 'Azure sign-in',
+          status: 'warn',
+          message: `Azure CLI default subscription is ${maskGuid(account.id)}, which differs from the configured target.`,
+          remediation: 'Mission Control passes the configured subscription explicitly, but running `az account set` avoids confusion.',
+        },
+      };
+    }
+
+    return {
+      check: {
+        name: 'Azure sign-in',
+        status: 'pass',
+        message: `Signed in as subscription ${account.name ?? 'unknown'} (${maskGuid(account.id)}).`,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? redactSensitiveText(error.message) : 'unknown error';
+    const notFound = (error as NodeJS.ErrnoException)?.code === 'ENOENT';
+    return {
+      check: {
+        name: 'Azure sign-in',
+        status: 'fail',
+        message: notFound ? 'Azure CLI is not available on PATH.' : `Not signed in to Azure (${message.slice(0, 200)}).`,
+        remediation: notFound
+          ? 'Install the Azure CLI, then run `az login`.'
+          : 'Run `az login` (add `--tenant <agent-tenant-id>` if the agent lives in another tenant). Azure MCP Server suppresses interactive sign-in, so you must sign in first.',
+      },
+    };
+  }
+}
+
+async function mcpToolSurfaceCheck(service: SreAgentService, config: SreAgentConfig): Promise<SreAgentPreflightCheck[]> {
+  const checks: SreAgentPreflightCheck[] = [];
+
+  try {
+    const tools = await withTimeout(service.listTools(), TOOL_LIST_TIMEOUT_MS);
+    const exposed = new Set(tools);
+    const missing = ALLOWED_SRE_AGENT_TOOLS.filter((tool) => !exposed.has(tool));
+    const forbidden = tools.filter((tool) => BLOCKED_SRE_AGENT_TOOLS.includes(tool) || /yolo/i.test(tool));
+
+    checks.push({
+      name: 'Azure MCP Server tool surface',
+      status: missing.length === 0 ? 'pass' : 'fail',
+      message:
+        missing.length === 0
+          ? `Azure MCP Server (${config.serverPackage}) exposed all ${tools.length} allowlisted SRE Agent tools.`
+          : `Azure MCP Server did not expose: ${missing.join(', ')}.`,
+      ...(missing.length === 0
+        ? {}
+        : {
+            remediation:
+              'Clear the npx cache (`rm -rf ~/.npm/_npx`) and confirm SRE_AGENT_MCP_PACKAGE points at a version that includes the sreagent namespace.',
+          }),
+    });
+
+    checks.push({
+      name: 'Auto-approval tools blocked',
+      status: forbidden.length === 0 ? 'pass' : 'fail',
+      message:
+        forbidden.length === 0
+          ? 'investigate_yolo and every auto-approval tool are absent from the MCP server surface.'
+          : `Blocked tools were exposed by the MCP server: ${forbidden.join(', ')}.`,
+      ...(forbidden.length === 0
+        ? {}
+        : { remediation: 'Do not use this build. Mission Control must launch Azure MCP Server with its --tool allowlist.' }),
+    });
+  } catch (error) {
+    const mcpError = error instanceof SreAgentMcpError ? error : undefined;
+    checks.push({
+      name: 'Azure MCP Server tool surface',
+      status: 'fail',
+      message: mcpError?.message ?? `Could not start the Azure MCP Server: ${errorText(error)}`,
+      remediation:
+        mcpError?.remediation ??
+        'Confirm Node.js LTS is installed so `npx` can launch the Azure MCP Server, then retry.',
+    });
+  }
+
+  return checks;
+}
+
+async function agentDiscoveryCheck(
+  service: SreAgentService,
+  config: SreAgentConfig,
+): Promise<{ check: SreAgentPreflightCheck; endpointHost?: string }> {
+  try {
+    const discovery = await service.discoverAgents();
+
+    if (!discovery.selected) {
+      const names = discovery.agents.map((agent) => agent.name).filter(Boolean);
+      return {
+        check: {
+          name: 'SRE Agent discovery',
+          status: 'fail',
+          message:
+            names.length > 0
+              ? `Agent '${config.agentName}' was not found. Visible agents: ${names.join(', ')}.`
+              : `No SRE Agent resources were visible in subscription ${maskGuid(config.subscriptionId)}.`,
+          remediation:
+            'Confirm SRE_AGENT_NAME/SRE_AGENT_RESOURCE_GROUP, and that you hold Reader on the Microsoft.App/agents resource.',
+        },
+      };
+    }
+
+    const selected = discovery.selected;
+    const provisioned = (selected.provisioningState ?? '').toLowerCase() === 'succeeded';
+
+    return {
+      check: {
+        name: 'SRE Agent discovery',
+        status: provisioned || !selected.provisioningState ? 'pass' : 'warn',
+        message: `Resolved agent '${selected.name}'${
+          selected.provisioningState ? ` (provisioningState: ${selected.provisioningState})` : ''
+        }${selected.location ? ` in ${selected.location}` : ''}.`,
+        ...(provisioned || !selected.provisioningState
+          ? {}
+          : { remediation: 'Wait for provisioningState to reach Succeeded before starting an investigation.' }),
+      },
+      ...(selected.endpointHost ? { endpointHost: selected.endpointHost } : {}),
+    };
+  } catch (error) {
+    const mcpError = error instanceof SreAgentMcpError ? error : undefined;
+    const isPermission = mcpError?.kind === 'permission';
+
+    return {
+      check: {
+        name: isPermission ? 'SRE Agent RBAC' : 'SRE Agent discovery',
+        status: 'fail',
+        message: mcpError?.message ?? `Agent discovery failed: ${errorText(error)}`,
+        remediation:
+          mcpError?.remediation ??
+          'Assign Reader (control plane) and SRE Agent Administrator (data plane) on the Microsoft.App/agents resource, then retry.',
+      },
+    };
+  }
+}
+
+async function endpointReachabilityCheck(
+  host: string,
+  resolveHost: (host: string) => Promise<boolean>,
+): Promise<SreAgentPreflightCheck> {
+  const expected = host.toLowerCase().endsWith(SRE_AGENT_DATA_PLANE_SUFFIX);
+
+  try {
+    const resolved = await withTimeout(resolveHost(host), NETWORK_TIMEOUT_MS);
+    if (resolved) {
+      return {
+        name: 'SRE Agent data-plane reachability',
+        status: expected ? 'pass' : 'warn',
+        message: expected
+          ? `Resolved the agent data-plane host ${host}.`
+          : `Resolved ${host}, which is outside the expected *.${SRE_AGENT_DATA_PLANE_SUFFIX} domain.`,
+        ...(expected ? {} : { remediation: 'Confirm the agent endpoint is a Microsoft-managed SRE Agent endpoint.' }),
+      };
+    }
+
+    return {
+      name: 'SRE Agent data-plane reachability',
+      status: 'fail',
+      message: `Could not resolve the agent data-plane host ${host}.`,
+      remediation: `Allow outbound DNS and HTTPS to *.${SRE_AGENT_DATA_PLANE_SUFFIX} through your proxy or firewall, then retry.`,
+    };
+  } catch (error) {
+    return {
+      name: 'SRE Agent data-plane reachability',
+      status: 'warn',
+      message: `Reachability check for ${host} did not complete: ${errorText(error)}`,
+      remediation: `Verify outbound access to *.${SRE_AGENT_DATA_PLANE_SUFFIX} manually.`,
+    };
+  }
+}
+
+function finalize(
+  service: SreAgentService,
+  checks: SreAgentPreflightCheck[],
+  config: SreAgentConfig,
+): SreAgentPreflightResult {
+  return {
+    ready: checks.every((check) => check.status !== 'fail'),
+    configured: config.configured,
+    enabled: config.enabled,
+    checks,
+    target: service.targetSummary(),
+    collectedAt: new Date().toISOString(),
+    portalHandoff: service.portalHandoff(),
+  };
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? redactSensitiveText(error.message).slice(0, 300) : 'unknown error';
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`Operation timed out after ${timeoutMs}ms`)), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/mission-control/backend/src/services/sre-agent/redaction.ts
+++ b/mission-control/backend/src/services/sre-agent/redaction.ts
@@ -1,0 +1,159 @@
+/**
+ * Redaction and output-bounding for everything the SRE Agent adapter returns or logs.
+ *
+ * Azure MCP Server already strips common credential patterns server-side, but Mission
+ * Control must not depend on an upstream control for its own safety guarantees. Every
+ * string that leaves the adapter — toward the browser, the audit log, or an evidence
+ * bundle — passes through `redactSensitiveText`, and every payload is length-bounded so
+ * a hostile or runaway response cannot exhaust the UI or the log.
+ */
+
+/** Ordered so that broader patterns cannot mask narrower, higher-value ones. */
+const REDACTION_RULES: ReadonlyArray<{ pattern: RegExp; replacement: string }> = Object.freeze([
+  // Bearer / auth headers
+  { pattern: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, replacement: '$1 [REDACTED]' },
+  // JWTs anywhere in free text
+  { pattern: /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\b/g, replacement: '[REDACTED-JWT]' },
+  // key=value secrets
+  {
+    pattern:
+      /\b(password|passwd|pwd|token|access[_-]?token|id[_-]?token|refresh[_-]?token|secret|client[_-]?secret|api[_-]?key|apikey|subscription[_-]?key|sas[_-]?token|authorization|connectionstring)(\s*[:=]\s*)(["']?)[^\s"',;}]+/gi,
+    replacement: '$1$2$3[REDACTED]',
+  },
+  // Storage / service connection string fragments
+  { pattern: /\b(AccountKey|SharedAccessSignature|SharedAccessKey)=[^;\s"']+/gi, replacement: '$1=[REDACTED]' },
+  // SAS query strings
+  { pattern: /\b(sig|sv|se|st|skoid|sktid)=[A-Za-z0-9%._~+/-]{8,}/gi, replacement: '$1=[REDACTED]' },
+  // PEM blocks. The END marker is optional so an already-truncated or malformed block
+  // still has its key material stripped rather than leaking the remainder.
+  {
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
+    replacement: '[REDACTED-PRIVATE-KEY]',
+  },
+]);
+
+export function redactSensitiveText(value: string): string {
+  let output = value;
+  for (const { pattern, replacement } of REDACTION_RULES) {
+    output = output.replace(pattern, replacement);
+  }
+  return output;
+}
+
+export interface BoundedText {
+  readonly text: string;
+  readonly truncated: boolean;
+  readonly originalLength: number;
+}
+
+/** Redacts, then truncates to `maxChars`, marking truncation explicitly rather than silently. */
+export function boundText(value: string, maxChars: number): BoundedText {
+  const redacted = redactSensitiveText(value);
+  if (redacted.length <= maxChars) {
+    return { text: redacted, truncated: false, originalLength: redacted.length };
+  }
+
+  return {
+    text: `${redacted.slice(0, maxChars)}\n\n[Mission Control truncated this response at ${maxChars} characters.]`,
+    truncated: true,
+    originalLength: redacted.length,
+  };
+}
+
+/**
+ * Masks a subscription/tenant GUID for display: keeps the first and last group so an
+ * operator can correlate it with the portal without publishing the full identifier.
+ */
+export function maskGuid(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  const match = /^([0-9a-fA-F]{8})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{12})$/.exec(trimmed);
+  if (!match) return '[redacted]';
+  return `${match[1]}-****-****-****-${match[5]!.slice(-6)}`;
+}
+
+/**
+ * Redacts the subscription segment of an ARM resource ID while preserving the parts an
+ * operator needs to identify the agent (resource group, provider, agent name).
+ */
+export function maskArmId(armId: string | undefined): string | undefined {
+  if (!armId) return undefined;
+  return armId.replace(/\/subscriptions\/([0-9a-fA-F-]{36})/i, (_full, sub: string) => `/subscriptions/${maskGuid(sub)}`);
+}
+
+/**
+ * Masks Azure subscription/tenant identifiers inside free text.
+ *
+ * The SRE Agent routinely quotes ARM resource IDs in its prose, so identity-field
+ * masking alone is not enough — the response body itself must be masked before it
+ * reaches the browser or an evidence bundle.
+ *
+ * `known` lets the caller mask the exact configured identifiers wherever they appear,
+ * which catches formats this function's patterns do not anticipate.
+ */
+export function maskIdentifiers(
+  text: string,
+  known: { subscriptionId?: string; tenantId?: string } = {},
+): string {
+  let output = text;
+
+  // ARM paths: /subscriptions/<guid>, /tenants/<guid>
+  output = output.replace(
+    /(\/(?:subscriptions|tenants)\/)([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/gi,
+    (_full, prefix: string, guid: string) => `${prefix}${maskGuid(guid)}`,
+  );
+
+  // Labelled identifiers: "subscription id: <guid>", "tenantId=<guid>"
+  output = output.replace(
+    /\b(subscription|tenant)(\s*id)?(\s*[:=]\s*|\s+)([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/gi,
+    (_full, label: string, idWord: string | undefined, sep: string, guid: string) =>
+      `${label}${idWord ?? ''}${sep}${maskGuid(guid)}`,
+  );
+
+  // Exact configured identifiers, wherever they appear.
+  for (const value of [known.subscriptionId, known.tenantId]) {
+    if (!value || !GUID_TEXT_PATTERN.test(value)) continue;
+    output = output.split(value).join(maskGuid(value) ?? '[redacted]');
+  }
+
+  return output;
+}
+
+const GUID_TEXT_PATTERN = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/** Recursively redacts a structure for audit logging, dropping deep or oversized branches. */
+export function redactForAudit(value: unknown, depth = 0): unknown {
+  if (depth > 4) return '[truncated-depth]';
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === 'string') {
+    const redacted = redactSensitiveText(value);
+    return redacted.length > 512 ? `${redacted.slice(0, 512)}…[truncated]` : redacted;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map((entry) => redactForAudit(entry, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>).slice(0, 40)) {
+      if (/token|secret|password|credential|authorization|apikey|api_key|connectionstring/i.test(key)) {
+        output[key] = '[REDACTED]';
+        continue;
+      }
+      // Mission Control streams backend logs to an on-screen terminal during demos, so
+      // subscription/tenant identifiers are masked in audit records too.
+      if (/^(subscription|subscriptionid|tenant|tenantid)$/i.test(key) && typeof entry === 'string') {
+        output[key] = maskGuid(entry) ?? '[redacted]';
+        continue;
+      }
+      output[key] = redactForAudit(entry, depth + 1);
+    }
+    return output;
+  }
+
+  return '[unsupported]';
+}

--- a/mission-control/backend/src/services/sre-agent/redaction.ts
+++ b/mission-control/backend/src/services/sre-agent/redaction.ts
@@ -157,3 +157,141 @@ export function redactForAudit(value: unknown, depth = 0): unknown {
 
   return '[unsupported]';
 }
+
+// ---------------------------------------------------------------------------
+// Streaming redaction for child-process stderr
+// ---------------------------------------------------------------------------
+
+const PRIVATE_KEY_BEGIN = /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/;
+const PRIVATE_KEY_END = /-----END [A-Z0-9 ]*PRIVATE KEY-----/;
+
+/**
+ * Longest secret start-marker we must never split across a commit boundary.
+ * `-----BEGIN OPENSSH PRIVATE KEY-----` is 35 characters; 96 gives ample headroom.
+ */
+const MARKER_GUARD = 96;
+
+/**
+ * Bounded, redaction-safe accumulator for a child process's stderr.
+ *
+ * A naive `raw = (raw + chunk).slice(-N)` rolling buffer is unsafe: for a secret
+ * longer than N (a PEM private key is typically 1.7–3.2 KB) the `-----BEGIN …-----`
+ * marker is evicted while key body survives. A later single `redactSensitiveText`
+ * pass then has no marker to match, so raw key material can reach an error message
+ * and the UI.
+ *
+ * This buffer removes that class of bug by construction:
+ *
+ *  1. **Redact before bounding.** `tail` only ever holds already-redacted text, so
+ *     evicting from it can never expose a secret — the secret is already a
+ *     placeholder.
+ *  2. **Never split a marker.** Only whole lines are committed (secret markers and
+ *     single-line secrets contain no newline). A pathological newline-free run is
+ *     force-committed only up to a `MARKER_GUARD` raw window that is retained, so a
+ *     marker straddling that boundary is still seen intact on the next chunk.
+ *  3. **Carry state across segments.** An unterminated `BEGIN … PRIVATE KEY` sets a
+ *     sticky "inside secret" flag, so continuation lines are dropped even after the
+ *     marker itself has been committed and evicted — the case regex-per-pass misses.
+ */
+export class RedactedStreamBuffer {
+  /** Always-redacted, bounded output. */
+  private tail = '';
+  /** Raw bytes not yet safe to commit (incomplete line / marker guard). */
+  private carry = '';
+  /** True while inside a private-key block whose END marker has not been seen. */
+  private insideSecret = false;
+
+  constructor(
+    private readonly maxChars = 2_000,
+    private readonly maxCarry = 4_096,
+  ) {}
+
+  append(chunk: string): void {
+    const combined = this.carry + chunk;
+    const lastNewline = combined.lastIndexOf('\n');
+
+    let rest: string;
+    if (lastNewline >= 0) {
+      this.commit(combined.slice(0, lastNewline + 1));
+      rest = combined.slice(lastNewline + 1);
+    } else {
+      rest = combined;
+    }
+
+    // A very long newline-free run still has to be bounded. Retain a marker-sized raw
+    // window so a start marker cannot be split across this forced commit.
+    if (rest.length > this.maxCarry) {
+      this.commit(rest.slice(0, rest.length - MARKER_GUARD));
+      rest = rest.slice(rest.length - MARKER_GUARD);
+    }
+
+    this.carry = rest;
+  }
+
+  /** Redacted, bounded view including the uncommitted carry. Does not mutate state. */
+  snapshot(): string {
+    const { text } = redactSegment(this.carry, this.insideSecret);
+    return `${this.tail}${text}`.slice(-this.maxChars).trim();
+  }
+
+  reset(): void {
+    this.tail = '';
+    this.carry = '';
+    this.insideSecret = false;
+  }
+
+  private commit(segment: string): void {
+    if (!segment) return;
+    const { text, insideSecret } = redactSegment(segment, this.insideSecret);
+    this.insideSecret = insideSecret;
+    // `tail` is already redacted, so bounding it here cannot reveal a secret.
+    this.tail = `${this.tail}${text}`.slice(-this.maxChars);
+  }
+}
+
+/**
+ * Redacts one segment, honouring and returning the sticky private-key state.
+ * Exported for direct testing of the state machine.
+ */
+export function redactSegment(
+  segment: string,
+  insideSecret: boolean,
+): { text: string; insideSecret: boolean } {
+  if (!segment) return { text: '', insideSecret };
+
+  let working = segment;
+  let state = insideSecret;
+
+  if (state) {
+    const end = PRIVATE_KEY_END.exec(working);
+    // Still inside the key: drop the whole segment rather than emit body material.
+    if (!end) return { text: '', insideSecret: true };
+    working = working.slice(end.index + end[0].length);
+    state = false;
+  }
+
+  // If the LAST begin marker has no matching end, suppress from there and stay sticky.
+  const lastBegin = lastIndexOfPattern(working, PRIVATE_KEY_BEGIN);
+  if (lastBegin >= 0) {
+    const afterBegin = working.slice(lastBegin);
+    const beginMatch = PRIVATE_KEY_BEGIN.exec(afterBegin);
+    const afterMarker = beginMatch ? afterBegin.slice(beginMatch[0].length) : afterBegin;
+    if (!PRIVATE_KEY_END.test(afterMarker)) {
+      working = `${working.slice(0, lastBegin)}[REDACTED-PRIVATE-KEY]`;
+      state = true;
+    }
+  }
+
+  return { text: redactSensitiveText(working), insideSecret: state };
+}
+
+function lastIndexOfPattern(value: string, pattern: RegExp): number {
+  const global = new RegExp(pattern.source, `${pattern.flags.replace('g', '')}g`);
+  let index = -1;
+  let match: RegExpExecArray | null;
+  while ((match = global.exec(value)) !== null) {
+    index = match.index;
+    if (match.index === global.lastIndex) global.lastIndex += 1;
+  }
+  return index;
+}

--- a/mission-control/backend/src/services/sre-agent/responseParser.ts
+++ b/mission-control/backend/src/services/sre-agent/responseParser.ts
@@ -1,0 +1,335 @@
+/**
+ * Tolerant parser for Azure MCP Server `sreagent_*` tool responses.
+ *
+ * The Azure MCP Server documents the *operations* and their inputs, but not a stable
+ * JSON schema for `threads_*` responses. This parser therefore probes a set of common
+ * key spellings and falls back to plain text, while holding two hard rules:
+ *
+ *   1. Never invent a thread ID or agent identity. If provenance cannot be established
+ *      from the payload, the caller must not claim the answer came from SRE Agent.
+ *   2. Never invent citations. Absent citations are reported as absent.
+ *
+ * Because the shape is inferred rather than contractual, `schemaConfidence` records how
+ * the values were obtained so the UI and docs can stay honest about it.
+ */
+
+export type SreAgentSchemaConfidence = 'structured' | 'inferred' | 'text-only';
+
+export interface ParsedAgentSummary {
+  readonly name?: string;
+  readonly armId?: string;
+  readonly resourceGroup?: string;
+  readonly subscriptionId?: string;
+  readonly location?: string;
+  readonly provisioningState?: string;
+  readonly endpointHost?: string;
+}
+
+export interface ParsedCitation {
+  readonly label: string;
+  readonly url?: string;
+  readonly source?: string;
+}
+
+export interface ParsedThreadResponse {
+  readonly threadId?: string;
+  readonly messageText: string;
+  readonly citations: ParsedCitation[];
+  readonly approvalRequired: boolean;
+  readonly approvalDetail?: string;
+  readonly statusHint?: string;
+  readonly schemaConfidence: SreAgentSchemaConfidence;
+  readonly raw?: unknown;
+}
+
+const THREAD_ID_KEYS = ['threadId', 'thread_id', 'threadID', 'ThreadId', 'thread'];
+const MESSAGE_KEYS = ['response', 'message', 'content', 'text', 'answer', 'result', 'output', 'summary'];
+const CITATION_KEYS = ['citations', 'references', 'sources', 'links'];
+
+/** GUID or opaque thread token; deliberately strict so prose cannot masquerade as an ID. */
+const THREAD_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/;
+
+/**
+ * Phrases indicating the agent paused at an approval gate. Standard investigation mode
+ * pauses rather than acting, and Mission Control must surface that state prominently.
+ */
+const APPROVAL_PATTERNS: readonly RegExp[] = Object.freeze([
+  /awaiting\s+(your\s+)?approval/i,
+  /approval\s+(is\s+)?required/i,
+  /requires?\s+(your\s+)?approval/i,
+  /pending\s+approval/i,
+  /approval\s+gate/i,
+  /waiting\s+for\s+(human\s+)?(confirmation|approval)/i,
+  /needs?\s+human\s+(confirmation|approval)/i,
+  /please\s+(approve|confirm)\s+/i,
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Parses JSON when the payload is JSON; otherwise returns undefined (text-only response). */
+export function tryParseJson(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Azure MCP Server wraps payloads in envelopes such as `{ status, results, duration }`. */
+function unwrapEnvelope(value: unknown): unknown {
+  let current = value;
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (!isRecord(current)) return current;
+    const next = current['results'] ?? current['result'] ?? current['value'] ?? current['data'];
+    if (next === undefined || next === null) return current;
+    current = next;
+  }
+  return current;
+}
+
+function firstString(source: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+/** Depth-first search for a plausible thread identifier. */
+function findThreadId(value: unknown, depth = 0): string | undefined {
+  if (depth > 5) return undefined;
+
+  if (isRecord(value)) {
+    for (const key of THREAD_ID_KEYS) {
+      const candidate = value[key];
+      if (typeof candidate === 'string' && THREAD_ID_PATTERN.test(candidate.trim())) {
+        return candidate.trim();
+      }
+      // `thread: { id }` shape
+      if (isRecord(candidate) && typeof candidate['id'] === 'string' && THREAD_ID_PATTERN.test(candidate['id'].trim())) {
+        return candidate['id'].trim();
+      }
+    }
+
+    // A bare `id` only counts when the object is clearly thread-shaped, so an agent or
+    // message ID is never mistaken for a thread ID.
+    const bareId = value['id'];
+    if (
+      typeof bareId === 'string' &&
+      THREAD_ID_PATTERN.test(bareId.trim()) &&
+      Object.keys(value).some((key) => /thread|conversation|messages/i.test(key))
+    ) {
+      return bareId.trim();
+    }
+
+    for (const entry of Object.values(value)) {
+      const found = findThreadId(entry, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value.slice(0, 25)) {
+      const found = findThreadId(entry, depth + 1);
+      if (found) return found;
+    }
+  }
+
+  return undefined;
+}
+
+function extractMessageText(payload: unknown, fallback: string): string {
+  if (typeof payload === 'string' && payload.trim()) return payload.trim();
+
+  if (isRecord(payload)) {
+    const direct = firstString(payload, MESSAGE_KEYS);
+    if (direct) return direct;
+
+    // Conversation shape: prefer the newest assistant/agent turn.
+    const messages = payload['messages'];
+    if (Array.isArray(messages) && messages.length > 0) {
+      const agentTurns = messages.filter((entry) => {
+        if (!isRecord(entry)) return false;
+        const role = String(entry['role'] ?? entry['sender'] ?? entry['author'] ?? '').toLowerCase();
+        return role === 'assistant' || role === 'agent' || role === 'system';
+      });
+      const chosen = (agentTurns.length > 0 ? agentTurns : messages).at(-1);
+      if (isRecord(chosen)) {
+        const text = firstString(chosen, [...MESSAGE_KEYS, 'body']);
+        if (text) return text;
+      }
+    }
+  }
+
+  if (Array.isArray(payload) && payload.length > 0) {
+    const last = payload.at(-1);
+    if (isRecord(last)) {
+      const text = firstString(last, MESSAGE_KEYS);
+      if (text) return text;
+    }
+  }
+
+  return fallback.trim();
+}
+
+/**
+ * Extracts citations only when the payload actually contains them.
+ * Returns an empty array otherwise — the UI renders "no citations returned".
+ */
+function extractCitations(payload: unknown, depth = 0): ParsedCitation[] {
+  if (depth > 4 || !isRecord(payload)) return [];
+
+  for (const key of CITATION_KEYS) {
+    const value = payload[key];
+    if (!Array.isArray(value)) continue;
+
+    const citations = value
+      .map((entry): ParsedCitation | undefined => {
+        if (typeof entry === 'string' && entry.trim()) {
+          const trimmed = entry.trim();
+          return /^https?:\/\//i.test(trimmed) ? { label: trimmed, url: trimmed } : { label: trimmed };
+        }
+        if (!isRecord(entry)) return undefined;
+
+        const label = firstString(entry, ['label', 'title', 'name', 'displayName', 'text', 'description']);
+        const url = firstString(entry, ['url', 'uri', 'link', 'href', 'portalUrl']);
+        const source = firstString(entry, ['source', 'type', 'kind', 'provider', 'resourceType']);
+        if (!label && !url) return undefined;
+
+        return {
+          label: label ?? url ?? 'Reference',
+          ...(url && /^https?:\/\//i.test(url) ? { url } : {}),
+          ...(source ? { source } : {}),
+        };
+      })
+      .filter((entry): entry is ParsedCitation => entry !== undefined);
+
+    if (citations.length > 0) return citations.slice(0, 25);
+  }
+
+  for (const entry of Object.values(payload)) {
+    const nested = extractCitations(entry, depth + 1);
+    if (nested.length > 0) return nested;
+  }
+
+  return [];
+}
+
+function detectApproval(payload: unknown, text: string): { required: boolean; detail?: string } {
+  if (isRecord(payload)) {
+    for (const key of ['approvalRequired', 'requiresApproval', 'awaitingApproval', 'pendingApproval', 'needsApproval']) {
+      if (payload[key] === true) {
+        const detail = firstString(payload, ['approvalMessage', 'approvalDetail', 'approvalPrompt', 'pendingAction']);
+        return { required: true, ...(detail ? { detail } : {}) };
+      }
+    }
+
+    const status = firstString(payload, ['status', 'state', 'threadStatus']);
+    if (status && /approval|awaiting|paused|blocked/i.test(status)) {
+      return { required: true, detail: `Agent reported status '${status}'.` };
+    }
+
+    const pending = payload['pendingApprovals'] ?? payload['approvals'];
+    if (Array.isArray(pending) && pending.length > 0) {
+      return { required: true, detail: `${pending.length} pending approval request(s) reported by the agent.` };
+    }
+  }
+
+  for (const pattern of APPROVAL_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match) {
+      const start = Math.max(0, match.index - 120);
+      return { required: true, detail: text.slice(start, match.index + 200).trim() };
+    }
+  }
+
+  return { required: false };
+}
+
+export function parseThreadResponse(rawText: string, structuredContent?: unknown): ParsedThreadResponse {
+  const parsedJson = structuredContent ?? tryParseJson(rawText);
+  const payload = unwrapEnvelope(parsedJson);
+  const hasStructure = payload !== undefined && (isRecord(payload) || Array.isArray(payload));
+
+  const threadId = hasStructure ? findThreadId(payload) : undefined;
+  const messageText = extractMessageText(payload, rawText);
+  const citations = hasStructure ? extractCitations(isRecord(payload) ? payload : { payload }) : [];
+  const approval = detectApproval(payload, messageText || rawText);
+  const statusHint = isRecord(payload) ? firstString(payload, ['status', 'state', 'threadStatus']) : undefined;
+
+  const schemaConfidence: SreAgentSchemaConfidence = !hasStructure
+    ? 'text-only'
+    : threadId
+      ? 'structured'
+      : 'inferred';
+
+  return {
+    ...(threadId ? { threadId } : {}),
+    messageText: messageText || rawText.trim(),
+    citations,
+    approvalRequired: approval.required,
+    ...(approval.detail ? { approvalDetail: approval.detail } : {}),
+    ...(statusHint ? { statusHint } : {}),
+    schemaConfidence,
+    raw: parsedJson,
+  };
+}
+
+/** Normalises one agent record from `sreagent_agents_list` / `sreagent_agents_get`. */
+export function parseAgentSummary(value: unknown): ParsedAgentSummary | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const name = firstString(value, ['name', 'agentName', 'agent']);
+  const armId = firstString(value, ['id', 'armId', 'resourceId']);
+  if (!name && !armId) return undefined;
+
+  const endpoint = firstString(value, ['endpoint', 'agentEndpoint', 'dataPlaneEndpoint', 'endpointUrl']);
+  let endpointHost: string | undefined;
+  if (endpoint) {
+    try {
+      endpointHost = new URL(endpoint.startsWith('http') ? endpoint : `https://${endpoint}`).host;
+    } catch {
+      endpointHost = undefined;
+    }
+  }
+
+  const subscriptionFromArm = armId ? /\/subscriptions\/([0-9a-fA-F-]{36})/i.exec(armId)?.[1] : undefined;
+  const resourceGroupFromArm = armId ? /\/resourceGroups\/([^/]+)/i.exec(armId)?.[1] : undefined;
+
+  const resourceGroup = firstString(value, ['resourceGroup', 'resourceGroupName']) ?? resourceGroupFromArm;
+  const subscriptionId = firstString(value, ['subscriptionId', 'subscription']) ?? subscriptionFromArm;
+  const location = firstString(value, ['location', 'region']);
+  const provisioningState = firstString(value, ['provisioningState', 'state', 'status']);
+
+  return {
+    ...(name ? { name } : {}),
+    ...(armId ? { armId } : {}),
+    ...(resourceGroup ? { resourceGroup } : {}),
+    ...(subscriptionId ? { subscriptionId } : {}),
+    ...(location ? { location } : {}),
+    ...(provisioningState ? { provisioningState } : {}),
+    ...(endpointHost ? { endpointHost } : {}),
+  };
+}
+
+/** Extracts every agent record from a list-shaped response. */
+export function parseAgentList(rawText: string, structuredContent?: unknown): ParsedAgentSummary[] {
+  const payload = unwrapEnvelope(structuredContent ?? tryParseJson(rawText));
+
+  const candidates: unknown[] = Array.isArray(payload)
+    ? payload
+    : isRecord(payload)
+      ? (['agents', 'items', 'value', 'resources'] as const)
+          .map((key) => payload[key])
+          .find((entry): entry is unknown[] => Array.isArray(entry)) ?? [payload]
+      : [];
+
+  return candidates
+    .map((entry) => parseAgentSummary(entry))
+    .filter((entry): entry is ParsedAgentSummary => entry !== undefined);
+}

--- a/mission-control/backend/src/types/index.ts
+++ b/mission-control/backend/src/types/index.ts
@@ -719,3 +719,201 @@ export interface InterruptRehearsalRunRequest {
 export interface ResumeRehearsalRunRequest {
   scenarioName: RehearsalScenarioName;
 }
+
+// ---------------------------------------------------------------------------
+// Azure SRE Agent MCP integration (issue #77)
+//
+// These contracts describe REAL Azure SRE Agent output obtained through the
+// supported Azure MCP Server `sreagent_*` tools. They are deliberately distinct
+// from the Assistant* (Local Analyst) contracts: Local Analyst output must never
+// be presented through these types, and `provenance` is always 'azure-sre-agent'.
+// ---------------------------------------------------------------------------
+
+/** Discriminator proving which system produced a response. */
+export type SreAgentProvenance = 'azure-sre-agent';
+
+export type SreAgentInvestigationStatus =
+  | 'completed'
+  | 'awaiting-approval'
+  | 'running'
+  | 'cancelled'
+  | 'timeout'
+  | 'failed';
+
+export type SreAgentFailureKind =
+  | 'not-configured'
+  | 'auth'
+  | 'permission'
+  | 'not-found'
+  | 'network'
+  | 'timeout'
+  | 'cancelled'
+  | 'runtime-missing'
+  | 'protocol'
+  | 'denied'
+  | 'unknown';
+
+export type SreAgentPreflightStatus = 'pass' | 'warn' | 'fail' | 'skipped';
+
+export interface SreAgentPreflightCheck {
+  name: string;
+  status: SreAgentPreflightStatus;
+  message: string;
+  /** Operator-actionable next step when the check is not passing. */
+  remediation?: string;
+}
+
+export interface SreAgentPreflightResult {
+  ready: boolean;
+  configured: boolean;
+  enabled: boolean;
+  checks: SreAgentPreflightCheck[];
+  /** Masked identifiers safe for screen-sharing and evidence packs. */
+  target: SreAgentTargetSummary;
+  collectedAt: string;
+  /** Portal handoff used whenever the MCP path is unavailable. */
+  portalHandoff: SreAgentPortalHandoff;
+}
+
+export interface SreAgentTargetSummary {
+  agentName?: string;
+  /** Subscription GUID, masked for display. */
+  subscriptionIdMasked?: string;
+  resourceGroup?: string;
+  tenantIdMasked?: string;
+  /** npm spec of the Azure MCP Server used, for supportability. */
+  serverPackage: string;
+  /** Exact set of MCP tools Mission Control may call. */
+  allowedTools: string[];
+  /** Tools that are permanently blocked, including auto-approval modes. */
+  blockedTools: string[];
+}
+
+export interface SreAgentPortalHandoff {
+  label: string;
+  href: string;
+  description: string;
+  /** Prompt the operator should paste when running the investigation manually. */
+  prompt?: string;
+}
+
+export interface SreAgentIdentity {
+  name: string;
+  /** ARM resource ID with the subscription segment masked. */
+  armIdMasked?: string;
+  resourceGroup?: string;
+  subscriptionIdMasked?: string;
+  location?: string;
+  provisioningState?: string;
+  /** Data-plane host only (never a full URL with query material). */
+  endpointHost?: string;
+}
+
+export interface SreAgentThreadIdentity {
+  id: string;
+  createdAt: string;
+  /** Portal link for the agent; thread-level deep links are not documented. */
+  portalUrl?: string;
+}
+
+export interface SreAgentCitation {
+  label: string;
+  url?: string;
+  source?: string;
+}
+
+export interface SreAgentApprovalState {
+  required: boolean;
+  detail?: string;
+  /**
+   * Always false. Mission Control never auto-approves; standard investigation mode
+   * pauses at approval gates and the operator resolves them in the SRE Agent portal.
+   */
+  autoApproved: false;
+}
+
+export interface SreAgentResponseMetadata {
+  /** Which allowlisted operation produced this response. */
+  operation: string;
+  /** Exact Azure MCP Server tool invoked. */
+  tool: string;
+  startedAt: string;
+  completedAt: string;
+  elapsedMs: number;
+  truncated: boolean;
+  /** How confidently the response shape was interpreted; schema is not contractual. */
+  schemaConfidence: 'structured' | 'inferred' | 'text-only';
+  serverPackage: string;
+  /** Correlates Mission Control audit records with SRE Agent audit events. */
+  correlationId: string;
+  limitations: string[];
+}
+
+export interface SreAgentInvestigation {
+  provenance: SreAgentProvenance;
+  status: SreAgentInvestigationStatus;
+  agent: SreAgentIdentity;
+  thread: SreAgentThreadIdentity;
+  response: string;
+  citations: SreAgentCitation[];
+  /** False means the agent returned none; Mission Control never invents citations. */
+  citationsPresent: boolean;
+  approval: SreAgentApprovalState;
+  metadata: SreAgentResponseMetadata;
+}
+
+export interface SreAgentErrorResponse {
+  error: string;
+  kind: SreAgentFailureKind;
+  remediation: string;
+  /** Always false: a failed MCP call is never presented as a successful investigation. */
+  investigationStarted: boolean;
+  /** Explicitly records that Local Analyst was not substituted. */
+  localAnalystSubstituted: false;
+  portalHandoff: SreAgentPortalHandoff;
+  correlationId: string;
+  timestamp: string;
+}
+
+export interface SreAgentDiscoveryResponse {
+  configured: boolean;
+  agents: SreAgentIdentity[];
+  selected?: SreAgentIdentity;
+  target: SreAgentTargetSummary;
+  collectedAt: string;
+}
+
+export interface StartSreAgentInvestigationRequest {
+  /** Approved scenario supplying the starter prompt, when starting from a scenario. */
+  scenarioName?: PortalValidationScenarioName;
+  /** Explicit operator prompt; required when no scenario is supplied. */
+  prompt?: string;
+  /** Optional client-supplied correlation id for audit stitching. */
+  correlationId?: string;
+}
+
+export interface ContinueSreAgentInvestigationRequest {
+  threadId: string;
+  prompt: string;
+  correlationId?: string;
+}
+
+export interface SreAgentThreadStatusRequest {
+  threadId: string;
+}
+
+export interface SreAgentScenarioPrompt {
+  scenarioName: PortalValidationScenarioName;
+  title: string;
+  prompt: string;
+}
+
+export interface SreAgentActiveThreadRecord {
+  threadId: string;
+  agentName: string;
+  scenarioName?: PortalValidationScenarioName;
+  startedAt: string;
+  updatedAt: string;
+  lastStatus: SreAgentInvestigationStatus;
+  correlationId: string;
+}

--- a/mission-control/frontend/src/components/AssistantPanel.vue
+++ b/mission-control/frontend/src/components/AssistantPanel.vue
@@ -2,14 +2,18 @@
   <section id="assistant" class="mission-panel">
     <div class="panel-heading">
       <div class="panel-heading__copy">
-        <span class="panel-eyebrow">Local analyst</span>
+        <span class="panel-eyebrow">
+          <span class="analyst-mark" aria-hidden="true">L</span>
+          Local analyst · not Azure SRE Agent
+        </span>
         <h2 class="panel-title">Explain This State</h2>
         <p class="panel-description">
           Ask the local analyst to explain a point-in-time Mission Control snapshot. It can triage and recommend safe next actions, but it does not deploy or repair.
+          It is <strong>not</strong> Azure SRE Agent — for a real cloud investigation use the Azure SRE Agent panel.
         </p>
       </div>
       <div class="panel-actions">
-        <span class="badge badge-info">Read-only</span>
+        <span class="badge badge-info">Local · read-only</span>
         <span class="badge" :class="answer ? 'badge-online' : 'badge-neutral'">
           {{ answer ? 'Answer ready' : 'Local only' }}
         </span>
@@ -328,3 +332,26 @@ async function ask() {
   }
 }
 </script>
+
+<style scoped>
+/* Cyan "L" mark pairs with the violet "A" mark on the Azure SRE Agent panel so the
+   two surfaces are distinguishable at a glance during a demo. */
+.panel-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.analyst-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 0.25rem;
+  background: rgb(34 211 238 / 0.85);
+  color: #0b1020;
+  font-weight: 700;
+  font-size: 0.7rem;
+}
+</style>

--- a/mission-control/frontend/src/components/MissionWallboard.vue
+++ b/mission-control/frontend/src/components/MissionWallboard.vue
@@ -172,6 +172,7 @@
       <Terminal :lines="jobLines" :title="jobStreamTitle" :tone="jobStreamKind === 'destroy' ? 'danger' : 'default'" />
     </div>
 
+    <SreAgentPanel v-if="controlPanelOpen" />
     <PortalValidation v-if="controlPanelOpen" />
     <RehearsalWorkflow v-if="controlPanelOpen" />
     
@@ -522,6 +523,7 @@ import { useApi } from '@/composables/useApi';
 import { useWebSocket } from '@/composables/useWebSocket';
 import PortalValidation from './PortalValidation.vue';
 import RehearsalWorkflow from './RehearsalWorkflow.vue';
+import SreAgentPanel from './SreAgentPanel.vue';
 import ScenarioNarrationPanel from './ScenarioNarrationPanel.vue';
 import Terminal from './Terminal.vue';
 import type {

--- a/mission-control/frontend/src/components/SreAgentPanel.vue
+++ b/mission-control/frontend/src/components/SreAgentPanel.vue
@@ -1,0 +1,534 @@
+<template>
+  <!--
+    Azure SRE Agent panel.
+
+    Deliberately distinct from the Local Analyst panel (AssistantPanel.vue):
+    different eyebrow, title, accent colour, icon and copy, so an audience can never
+    confuse a real Azure SRE Agent response with the local read-only explainer.
+    This panel only ever renders output that carries a real agent resource and thread ID.
+  -->
+  <section id="sre-agent" class="mission-panel sre-agent-panel">
+    <div class="panel-heading">
+      <div class="panel-heading__copy">
+        <span class="panel-eyebrow sre-agent-eyebrow">
+          <span class="sre-agent-mark" aria-hidden="true">A</span>
+          Azure SRE Agent · cloud agent
+        </span>
+        <h2 class="panel-title">Investigate with Azure SRE Agent</h2>
+        <p class="panel-description">
+          Runs a <strong>real</strong> Azure SRE Agent investigation over the supported Azure MCP Server path, using your
+          host Azure sign-in. This is not the Local Analyst: responses below come from the Azure SRE Agent resource named
+          in the identity strip, and every answer carries a live thread ID.
+        </p>
+      </div>
+      <div class="panel-actions">
+        <span class="badge sre-agent-badge">Real agent</span>
+        <span class="badge" :class="statusBadgeClass">{{ statusLabel }}</span>
+      </div>
+    </div>
+
+    <!-- Not configured: fail honestly, never silently fall back. -->
+    <div v-if="config && !config.configured" class="wallboard-alert wallboard-alert--warning" role="status">
+      <strong>Azure SRE Agent is not configured.</strong>
+      <ul class="compact-list">
+        <li v-for="issue in config.configurationIssues" :key="issue">{{ issue }}</li>
+      </ul>
+      <a class="command-button command-button--neutral sre-agent-portal-link" :href="config.portalHandoff.href" target="_blank" rel="noreferrer noopener">
+        {{ config.portalHandoff.label }}
+      </a>
+    </div>
+
+    <div v-if="config?.configured" class="sre-agent-layout">
+      <!-- Identity strip: proves which agent and thread produced the answer. -->
+      <div class="card card--status sre-agent-identity" aria-label="Agent and thread identity">
+        <div class="field-label">Agent &amp; thread identity</div>
+        <dl class="sre-agent-identity__grid">
+          <div>
+            <dt>Agent</dt>
+            <dd>{{ investigation?.agent.name ?? config.target.agentName ?? 'Not resolved' }}</dd>
+          </div>
+          <div>
+            <dt>ARM resource</dt>
+            <dd class="sre-agent-mono">{{ investigation?.agent.armIdMasked ?? 'Resolved on first investigation' }}</dd>
+          </div>
+          <div>
+            <dt>Subscription</dt>
+            <dd class="sre-agent-mono">{{ investigation?.agent.subscriptionIdMasked ?? config.target.subscriptionIdMasked ?? '—' }}</dd>
+          </div>
+          <div>
+            <dt>Thread ID</dt>
+            <dd class="sre-agent-mono">{{ investigation?.thread.id ?? 'No thread yet' }}</dd>
+          </div>
+          <div>
+            <dt>Started</dt>
+            <dd>{{ investigation ? formatTime(investigation.metadata.startedAt) : '—' }}</dd>
+          </div>
+          <div>
+            <dt>Elapsed</dt>
+            <dd>{{ elapsedLabel }}</dd>
+          </div>
+        </dl>
+        <p class="sre-agent-note">
+          Subscription and tenant identifiers are masked here and in the response text below.
+          Auto-approval tools (<code>investigate_yolo</code>) are blocked in code and absent from the MCP server surface.
+        </p>
+      </div>
+
+      <!-- Scenario starters + follow-up -->
+      <div class="card card--control sre-agent-card">
+        <div class="field-label">Approved scenario starters</div>
+        <div class="sre-agent-prompts">
+          <button
+            v-for="scenario in config.scenarioPrompts"
+            :key="scenario.scenarioName"
+            class="command-button command-button--neutral sre-agent-prompt"
+            type="button"
+            :disabled="busy"
+            :title="scenario.prompt"
+            @click="startFromScenario(scenario.scenarioName)"
+          >
+            {{ scenario.scenarioName }}
+          </button>
+        </div>
+
+        <label class="field-label" for="sre-agent-prompt">
+          {{ investigation ? 'Follow-up in this thread' : 'Or write an investigation prompt' }}
+        </label>
+        <textarea
+          id="sre-agent-prompt"
+          v-model="prompt"
+          class="field-control sre-agent-input"
+          maxlength="4000"
+          rows="3"
+          :disabled="busy"
+          :placeholder="investigation ? 'Ask a follow-up; it continues the same thread…' : 'Describe the incident to investigate…'"
+          @keydown.meta.enter.prevent="submitPrompt"
+          @keydown.ctrl.enter.prevent="submitPrompt"
+        ></textarea>
+
+        <div class="sre-agent-footer">
+          <span>{{ prompt.length }}/4000</span>
+          <div class="sre-agent-actions">
+            <button
+              v-if="busy"
+              class="command-button command-button--warning px-4 py-2 text-xs"
+              type="button"
+              @click="cancel"
+            >
+              Stop
+            </button>
+            <button
+              class="command-button sre-agent-run px-4 py-2 text-xs"
+              type="button"
+              :disabled="busy || prompt.trim().length === 0"
+              :style="{ opacity: busy || prompt.trim().length === 0 ? 0.5 : 1 }"
+              @click="submitPrompt"
+            >
+              {{ busy ? 'Investigating…' : investigation ? 'Send follow-up' : 'Investigate with SRE Agent' }}
+            </button>
+          </div>
+        </div>
+        <p v-if="busy" class="sre-agent-note" role="status">
+          Standard mode: the agent pauses at approval gates and Mission Control never auto-approves.
+        </p>
+      </div>
+
+      <!-- Honest failure + portal handoff. Never a Local Analyst answer. -->
+      <div v-if="failure" class="card card--status sre-agent-failure" role="alert">
+        <div class="field-label">Azure SRE Agent unavailable</div>
+        <p class="sre-agent-failure__message">{{ failure.error }}</p>
+        <p class="sre-agent-failure__remediation">{{ failure.remediation }}</p>
+        <p class="sre-agent-note">
+          Mission Control did not substitute Local Analyst output for this request. No SRE Agent result is shown above.
+        </p>
+        <a
+          class="command-button command-button--neutral sre-agent-portal-link"
+          :href="failure.portalHandoff.href"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {{ failure.portalHandoff.label }}
+        </a>
+        <details v-if="failure.portalHandoff.prompt" class="sre-agent-details">
+          <summary>Prompt to run manually in the portal</summary>
+          <pre class="sre-agent-pre">{{ failure.portalHandoff.prompt }}</pre>
+        </details>
+      </div>
+
+      <!-- Approval gate -->
+      <div v-if="investigation?.approval.required" class="card card--status sre-agent-approval" role="status">
+        <div class="field-label">Approval gate — operator action required</div>
+        <p>{{ investigation.approval.detail ?? 'The agent paused and is waiting for human approval before continuing.' }}</p>
+        <p class="sre-agent-note">
+          Mission Control cannot approve this. Review and approve in the Azure SRE Agent portal.
+        </p>
+        <a class="command-button command-button--neutral sre-agent-portal-link" :href="portalUrl" target="_blank" rel="noreferrer noopener">
+          Approve in Azure SRE Agent portal
+        </a>
+      </div>
+
+      <!-- Response -->
+      <div v-if="investigation" class="card card--status sre-agent-response">
+        <div class="field-label">
+          Azure SRE Agent response
+          <span class="sre-agent-provenance">from agent {{ investigation.agent.name }} · thread {{ shortThread }}</span>
+        </div>
+        <pre class="sre-agent-pre">{{ investigation.response }}</pre>
+        <p v-if="investigation.metadata.truncated" class="sre-agent-note">
+          Response truncated by Mission Control output limits.
+        </p>
+
+        <div class="field-label">Citations</div>
+        <ul v-if="investigation.citationsPresent" class="compact-list">
+          <li v-for="(citation, index) in investigation.citations" :key="`${citation.label}-${index}`">
+            <a v-if="citation.url" :href="citation.url" target="_blank" rel="noreferrer noopener">{{ citation.label }}</a>
+            <span v-else>{{ citation.label }}</span>
+            <span v-if="citation.source" class="badge badge-info sre-agent-citation-source">{{ citation.source }}</span>
+          </li>
+        </ul>
+        <p v-else class="sre-agent-note">
+          The agent returned no citations for this response. Mission Control does not invent citations.
+          Citation links open the cited Azure resource and may contain a resource path.
+        </p>
+
+        <details class="sre-agent-details">
+          <summary>Provenance and limitations</summary>
+          <ul class="compact-list">
+            <li>Operation: <code>{{ investigation.metadata.operation }}</code> via <code>{{ investigation.metadata.tool }}</code></li>
+            <li>Azure MCP Server: <code>{{ investigation.metadata.serverPackage }}</code></li>
+            <li>Correlation ID: <code>{{ investigation.metadata.correlationId }}</code></li>
+            <li>Response shape confidence: {{ investigation.metadata.schemaConfidence }}</li>
+            <li v-for="limitation in investigation.metadata.limitations" :key="limitation">{{ limitation }}</li>
+          </ul>
+        </details>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { ApiError, useApi, type SreAgentConfigResponse } from '../composables/useApi';
+import type { SreAgentErrorResponse, SreAgentInvestigation } from '../types/api';
+
+const api = useApi();
+
+const config = ref<SreAgentConfigResponse | null>(null);
+const investigation = ref<SreAgentInvestigation | null>(null);
+const failure = ref<SreAgentErrorResponse | null>(null);
+const prompt = ref('');
+const busy = ref(false);
+const activeCorrelationId = ref<string | null>(null);
+const elapsedMs = ref(0);
+
+let elapsedTimer: ReturnType<typeof setInterval> | undefined;
+
+const portalUrl = computed(() => config.value?.portalHandoff.href ?? 'https://sre.azure.com');
+const shortThread = computed(() => {
+  const id = investigation.value?.thread.id ?? '';
+  return id.length > 16 ? `${id.slice(0, 16)}…` : id;
+});
+
+const statusLabel = computed(() => {
+  if (busy.value) return 'Investigating';
+  if (failure.value) return 'Unavailable';
+  if (!config.value?.configured) return 'Not configured';
+  if (investigation.value?.approval.required) return 'Awaiting approval';
+  if (investigation.value) return 'Thread active';
+  return 'Ready';
+});
+
+const statusBadgeClass = computed(() => {
+  if (busy.value) return 'badge-info';
+  if (failure.value || !config.value?.configured) return 'badge-offline';
+  if (investigation.value?.approval.required) return 'badge-warning';
+  if (investigation.value) return 'badge-online';
+  return 'badge-neutral';
+});
+
+const elapsedLabel = computed(() => {
+  if (busy.value) return `${Math.round(elapsedMs.value / 1000)}s (running)`;
+  if (!investigation.value) return '—';
+  return `${(investigation.value.metadata.elapsedMs / 1000).toFixed(1)}s`;
+});
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString();
+  } catch {
+    return iso;
+  }
+}
+
+function newCorrelationId(): string {
+  return `mc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Extracts the typed error body so the UI can show remediation + portal handoff. */
+function toFailure(error: unknown): SreAgentErrorResponse {
+  if (error instanceof ApiError && error.body && typeof error.body === 'object' && 'kind' in error.body) {
+    return error.body as SreAgentErrorResponse;
+  }
+
+  return {
+    error: error instanceof Error ? error.message : String(error),
+    kind: 'unknown',
+    remediation: 'Verify Azure sign-in, RBAC, and network access, then retry.',
+    investigationStarted: false,
+    localAnalystSubstituted: false,
+    portalHandoff: config.value?.portalHandoff ?? {
+      label: 'Open Azure SRE Agent portal',
+      href: 'https://sre.azure.com',
+      description: 'Run the investigation in the Azure SRE Agent portal.',
+    },
+    correlationId: 'unknown',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function startElapsedTimer() {
+  const startedAt = Date.now();
+  elapsedMs.value = 0;
+  elapsedTimer = setInterval(() => {
+    elapsedMs.value = Date.now() - startedAt;
+  }, 250);
+}
+
+function stopElapsedTimer() {
+  if (elapsedTimer) {
+    clearInterval(elapsedTimer);
+    elapsedTimer = undefined;
+  }
+}
+
+async function run(operation: () => Promise<SreAgentInvestigation>, correlationId: string) {
+  busy.value = true;
+  failure.value = null;
+  activeCorrelationId.value = correlationId;
+  startElapsedTimer();
+
+  try {
+    investigation.value = await operation();
+    prompt.value = '';
+  } catch (error) {
+    // Never replace a failed SRE Agent call with Local Analyst output.
+    failure.value = toFailure(error);
+  } finally {
+    busy.value = false;
+    activeCorrelationId.value = null;
+    stopElapsedTimer();
+  }
+}
+
+function startFromScenario(scenarioName: string) {
+  const correlationId = newCorrelationId();
+  void run(() => api.startSreAgentInvestigation({ scenarioName, correlationId }), correlationId);
+}
+
+function submitPrompt() {
+  const text = prompt.value.trim();
+  if (!text || busy.value) return;
+
+  const correlationId = newCorrelationId();
+  const threadId = investigation.value?.thread.id;
+
+  if (threadId) {
+    void run(() => api.continueSreAgentInvestigation({ threadId, prompt: text, correlationId }), correlationId);
+    return;
+  }
+
+  void run(() => api.startSreAgentInvestigation({ prompt: text, correlationId }), correlationId);
+}
+
+async function cancel() {
+  const correlationId = activeCorrelationId.value;
+  if (!correlationId) return;
+  try {
+    await api.cancelSreAgentInvestigation(correlationId);
+  } catch {
+    // Cancellation is best-effort; the request may have already finished.
+  }
+}
+
+onMounted(async () => {
+  try {
+    config.value = await api.getSreAgentConfig();
+  } catch (error) {
+    failure.value = toFailure(error);
+  }
+});
+
+onBeforeUnmount(stopElapsedTimer);
+</script>
+
+<style scoped>
+/* Violet accent — intentionally different from the Local Analyst panel, applied as a
+   subtle tint/hairline consistent with the wallboard's existing card styling. */
+.sre-agent-panel {
+  border-left: 1px solid rgb(139 92 246 / 0.34);
+}
+
+.sre-agent-eyebrow {
+  color: #a78bfa;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  letter-spacing: 0.08em;
+}
+
+.sre-agent-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 0.25rem;
+  background: #8b5cf6;
+  color: #0b1020;
+  font-weight: 700;
+  font-size: 0.7rem;
+}
+
+.sre-agent-badge {
+  background: rgba(139, 92, 246, 0.18);
+  color: #c4b5fd;
+  border: 1px solid rgba(139, 92, 246, 0.5);
+}
+
+.sre-agent-layout {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sre-agent-identity__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0.4rem 0;
+}
+
+.sre-agent-identity__grid dt {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.7;
+}
+
+.sre-agent-identity__grid dd {
+  margin: 0.1rem 0 0;
+  font-size: 0.82rem;
+  word-break: break-word;
+}
+
+.sre-agent-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem !important;
+}
+
+.sre-agent-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.sre-agent-prompt {
+  font-size: 0.72rem;
+  padding: 0.3rem 0.6rem;
+}
+
+.sre-agent-input {
+  width: 100%;
+  resize: vertical;
+}
+
+.sre-agent-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  font-size: 0.72rem;
+  opacity: 0.8;
+}
+
+.sre-agent-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.sre-agent-run {
+  background: #8b5cf6;
+  color: #0b1020;
+  font-weight: 600;
+}
+
+.sre-agent-note {
+  font-size: 0.72rem;
+  opacity: 0.75;
+  margin-top: 0.4rem;
+}
+
+.sre-agent-failure {
+  background: rgb(248 113 113 / 0.08);
+  border: 1px solid rgb(248 113 113 / 0.34);
+}
+
+.sre-agent-failure__message {
+  font-weight: 600;
+  margin: 0.3rem 0;
+}
+
+.sre-agent-failure__remediation {
+  font-size: 0.8rem;
+  margin: 0.2rem 0;
+}
+
+.sre-agent-approval {
+  background: rgb(251 191 36 / 0.08);
+  border: 1px solid rgb(251 191 36 / 0.38);
+}
+
+.sre-agent-response {
+  border: 1px solid rgb(139 92 246 / 0.28);
+}
+
+.sre-agent-provenance {
+  margin-left: 0.5rem;
+  font-size: 0.68rem;
+  opacity: 0.75;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.sre-agent-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  margin: 0.3rem 0 0.6rem;
+  max-height: 26rem;
+  overflow-y: auto;
+}
+
+.sre-agent-citation-source {
+  margin-left: 0.4rem;
+}
+
+.sre-agent-details {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.sre-agent-details summary {
+  cursor: pointer;
+  opacity: 0.85;
+}
+
+.sre-agent-portal-link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.72rem;
+  text-decoration: none;
+}
+</style>

--- a/mission-control/frontend/src/composables/useApi.ts
+++ b/mission-control/frontend/src/composables/useApi.ts
@@ -24,8 +24,37 @@ import type {
   Scenario,
   Service,
   ServiceEndpointsResponse,
+  SreAgentDiscoveryResponse,
+  SreAgentInvestigation,
+  SreAgentPortalHandoff,
+  SreAgentPreflightResult,
+  SreAgentScenarioPrompt,
+  SreAgentTargetSummary,
   UpdateRehearsalEvidenceRequest,
 } from '../types/api';
+
+/** Configuration snapshot for the Azure SRE Agent MCP path. */
+export interface SreAgentConfigResponse {
+  configured: boolean;
+  enabled: boolean;
+  configurationIssues: string[];
+  target: SreAgentTargetSummary;
+  portalHandoff: SreAgentPortalHandoff;
+  scenarioPrompts: SreAgentScenarioPrompt[];
+}
+
+/** Error that preserves the structured API error body (used for SRE Agent failures). */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(status: number, message: string, body: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
 
 export async function api<T>(path: string, options?: RequestInit): Promise<T> {
   const response = await fetch(path, {
@@ -36,13 +65,14 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
   if (!response.ok) {
     const body = await response.text();
     let message = body;
+    let parsedBody: unknown;
     try {
-      const parsed = JSON.parse(body) as { error?: string };
-      message = parsed.error ?? body;
+      parsedBody = JSON.parse(body) as { error?: string };
+      message = (parsedBody as { error?: string }).error ?? body;
     } catch {
       // Keep the raw response text for non-JSON API errors.
     }
-    throw new Error(`API ${response.status}: ${message}`);
+    throw new ApiError(response.status, `API ${response.status}: ${message}`, parsedBody);
   }
 
   return response.json() as Promise<T>;
@@ -92,6 +122,26 @@ export function useApi() {
       } satisfies AssistantAskRequest),
     }),
     deploy: (params: DeployParams) => api<Job>('/api/deploy', { method: 'POST', body: JSON.stringify(params) }),
+
+    // --- Azure SRE Agent (real agent via supported MCP path) ---------------
+    // These call the real Azure SRE Agent. They are deliberately separate from
+    // askAssistant (Local Analyst) and must never be used as a fallback for it.
+    getSreAgentConfig: () => api<SreAgentConfigResponse>('/api/sre-agent/config'),
+    getSreAgentPreflight: (skipMcpProbe = false) =>
+      api<SreAgentPreflightResult>(`/api/sre-agent/preflight${skipMcpProbe ? '?skipMcpProbe=true' : ''}`),
+    getSreAgents: () => api<SreAgentDiscoveryResponse>('/api/sre-agent/agents'),
+    startSreAgentInvestigation: (body: { scenarioName?: string; prompt?: string; correlationId?: string }) =>
+      api<SreAgentInvestigation>('/api/sre-agent/investigations', { method: 'POST', body: JSON.stringify(body) }),
+    continueSreAgentInvestigation: (body: { threadId: string; prompt: string; correlationId?: string }) =>
+      api<SreAgentInvestigation>('/api/sre-agent/investigations/continue', { method: 'POST', body: JSON.stringify(body) }),
+    getSreAgentThreadStatus: (threadId: string) =>
+      api<SreAgentInvestigation>(`/api/sre-agent/investigations/${encodeURIComponent(threadId)}`),
+    cancelSreAgentInvestigation: (correlationId: string) =>
+      api<{ cancelled: boolean; message: string; limitation: string }>('/api/sre-agent/investigations/cancel', {
+        method: 'POST',
+        body: JSON.stringify({ correlationId }),
+      }),
+
     destroy: (params: DestroyParams) => api<Job>('/api/destroy', { method: 'POST', body: JSON.stringify(params) }),
     enableScenario: (name: string) => api<{ ok: boolean }>(`/api/scenarios/${name}/enable`, { method: 'POST' }),
     disableScenario: (name: string) => api<{ ok: boolean }>(`/api/scenarios/${name}/disable`, { method: 'POST' }),

--- a/mission-control/frontend/src/types/api.ts
+++ b/mission-control/frontend/src/types/api.ts
@@ -606,3 +606,201 @@ export interface RehearsalState {
   runs: RehearsalRun[];
   updatedAt: string;
 }
+
+// ---------------------------------------------------------------------------
+// Azure SRE Agent MCP integration (issue #77)
+//
+// These contracts describe REAL Azure SRE Agent output obtained through the
+// supported Azure MCP Server `sreagent_*` tools. They are deliberately distinct
+// from the Assistant* (Local Analyst) contracts: Local Analyst output must never
+// be presented through these types, and `provenance` is always 'azure-sre-agent'.
+// ---------------------------------------------------------------------------
+
+/** Discriminator proving which system produced a response. */
+export type SreAgentProvenance = 'azure-sre-agent';
+
+export type SreAgentInvestigationStatus =
+  | 'completed'
+  | 'awaiting-approval'
+  | 'running'
+  | 'cancelled'
+  | 'timeout'
+  | 'failed';
+
+export type SreAgentFailureKind =
+  | 'not-configured'
+  | 'auth'
+  | 'permission'
+  | 'not-found'
+  | 'network'
+  | 'timeout'
+  | 'cancelled'
+  | 'runtime-missing'
+  | 'protocol'
+  | 'denied'
+  | 'unknown';
+
+export type SreAgentPreflightStatus = 'pass' | 'warn' | 'fail' | 'skipped';
+
+export interface SreAgentPreflightCheck {
+  name: string;
+  status: SreAgentPreflightStatus;
+  message: string;
+  /** Operator-actionable next step when the check is not passing. */
+  remediation?: string;
+}
+
+export interface SreAgentPreflightResult {
+  ready: boolean;
+  configured: boolean;
+  enabled: boolean;
+  checks: SreAgentPreflightCheck[];
+  /** Masked identifiers safe for screen-sharing and evidence packs. */
+  target: SreAgentTargetSummary;
+  collectedAt: string;
+  /** Portal handoff used whenever the MCP path is unavailable. */
+  portalHandoff: SreAgentPortalHandoff;
+}
+
+export interface SreAgentTargetSummary {
+  agentName?: string;
+  /** Subscription GUID, masked for display. */
+  subscriptionIdMasked?: string;
+  resourceGroup?: string;
+  tenantIdMasked?: string;
+  /** npm spec of the Azure MCP Server used, for supportability. */
+  serverPackage: string;
+  /** Exact set of MCP tools Mission Control may call. */
+  allowedTools: string[];
+  /** Tools that are permanently blocked, including auto-approval modes. */
+  blockedTools: string[];
+}
+
+export interface SreAgentPortalHandoff {
+  label: string;
+  href: string;
+  description: string;
+  /** Prompt the operator should paste when running the investigation manually. */
+  prompt?: string;
+}
+
+export interface SreAgentIdentity {
+  name: string;
+  /** ARM resource ID with the subscription segment masked. */
+  armIdMasked?: string;
+  resourceGroup?: string;
+  subscriptionIdMasked?: string;
+  location?: string;
+  provisioningState?: string;
+  /** Data-plane host only (never a full URL with query material). */
+  endpointHost?: string;
+}
+
+export interface SreAgentThreadIdentity {
+  id: string;
+  createdAt: string;
+  /** Portal link for the agent; thread-level deep links are not documented. */
+  portalUrl?: string;
+}
+
+export interface SreAgentCitation {
+  label: string;
+  url?: string;
+  source?: string;
+}
+
+export interface SreAgentApprovalState {
+  required: boolean;
+  detail?: string;
+  /**
+   * Always false. Mission Control never auto-approves; standard investigation mode
+   * pauses at approval gates and the operator resolves them in the SRE Agent portal.
+   */
+  autoApproved: false;
+}
+
+export interface SreAgentResponseMetadata {
+  /** Which allowlisted operation produced this response. */
+  operation: string;
+  /** Exact Azure MCP Server tool invoked. */
+  tool: string;
+  startedAt: string;
+  completedAt: string;
+  elapsedMs: number;
+  truncated: boolean;
+  /** How confidently the response shape was interpreted; schema is not contractual. */
+  schemaConfidence: 'structured' | 'inferred' | 'text-only';
+  serverPackage: string;
+  /** Correlates Mission Control audit records with SRE Agent audit events. */
+  correlationId: string;
+  limitations: string[];
+}
+
+export interface SreAgentInvestigation {
+  provenance: SreAgentProvenance;
+  status: SreAgentInvestigationStatus;
+  agent: SreAgentIdentity;
+  thread: SreAgentThreadIdentity;
+  response: string;
+  citations: SreAgentCitation[];
+  /** False means the agent returned none; Mission Control never invents citations. */
+  citationsPresent: boolean;
+  approval: SreAgentApprovalState;
+  metadata: SreAgentResponseMetadata;
+}
+
+export interface SreAgentErrorResponse {
+  error: string;
+  kind: SreAgentFailureKind;
+  remediation: string;
+  /** Always false: a failed MCP call is never presented as a successful investigation. */
+  investigationStarted: boolean;
+  /** Explicitly records that Local Analyst was not substituted. */
+  localAnalystSubstituted: false;
+  portalHandoff: SreAgentPortalHandoff;
+  correlationId: string;
+  timestamp: string;
+}
+
+export interface SreAgentDiscoveryResponse {
+  configured: boolean;
+  agents: SreAgentIdentity[];
+  selected?: SreAgentIdentity;
+  target: SreAgentTargetSummary;
+  collectedAt: string;
+}
+
+export interface StartSreAgentInvestigationRequest {
+  /** Approved scenario supplying the starter prompt, when starting from a scenario. */
+  scenarioName?: PortalValidationScenarioName;
+  /** Explicit operator prompt; required when no scenario is supplied. */
+  prompt?: string;
+  /** Optional client-supplied correlation id for audit stitching. */
+  correlationId?: string;
+}
+
+export interface ContinueSreAgentInvestigationRequest {
+  threadId: string;
+  prompt: string;
+  correlationId?: string;
+}
+
+export interface SreAgentThreadStatusRequest {
+  threadId: string;
+}
+
+export interface SreAgentScenarioPrompt {
+  scenarioName: PortalValidationScenarioName;
+  title: string;
+  prompt: string;
+}
+
+export interface SreAgentActiveThreadRecord {
+  threadId: string;
+  agentName: string;
+  scenarioName?: PortalValidationScenarioName;
+  startedAt: string;
+  updatedAt: string;
+  lastStatus: SreAgentInvestigationStatus;
+  correlationId: string;
+}


### PR DESCRIPTION
Closes #77

Mission Control can now start and continue a **real, approval-gated Azure SRE Agent investigation** in-dashboard, through the supported Azure MCP Server `sreagent` tool surface. No private or undocumented API is called, and the portal is never scraped.

This supersedes the "portal handoff only" verdict in `docs/SRE-AGENT-API-RESEARCH.md`, which predates Microsoft documenting the SRE Agent MCP server.

## Architecture

Proven from current first-party docs **plus a live transport spike** against the real Azure MCP Server (`3.0.0-beta.34`):

```
Mission Control backend (Fastify)
  └── MCP client (@modelcontextprotocol/sdk, stdio)
        └── npx -y @azure/mcp@latest server start --tool <6 allowlisted tools>
              ├── control plane (ARM)         → discovery   [Reader]
              └── data plane (*.azuresre.ai)  → threads     [SRE Agent Administrator]
```

- Transport, launcher, auth model, RBAC roles, data-plane domain, and investigation limits all match [SRE Agent MCP server](https://learn.microsoft.com/azure/sre-agent/mcp-server) and [Set up the SRE Agent MCP server](https://learn.microsoft.com/azure/sre-agent/setup-mcp-server).
- Reuses the **host** Azure identity (`az login`). No token, client secret, or MCP env value ever reaches the adapter or the browser.

## Security: `investigate_yolo` is impossible

Microsoft warns that `investigate_yolo` auto-approves **all** gates including infrastructure mutation. It is blocked in three independent layers:

1. **Server surface** — the child process is launched with one `--tool` flag per allowlisted tool, so the tool is *never registered on the server*. Operator `SRE_AGENT_MCP_ARGS` overrides cannot widen this: tool-exposure flags are stripped.
2. **Client mapping** — callers address typed operations; raw tool names are unreachable.
3. **Denylist assertion** — `assertToolAllowed` rejects `/yolo/i`, `/auto[_-]?approve/i`, `/approve[_-]?all/i`, `/bypass[_-]?approval/i`, `/no[_-]?confirm/i` plus 22 explicit tools, immediately before every dispatch.

Verified empirically — with the filter, the real server exposes exactly 6 tools; without it, 55 including yolo:

```
TOTAL TOOLS: 6
sreagent_agents_get / sreagent_agents_list / sreagent_threads_create
sreagent_threads_get / sreagent_threads_investigate / sreagent_threads_send_message
```

Preflight re-verifies this at runtime and **fails** if an auto-approval tool ever appears. `SreAgentApprovalState.autoApproved` is typed as the literal `false`, so an auto-approving path would not compile.

## Honesty guarantees

- **Provenance**: a response is labelled `provenance: 'azure-sre-agent'` only when it carries **both** a real agent identity **and** a real thread ID; otherwise the request fails.
- **No silent fallback**: failures return `localAnalystSubstituted: false` + portal handoff (with the prompt), and carry **no** success-shaped field.
- **No invented citations**: rendered when present, reported absent when not.
- **Schema honesty**: response shapes are not contractual, so `schemaConfidence` reports how values were obtained.
- **Cancellation honesty**: Azure MCP Server documents no server-side stop. Cancel aborts the Mission Control request and prevents retries; the UI and docs say agent-side work may continue.

## Also included

Env-driven config (no hardcoded target) · actionable auth/RBAC/network/tool-surface preflight · per-operation timeouts, cancellation covering the whole logical operation · bounded output · redaction of secrets **and** of subscription/tenant identifiers in response prose, citation labels, and approval detail · audit logging matching `docs/LOCAL-ANALYST-GOVERNANCE.md` fields · MCP process lifecycle with `SIGINT`/`SIGTERM` disposal · durable thread references for restart recovery.

**UI separation**: violet **A** "Azure SRE Agent · cloud agent" panel vs. cyan **L** "Local analyst · not Azure SRE Agent", with agent name, masked ARM ID, thread ID, status, and elapsed time shown beside every response.

## Validation

| Check | Result |
|---|---|
| `npm run lint` (vue-tsc + tsc) | pass |
| `npm run build` (frontend + backend) | pass |
| `npm test -w backend` | **100 pass / 0 fail** |
| `npm test -w frontend` | 3 pass / 0 fail |
| Compiled `dist` smoke test | config 200, 6 tools, no yolo, sub GUID not leaked; failure path returns `localAnalystSubstituted: false` with no `provenance`/`response` |
| ReDoS probe on redaction rules | worst case ~1 ms on 200 KB adversarial inputs |
| Adversarial parser probes | prose/agent-ID/message-ID cannot fake a thread ID; `javascript:` citation URLs dropped |

Tests use a **real MCP server** (official SDK) over `InMemoryTransport`, so the genuine protocol — tool registration, JSON-RPC dispatch, timeouts, cancellation — is exercised with no `npx` and no Azure.

### Self-review fixes

A review pass caught and I fixed, each with a regression test: subscription/tenant GUIDs leaking through agent **prose and citation labels**; raw tenant GUID in a preflight `remediation` string; `dispose()` racing a cold server start and orphaning the child process; the `onClose` cleanup being dead code with no signal handler; unredacted text in the fallback error branch; per-chunk stderr redaction missing secrets that straddle chunk boundaries; and an unterminated PEM block escaping redaction. An earlier failing test also exposed a real bug where cancellation only covered the final MCP call, not agent resolution.

## ⚠️ Live Azure status — honest limitation

**No live validation was performed.** No Energy Grid Azure SRE Agent resource was available, and the task scope prohibited provisioning one or touching the AmeriGas resource group. No Azure resources were created, modified, or deleted by this work.

**Proven**: the supported architecture; that the real Azure MCP Server starts over stdio and exposes exactly the six allowlisted tools with yolo absent; the full adapter against a protocol-faithful fake.

**Not proven** (required before claiming "SRE Agent diagnosed" in a customer demo): a real thread ID and cited response from a live agent; a real approval gate pausing; correlation of a `correlationId` with an SRE Agent audit event.

A precise, copy-pasteable live validation runbook is in [`docs/SRE-AGENT-MCP-INTEGRATION.md` §10](https://github.com/johnstel/azure-sre-agent-energy-grid/blob/johnstel-issue-77-p0-embed-real-sre-agent-investigations-i-e686a5/docs/SRE-AGENT-MCP-INTEGRATION.md). **The portal validation workflow remains authoritative until it is completed.**

## Docs

New `docs/SRE-AGENT-MCP-INTEGRATION.md`; updated `SRE-AGENT-API-RESEARCH.md` (supersession notice that preserves what is still accurate), `LOCAL-ANALYST-GOVERNANCE.md`, `SRE-AGENT-SETUP.md`, `TROUBLESHOOTING.md` (new MCP symptom table), and `mission-control/README.md`.

Existing Mission Control behavior and all prior enhancements are preserved — the changes are additive.