### PR TITLE
Add review-mode mitigation evidence lifecycle

### DIFF
--- a/mission-control/backend/src/services/NativeIncidentReconciliationService.test.ts
+++ b/mission-control/backend/src/services/NativeIncidentReconciliationService.test.ts
@@ -107,6 +107,58 @@ test('an observed ApprovalDecision event moves autonomy-review incidents out of 
   assert.equal(evidence.approvalDecision, 'unknown');
 });
 
+test('review-mode denied mitigation is surfaced as a deny state with no mutation', () => {
+  const evidence = reconcileNativeIncidentEvidence([snapshotRow()], {
+    hasLocalFallback: true,
+    now: new Date('2026-01-01T00:02:00Z'),
+    reviewModeMitigation: {
+      stage: 'denied',
+      stateMutation: 'unchanged',
+      liveProofStatus: 'blocked',
+      reason: 'Operator denied the proposed action before execution.',
+    },
+  });
+
+  assert.equal(evidence.state, 'denied');
+  assert.equal(evidence.reviewModeMitigation?.stateMutation, 'unchanged');
+  assert.equal(evidence.reviewModeMitigation?.liveProofStatus, 'blocked');
+});
+
+test('review-mode approval stages without real correlation remain unknown instead of being fabricated', () => {
+  const evidence = reconcileNativeIncidentEvidence([snapshotRow({ ThreadId: undefined, CorrelationId: undefined })], {
+    hasLocalFallback: true,
+    now: new Date('2026-01-01T00:02:00Z'),
+    reviewModeMitigation: {
+      stage: 'approved',
+      stateMutation: 'applied',
+      liveProofStatus: 'pending',
+      reason: 'Approval is pending a correlated execution event.',
+    },
+  });
+
+  assert.equal(evidence.state, 'unknown');
+  assert.equal(evidence.reviewModeMitigation?.liveProofStatus, 'blocked');
+});
+
+test('verification requires both Kubernetes health and a functional signal', () => {
+  const evidence = reconcileNativeIncidentEvidence([snapshotRow()], {
+    hasLocalFallback: true,
+    now: new Date('2026-01-01T00:02:00Z'),
+    reviewModeMitigation: {
+      stage: 'verification-passed',
+      stateMutation: 'applied',
+      liveProofStatus: 'pending',
+      verification: {
+        kubernetesHealthy: false,
+        functionalSignalObserved: true,
+      },
+    },
+  });
+
+  assert.equal(evidence.state, 'verification-failed');
+  assert.equal(evidence.reviewModeMitigation?.liveProofStatus, 'blocked');
+});
+
 test('mitigated incidents report native-mitigated regardless of autonomy level', () => {
   const evidence = reconcileNativeIncidentEvidence(
     [snapshotRow({ IncidentMitigatedByAgent: 'True', IncidentMitigatedOn: '2026-01-01T00:10:00Z' })],

--- a/mission-control/backend/src/services/NativeIncidentReconciliationService.ts
+++ b/mission-control/backend/src/services/NativeIncidentReconciliationService.ts
@@ -17,7 +17,13 @@
 //   cooldown window (default 3h, https://learn.microsoft.com/azure/sre-agent/response-plan). The
 //   real merge decision is made by Azure SRE Agent itself; Mission Control does not claim to
 //   control or guarantee it.
-import type { NativeApprovalDecisionState, NativeIncidentEvidence, NativeIncidentEvidenceState } from '../types/index.js';
+import type {
+  NativeApprovalDecisionState,
+  NativeIncidentEvidence,
+  NativeIncidentEvidenceState,
+  ReviewModeMitigationState,
+  ReviewModeVerificationSignal,
+} from '../types/index.js';
 
 export const DEFAULT_REINVESTIGATION_COOLDOWN_HOURS = 3; // Documented Azure Monitor response-plan default.
 export const DEFAULT_STALE_MINUTES = 30;
@@ -55,6 +61,8 @@ export interface ReconcileNativeEvidenceOptions {
   strongCorrelation?: boolean;
   /** Raw ApprovalDecision rows correlated to the same thread/incident, if queried. */
   approvalRows?: Record<string, unknown>[];
+  /** Review-mode mitigation state captured by Mission Control or an upstream workflow. */
+  reviewModeMitigation?: ReviewModeMitigationState;
 }
 
 function toBoolean(value: unknown): boolean {
@@ -176,6 +184,55 @@ function resolveApprovalDecision(approvalRows: Record<string, unknown>[] | undef
   return 'unknown';
 }
 
+function normalizeReviewModeMitigation(
+  mitigation: ReviewModeMitigationState | undefined,
+  verification: ReviewModeVerificationSignal | undefined,
+  correlationReady: boolean,
+): ReviewModeMitigationState | undefined {
+  if (!mitigation) return undefined;
+
+  const normalized: ReviewModeMitigationState = {
+    ...mitigation,
+    observedAt: mitigation.observedAt ?? new Date().toISOString(),
+    verification: mitigation.verification ?? verification,
+  };
+
+  if (normalized.stage === 'denied') {
+    normalized.stateMutation = 'unchanged';
+    normalized.liveProofStatus = 'blocked';
+    return normalized;
+  }
+
+  if (
+    (normalized.stage === 'approved' || normalized.stage === 'executing' || normalized.stage === 'verification-passed' || normalized.stage === 'verification-failed' || normalized.stage === 'rollback' || normalized.stage === 'escalation') &&
+    !correlationReady
+  ) {
+    normalized.stage = 'unknown';
+    normalized.reason = normalized.reason ?? 'Review-mode execution states require a real correlationId/threadId; Mission Control keeps the lifecycle unknown instead of fabricating a match.';
+    normalized.stateMutation = normalized.stateMutation === 'applied' ? 'unknown' : normalized.stateMutation;
+    normalized.liveProofStatus = 'blocked';
+    return normalized;
+  }
+
+  if (normalized.stage === 'verification-passed' || normalized.stage === 'verification-failed') {
+    const verificationSignals = normalized.verification ?? verification;
+    if (!verificationSignals || !verificationSignals.kubernetesHealthy || !verificationSignals.functionalSignalObserved) {
+      normalized.stage = 'verification-failed';
+      normalized.reason = normalized.reason ?? 'Verification requires both Kubernetes health and a scenario-relevant functional signal.';
+      normalized.liveProofStatus = 'blocked';
+      normalized.stateMutation = normalized.stateMutation === 'applied' ? 'unknown' : normalized.stateMutation;
+      return normalized;
+    }
+  }
+
+  if (normalized.stage === 'stale') {
+    normalized.liveProofStatus = 'blocked';
+    normalized.stateMutation = normalized.stateMutation === 'applied' ? 'unknown' : normalized.stateMutation;
+  }
+
+  return normalized;
+}
+
 /**
  * Reconciles the freshest matching native evidence into a typed, honest Mission Control state.
  * `rawRows` should already be correlated (via SreAgentEvidenceService threadId/incidentId/
@@ -270,8 +327,17 @@ export function reconcileNativeIncidentEvidence(
 
   const approvalDecision = resolveApprovalDecision(options.approvalRows);
 
+  const correlationReady = strongCorrelation || Boolean(latest.threadId || latest.correlationId);
+  const reviewModeMitigation = normalizeReviewModeMitigation(
+    options.reviewModeMitigation,
+    undefined,
+    correlationReady,
+  );
+
   let state: NativeIncidentEvidenceState;
-  if (latest.incidentMitigatedByAgent) {
+  if (reviewModeMitigation) {
+    state = reviewModeMitigation.stage as NativeIncidentEvidenceState;
+  } else if (latest.incidentMitigatedByAgent) {
     state = 'native-mitigated';
   } else if ((latest.agentAutonomyLevel ?? '').toLowerCase() === 'review' && approvalDecision === 'pending') {
     state = 'native-approval-required';
@@ -292,6 +358,9 @@ export function reconcileNativeIncidentEvidence(
     limitations.push('No ApprovalDecision event was correlated; approval state is inferred only from AgentAutonomyLevel and IncidentMitigatedByAgent, not from a confirmed approval/rejection record.');
   } else {
     limitations.push('An ApprovalDecision event was observed, but its specific outcome fields are SCHEMA_TBD (docs/CAPABILITY-CONTRACTS.md SS8); only its presence is used here.');
+  }
+  if (reviewModeMitigation) {
+    limitations.push(`Review-mode mitigation state is ${reviewModeMitigation.stage} with live-proof status ${reviewModeMitigation.liveProofStatus}.`);
   }
   limitations.push('withinCooldown is a client-side estimate of the documented reinvestigation cooldown window, not a value read from the response plan itself.');
 
@@ -315,6 +384,7 @@ export function reconcileNativeIncidentEvidence(
     handledOn: latest.incidentHandledOn,
     mitigatedOn: latest.incidentMitigatedOn,
     approvalDecision,
+    reviewModeMitigation,
     cooldownHours,
     withinCooldown,
     limitations,

--- a/mission-control/backend/src/types/index.ts
+++ b/mission-control/backend/src/types/index.ts
@@ -384,9 +384,67 @@ export type NativeIncidentEvidenceState =
   | 'native-observed'
   | 'native-approval-required'
   | 'native-mitigated'
+  | 'proposed'
+  | 'denied'
+  | 'approved'
+  | 'executing'
+  | 'verification-passed'
+  | 'verification-failed'
+  | 'rollback'
+  | 'escalation'
+  | 'unknown'
+  | 'stale'
   | 'evidence-unavailable';
 
 export type NativeApprovalDecisionState = 'approved' | 'rejected' | 'pending' | 'unknown';
+
+export type ReviewModeMitigationLifecycleStage =
+  | 'proposed'
+  | 'denied'
+  | 'approved'
+  | 'executing'
+  | 'verification-passed'
+  | 'verification-failed'
+  | 'rollback'
+  | 'escalation'
+  | 'unknown'
+  | 'stale';
+
+export interface ReviewModeVerificationSignal {
+  kubernetesHealthy: boolean;
+  functionalSignalObserved: boolean;
+  signal?: string;
+}
+
+export interface ReviewModeActionDesign {
+  scenarioName: RehearsalScenarioName;
+  operation: string;
+  preconditions: string[];
+  risk: string;
+  affectedScope: string;
+  leastPrivilege: string;
+  allowlist: string[];
+  policyHook: string;
+  timeoutSeconds: number;
+  rollback: string;
+  verification: ReviewModeVerificationSignal & {
+    requiredSignals: string[];
+  };
+  approvalMode: 'review';
+  notes?: string;
+}
+
+export interface ReviewModeMitigationState {
+  stage: ReviewModeMitigationLifecycleStage;
+  observedAt?: string;
+  correlationId?: string;
+  threadId?: string;
+  stateMutation: 'unchanged' | 'applied' | 'not-applicable' | 'unknown';
+  reason?: string;
+  verification?: ReviewModeVerificationSignal;
+  actionDesign?: ReviewModeActionDesign;
+  liveProofStatus: 'pending' | 'verified' | 'blocked';
+}
 
 // Reconciled, honest evidence for a single incident. `state` MUST default to
 // 'evidence-unavailable' when no observed telemetry exists -- never infer health from absence.
@@ -410,6 +468,7 @@ export interface NativeIncidentEvidence {
   handledOn?: string;
   mitigatedOn?: string;
   approvalDecision?: NativeApprovalDecisionState;
+  reviewModeMitigation?: ReviewModeMitigationState;
   cooldownHours: number;
   withinCooldown: boolean;
   limitations: string[];
@@ -737,6 +796,7 @@ export interface RehearsalEvidencePackage {
   attachmentChecksums: RehearsalAttachmentChecksum[];
   redactionFindings: string[];
   sensitivePatterns: string[];
+  reviewModeMitigation?: ReviewModeMitigationState;
   complete: boolean;
 }
 
@@ -816,6 +876,7 @@ export interface UpdateRehearsalEvidenceRequest {
   attachmentChecksums?: RehearsalAttachmentChecksum[];
   redactionFindings?: string[];
   sensitivePatterns?: string[];
+  reviewModeMitigation?: ReviewModeMitigationState;
   complete?: boolean;
   notes?: string;
 }


### PR DESCRIPTION
## Summary

This PR adds the first review-mode mitigation lifecycle slice for Mission Control native incident evidence.

### What changed
- Extended the shared Mission Control typed contracts to model review-mode lifecycle stages (`proposed`, `denied`, `approved`, `executing`, `verification-passed`, `verification-failed`, `rollback`, `escalation`, `unknown`, `stale`) and attach explicit action-design + verification metadata.
- Updated native incident reconciliation so Mission Control surfaces review-mode mitigation state, preserves denial/no-mutation semantics, and degrades to `unknown` when execution stages appear without a real correlation identifier.
- Added targeted tests for denied/no-mutation handling, correlation-safe approval state, and verification-failure semantics.

## Security / action design
- The implementation remains conservative and read-only by default: it never fabricates approvals or execution success.
- Review-mode execution states require a real correlation identifier/thread identifier; otherwise Mission Control marks the state as `unknown` rather than inventing a match.
- Verification is only considered successful when both Kubernetes health and a scenario-relevant functional signal are present.

## Validation
- `node --test --import tsx src/services/NativeIncidentReconciliationService.test.ts`
- `npm test`
- `npm run build`
- `npm run lint`

## Live proof status
- Live deny/approve execution proof remains intentionally pending rather than fabricated. The new reconciliation path now preserves that honesty in the evidence model and tests.

Closes #80