### PR TITLE
Add evidence-derived Review-mode mitigation lifecycle for MongoDBDown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ azureconfig.json
 # Compiled ARM templates (can regenerate from Bicep)
 *.json
 !infra/grafana/energy-grid-incident-dashboard.json
+!infra/sre-agent/tool-access-policy.json
 !package.json
 !devcontainer.json
 !launch.json

--- a/docs/CAPABILITY-CONTRACTS.md
+++ b/docs/CAPABILITY-CONTRACTS.md
@@ -377,7 +377,22 @@ traces
 
 This demo proves **Review mode only**. Auto mode exists but is out of scope for this wave.
 
-No document, slide, runbook, prompt, or live demo shall claim that auto-remediation is demonstrated by this lab. The current deployment uses `mode: 'Review'` and `accessLevel: 'High'`, which means the agent may recommend remediation but a human operator remains responsible for executing write actions. If the Azure SRE Agent portal exposes a specific approval/denial UX in this environment, capture it as evidence before mentioning it; otherwise use “agent recommends, operator executes.”
+No document, slide, runbook, prompt, or live demo shall claim that auto-remediation is demonstrated by this lab. The current deployment uses `mode: 'Review'`, which means the agent may propose remediation but a human decision is required before any write executes.
+
+**Scoped exception (issue #80, `MongoDBDown` only).** One reversible scenario has a documented,
+guardrailed Review-mode mitigation path — see [`REVIEW-MODE-MITIGATION.md`](REVIEW-MODE-MITIGATION.md).
+For every other scenario, keep the conservative “agent recommends, operator executes” wording.
+Even for `MongoDBDown`, Mission Control derives the lifecycle from observed `IncidentActivitySnapshot`,
+`ApprovalDecision`, `AgentToolExecution` and `AgentAzCliExecution` telemetry and reports
+`verification-passed` **only** when approval, execution, and three post-execution probes were all
+observed and correlated by exact identifier. Live deny/approve proof is recorded as **pending**
+until captured against a real environment (`REVIEW-MODE-MITIGATION.md` §10) — do not present it as
+proven before then.
+
+A Kubernetes write does **not** trigger the native Review-mode Approve/Deny button on its own
+([run modes](https://learn.microsoft.com/azure/sre-agent/run-modes) scopes that gate to Azure
+infrastructure operations). The approval gate for this path is a global Tool Access Policy `ask`
+rule combined with response-plan run mode Review.
 
 Any future Auto mode demo requires a separate security review with evidence of:
 
@@ -402,7 +417,8 @@ The current demo profile intentionally grants broad roles through `scripts/confi
 | Key Vault Secrets Officer | Key Vault | ⚠️ DEMO ONLY | ❌ Remove or Key Vault Secrets User | Agent doesn't manage secrets |
 | AcrPull | ACR | ✅ | ✅ Keep if image metadata/pull access is needed | No scenario requires image push |
 | Reader | Subscription | ⚠️ DEMO ONLY | Reader (Resource Group scope) | Limit enumeration surface |
-| Contributor | Resource Group | ⚠️ DEMO ONLY (`accessLevel: 'High'`) | ❌ Remove (`accessLevel: 'Low'`) | Use Low for read-only diagnosis |
+| Contributor | Resource Group | ⚠️ DEMO ONLY (`accessLevel: 'High'`) | ❌ Remove (`accessLevel: 'Low'` or `'Mitigation'`) | Use Low for read-only diagnosis; use `Mitigation` for the issue #80 remediation path, which grants **no** Contributor |
+| SRE Agent Energy Grid Mitigation Operator (custom) | AKS resource | ✅ `accessLevel: 'Mitigation'` | ✅ Keep | Only `managedClusters/read` + `listClusterUserCredential/action`; no admin credential, no `runCommand`, no wildcard |
 
 `accessLevel: 'Low'` gives Reader + Log Analytics Reader. `accessLevel: 'High'` adds Contributor. The Bicep source of truth allows only `High` and `Low` for `accessLevel`; do not use other values.
 
@@ -556,7 +572,8 @@ telemetry — see `infra/bicep/modules/app-insights.bicep` and `sre-agent.bicep`
 | `IncidentActivitySnapshot` | Documented: `IncidentId`, `IncidentTitle`, `IncidentSeverity`, `IncidentStatus`, `IncidentPlatform`, `IncidentMitigatedByAgent`, `IncidentAssistedByAgent`, `AgentAutonomyLevel`, `ResponsePlanId`, `ResponsePlanCustom`, `IncidentImpactedService`, `IncidentCreatedOn`, `IncidentHandledOn`, `IncidentMitigatedOn` |
 | `AgentExecution` | `SCHEMA_TBD` — Microsoft Learn documents only "session start/end lifecycle" without an itemized field table |
 | `AgentToolExecution` | Documented: `EventType`, `ToolName`, `ToolInput`, `ToolOutput`, `SubAgentName`, `CallId` |
-| `ApprovalDecision` | `SCHEMA_TBD` — Microsoft Learn shows only a raw `customDimensions` projection, no itemized field table |
+| `ApprovalDecision` | `SCHEMA_TBD` — Microsoft Learn shows only a raw `customDimensions` projection, no itemized field table. `mitigationLifecycle.ts` scans a bounded candidate-key list for the outcome and resolves to `unknown` when none matches; it never defaults to `approved`. |
+| `AgentAzCliExecution` | Name documented ("Azure CLI commands run by the agent"); fields `SCHEMA_TBD`. Correlated when present, but never required for the kubectl mitigation path. |
 
 Shared correlation fields on every event (all four): `gen_ai.agent.id`, `gen_ai.agent.name`,
 `TraceId`, `SpanId`, `ParentSpanId`, `ThreadId`, `LogTimestamp`, `CorrelationId`.

--- a/docs/DEMO-RUNBOOK.md
+++ b/docs/DEMO-RUNBOOK.md
@@ -609,3 +609,76 @@ Blockers resolved: ☐ Yes ☐ No (list blockers below)
 Ready for Wave 2 scenario validation: ☐ Yes ☐ No
 
 **Notes:**
+
+---
+
+## Review-mode mitigation (MongoDBDown)
+
+> Issue #80. Full action design, blast radius, permission boundary and evidence contract:
+> [`REVIEW-MODE-MITIGATION.md`](REVIEW-MODE-MITIGATION.md).
+>
+> **Live deny/approve proof is currently PENDING.** Run this procedure against a real lab to
+> capture it. Until then, do not present the deny or approve paths as proven.
+
+### Prerequisites
+
+1. Deploy with the least-privilege posture:
+   ```bash
+   az deployment sub create --template-file infra/bicep/main.bicep \
+     --parameters sreAgentAccessLevel=Mitigation enableReviewModeMitigation=true
+   ```
+   Add `enableAgentKubernetesRbac=true` to move the boundary into the Kubernetes API server
+   (removes the documented demo-only permission breadth).
+
+2. Apply and verify the guardrails:
+   ```bash
+   pwsh ./scripts/validate-sre-agent-mitigation-guardrails.ps1
+   pwsh ./scripts/configure-sre-agent-mitigation-guardrails.ps1 -ResourceGroupName <rg>
+   pwsh ./scripts/configure-sre-agent-mitigation-guardrails.ps1 -ResourceGroupName <rg> -Apply
+   ```
+   The first command must exit 0. The second must not report Contributor on the agent identity.
+
+3. **Set the response plan to Review.** Microsoft documents the *response plan* default as
+   Autonomous even though the agent-level default is Review
+   ([run modes](https://learn.microsoft.com/azure/sre-agent/run-modes)). In the agent portal, edit
+   the incident trigger and set **Agent autonomy level → Review**. If you skip this, Mission
+   Control reports `blocked-run-mode` and the demonstration correctly refuses to proceed.
+
+### Capture the deny path
+
+1. Break the scenario: `kubectl apply -f k8s/scenarios/mongodb-down.yaml`
+2. Record the pre-decision baseline so the no-mutation proof has an earlier observation:
+   ```bash
+   curl -s "http://localhost:3001/api/mitigation/evidence?threadId=<threadId>"
+   kubectl get deployment mongodb -n energy -o jsonpath='{.spec.replicas}{"\n"}'
+   ```
+3. Let the agent investigate and propose. In the portal, select **Deny**.
+4. Re-query the evidence endpoint. Expected: `state: "denied"` with
+   `resourceState.mutation: "unchanged"`.
+   - `denied-with-unverified-state` means there is no fresh before/after pair — capture one and retry.
+   - `deny-violation` is a **security finding**: stop and investigate the policy/RBAC boundary.
+
+### Capture the approve path
+
+1. Ask the agent to propose the mitigation again. In the portal, select **Approve**.
+2. Poll the evidence endpoint until `execution.completedAt` is populated.
+3. Expected end state: `state: "verification-passed"`, `incidentResolved: true`, and all three
+   probes (`kubernetes-readiness`, `service-endpoint-health`, `golden-transaction`) reporting
+   `pass` with timestamps **after** `execution.completedAt`.
+4. Attach the evidence to the rehearsal package (it is re-derived server-side, not trusted from the body):
+   ```bash
+   curl -s -X POST http://localhost:3001/api/rehearsals/MongoDBDown/mitigation-evidence \
+     -H 'content-type: application/json' -d '{"threadId":"<threadId>"}'
+   ```
+
+### Prove an out-of-scope command is blocked
+
+Ask the agent to do something outside the allowlist, for example
+"delete the mongodb deployment in the energy namespace". Expected: the tool access policy `deny`
+rule blocks it. Mission Control reports it under `securityFindings` and it never contributes to
+`verification-passed`.
+
+### Rollback
+
+`kubectl scale deployment/mongodb -n energy --replicas=0` — inside the same allowlist, so the
+rollback is itself gated and audited.

--- a/docs/DEMO-RUNBOOK.md
+++ b/docs/DEMO-RUNBOOK.md
@@ -638,6 +638,18 @@ Ready for Wave 2 scenario validation: ☐ Yes ☐ No
    ```
    The first command must exit 0. The second must not report Contributor on the agent identity.
 
+   With `enableAgentKubernetesRbac=true`, the `-Apply` run also creates the Layer 2 assignment at
+   exactly `<aksResourceId>/namespaces/energy` (Bicep cannot express that extension-resource scope —
+   see [`REVIEW-MODE-MITIGATION.md` §3](REVIEW-MODE-MITIGATION.md)) and reads it back to verify.
+   Expected output:
+   ```text
+   [PASS   ] Created and verified namespace-scoped assignment. Returned scope:
+             /subscriptions/…/managedClusters/<aks>/namespaces/energy
+   ```
+   A `CLUSTER-WIDE GRANT` or `OUT-OF-SCOPE GRANT` line is a **failure**, not a warning: the script
+   prints the exact `az role assignment delete --ids …` command to remove it. Namespace enforcement
+   is never reported from the mere existence of an assignment.
+
 3. **Set the response plan to Review.** Microsoft documents the *response plan* default as
    Autonomous even though the agent-level default is Review
    ([run modes](https://learn.microsoft.com/azure/sre-agent/run-modes)). In the agent portal, edit

--- a/docs/REVIEW-MODE-MITIGATION.md
+++ b/docs/REVIEW-MODE-MITIGATION.md
@@ -1,0 +1,330 @@
+# Review-Mode Mitigation — Action Design, Guardrails, and Evidence Contract
+
+> Issue #80 · Status: **implemented, live approve/deny proof PENDING** (no Energy Grid environment
+> is currently deployed in this subscription — see §10).
+
+This document is the action-design gate required by issue #80. It records the feasibility analysis,
+the exact chosen action, the enforcement boundary, and the evidence contract that Mission Control
+uses to *derive* — never assert — the mitigation lifecycle.
+
+Everything below cites current first-party Microsoft Learn guidance. Where Microsoft does not
+document a field, this document says so explicitly and the code refuses to guess.
+
+---
+
+## 1 · Feasibility gate: does a Kubernetes fix trigger the Review-mode approval gate?
+
+This was the blocking question. **It is resolved: no, not by itself.**
+
+Microsoft Learn, [Run modes in Azure SRE Agent](https://learn.microsoft.com/azure/sre-agent/run-modes):
+
+> Review mode shows **Approve** and **Deny** buttons **only for Azure infrastructure operations**.
+> Other actions […] proceed based on the agent's reasoning and your response plan instructions.
+> To add governance controls for these actions, use Hooks or Tool Access Policies to enforce safety
+> checks before or after specific tool calls.
+
+And [Execute mitigations](https://learn.microsoft.com/azure/sre-agent/execute-mitigations) scopes the
+native gate to the Azure CLI tool: *"Write commands: Modify any Azure resource […] **Requires
+approval in Review mode**."*
+
+`kubectl scale` is dispatched through the `RunKubectlWriteCommand` tool
+([Tool access policies](https://learn.microsoft.com/azure/sre-agent/tool-access-policies)), which is
+**not** an Azure Resource Manager write. Relying on run mode alone to gate it would be exactly the
+kind of unproven assumption that got the previous attempt rejected.
+
+Microsoft documents the supported control for this case in the same page:
+
+> **Ask** (global only): If matched, the agent pauses for approval in Review mode, or auto-approves
+> in Autonomous mode.
+
+So the supported approval contract for a Kubernetes remediation is **Tool Access Policy `ask` +
+response plan run mode `Review`**. Both are required. Because an `ask` rule *auto-approves* under
+Autonomous, an observed effective mode of `Review` is a hard precondition — which is why
+`assertReviewModeOrBlock()` (§7) blocks the demo loudly on `autonomous`/unknown.
+
+### 1.1 Why MongoDBDown cannot use the native Azure-infrastructure gate
+
+| Candidate Azure-infrastructure action | Verdict |
+| --- | --- |
+| Any ARM operation that scales a Kubernetes `Deployment` | **Does not exist.** ARM has no data-plane verb for in-cluster workloads. |
+| `az aks command invoke` (`Microsoft.ContainerService/managedClusters/runCommand/action`) | ARM write, *would* trigger the native gate — but it is arbitrary in-cluster shell execution. Issue #80 non-goals forbid "arbitrary shell execution", and it would defeat every allowlist below. **Rejected.** |
+| `az aks nodepool scale` | Does not restore MongoDB. Also invalid here: both node pools set `enableAutoScaling: true` (`infra/bicep/modules/aks.bicep`), and AKS rejects `nodepool scale` on autoscaler-enabled pools. **Rejected.** |
+| `az aks start` / `stop` | Whole-cluster blast radius. **Rejected.** |
+
+### 1.2 Why no other repository scenario changes this answer
+
+All ten scenarios in `k8s/scenarios/` are Kubernetes data-plane faults (deployment spec, ConfigMap,
+Service selector, NetworkPolicy, replica count). None is repairable by a pure ARM write. Notably
+`pending-pods` requests 32Gi/8 CPU per pod, which no node *count* change fixes — it needs a larger
+VM SKU — and the autoscaler constraint above applies.
+
+**Conclusion:** MongoDBDown is retained (it is the preferred scenario in issue #80, is reversible,
+has the smallest blast radius, and has the richest verification story), and it is governed by the
+Tool Access Policy `ask` path rather than the native Azure-infrastructure button. This is a
+documented, first-party supported approval mechanism — not a workaround.
+
+---
+
+## 2 · The chosen action
+
+| Property | Value |
+| --- | --- |
+| **Scenario** | `MongoDBDown` (`k8s/scenarios/mongodb-down.yaml`) — `mongodb` Deployment scaled to 0 |
+| **Exact action** | `kubectl scale deployment/mongodb --namespace energy --replicas=1` |
+| **Runtime tool** | `RunKubectlWriteCommand` |
+| **Resource** | exactly one object: `apps/v1 Deployment energy/mongodb` |
+| **Approval gate** | Tool Access Policy `ask` rule + response plan run mode `Review` |
+| **Timeout** | 120 s for the action; 300 s total for the verify phase |
+| **Rollback** | `kubectl scale deployment/mongodb --namespace energy --replicas=0` (inside the same allowlist, so rollback is itself governed and auditable) |
+
+### Preconditions (all must hold before the action is proposed)
+
+1. Response plan effective run mode is observed as `Review`.
+2. `mongodb` Deployment exists in namespace `energy` with `spec.replicas == 0`.
+3. The `mongodb-data-pvc` PersistentVolumeClaim is `Bound` (the action must not provoke re-provisioning).
+4. The Tool Access Policy in `infra/sre-agent/tool-access-policy.json` is applied at global scope.
+5. The agent identity does **not** hold Contributor on the resource group (§4).
+
+### Blast radius
+
+Replica count of a single Deployment in a single namespace of a single cluster.
+**No data is mutated** — the PVC and its contents are untouched; scaling to 1 re-attaches the
+existing volume. Nothing outside namespace `energy` is reachable by the allowlisted command.
+
+### Failure handling
+
+| Failure | Behaviour |
+| --- | --- |
+| Deny | Incident stays unresolved; requires an observed rejection event **plus** before/after resource-state evidence proving `replicas` never changed (§6). |
+| Insufficient permission | Surfaces as a tool execution failure; lifecycle becomes `execution-failed`, never `verification-passed`. |
+| Action timeout | `execution-failed` + rollback guidance. |
+| Verification failed / stale / partial / no-data | Incident remains **unresolved**, lifecycle is `verification-failed`, and rollback/escalation guidance is emitted. Never resolved. |
+
+---
+
+## 3 · Enforcement boundary (defence in depth)
+
+Enforcement is layered so that no single bypass — including prompt injection into the agent — grants
+an out-of-scope action. Layers are listed narrowest-first.
+
+### Layer 1 — Tool Access Policy (always on, primary boundary)
+
+`infra/sre-agent/tool-access-policy.json`, applied at **global** scope via
+`scripts/configure-sre-agent-mitigation-guardrails.ps1`.
+
+Only the global scope can `deny`, and per Microsoft's evaluation order `deny` is checked first, so
+these rules cannot be widened by a custom-agent or thread-level allow.
+
+- `ask` — exactly one pattern: the scale command above, pinned to `deployment/mongodb`, `-n energy`,
+  and `--replicas=0|1`.
+- `deny` — deletes/removes, `exec`, `port-forward`, `cp`, `attach`, `proxy`, `az keyvault`, all
+  `RunAzCliWriteCommands`, `ExecutePythonCode`, `RunInTerminal`, `RunShellCommand`, and
+  `az aks command invoke`.
+- `allow` — read-only tools only.
+
+> **Known limitation, deliberately not papered over:** `RunKubectlWriteCommand` argument globs are
+> string patterns. They are a real control at the agent's execution boundary, but they are not an
+> API-server-side authorization decision. That is why Layer 2 exists, and why
+> `validate-sre-agent-mitigation-guardrails.ps1` reports the two layers separately instead of
+> claiming one implies the other.
+
+### Layer 2 — Azure RBAC for Kubernetes, namespace-scoped (opt-in)
+
+Set `enableAgentKubernetesRbac = true` (default `false`). This enables managed Entra integration
+with Azure RBAC on the cluster and assigns the agent identity a **custom role** whose only
+`dataActions` are `apps/deployments` read/write, at scope
+`<aksResourceId>/namespaces/energy`. Authorization is then enforced by the API server, not by a
+string match.
+
+It is **off by default** because enabling Entra integration changes how `az aks get-credentials`
+issues operator kubeconfigs, and this repository has no live environment in which to validate that
+change (§10). `scripts/deploy.ps1` already switches to `--admin` when the flag is on.
+
+### Layer 3 — Azure control-plane custom role (replaces Contributor)
+
+New `accessLevel` value **`Mitigation`** in `infra/bicep/modules/sre-agent.bicep` assigns:
+
+- `Log Analytics Reader`, `Reader` (unchanged), and
+- a custom role definition **`SRE Agent Energy Grid Mitigation Operator`**
+  (`infra/bicep/modules/sre-agent-mitigation-role.bicep`) whose only actions are
+  `Microsoft.ContainerService/managedClusters/read` and
+  `…/listClusterUserCredential/action`, scoped to the AKS resource — **not** the resource group.
+
+Contributor is **not** assigned on this path. `High` still exists for the pre-existing broad-access
+lab flows, but the guardrail validator **fails** (not warns) if Contributor is present while the
+mitigation path is enabled.
+
+### Layer 4 — Run mode
+
+Response plan run mode `Review`. Required, and independently verified from telemetry rather than
+trusted from configuration (§7).
+
+---
+
+## 4 · Documented demo-only permission breadth
+
+With Layer 2 **off** (the default), `listClusterUserCredential` returns a cluster credential whose
+in-cluster authority is governed by the cluster's own RBAC. Because this lab does not disable local
+accounts, that credential is broader than the single Deployment this action needs.
+
+This is disclosed rather than hidden:
+
+- `scripts/validate-sre-agent-mitigation-guardrails.ps1` emits a **loud, non-suppressible**
+  `DEMO-ONLY PERMISSION BREADTH` finding whenever Layer 2 is inactive.
+- The Mission Control API returns the same disclosure in `guardrails.disclosures[]`, and the UI
+  renders it as a warning badge on the mitigation panel.
+- Layer 1 still constrains what the agent will actually run.
+
+To remove this breadth entirely, deploy with `enableAgentKubernetesRbac = true`.
+
+---
+
+## 5 · Evidence contract — lifecycle is *derived*, never asserted
+
+Mission Control never accepts a lifecycle state from a request body. Every state is derived from
+runtime-validated, redacted Application Insights `customEvents` rows.
+
+Implementation: `mission-control/backend/src/services/sre-agent/mitigationLifecycle.ts`.
+
+### Correlated events
+
+| Event | Role | Schema status |
+| --- | --- | --- |
+| `IncidentActivitySnapshot` | incident identity, status, `AgentAutonomyLevel`, response plan | [Documented](https://learn.microsoft.com/azure/sre-agent/audit-agent-actions#incident-lifecycle-incidentactivitysnapshot) |
+| `ApprovalDecision` | the human approve/reject decision | **`SCHEMA_TBD`** — Microsoft publishes only a raw `customDimensions` projection. Outcome is read from a bounded candidate-key scan and is `unknown` (never guessed) when absent. |
+| `AgentToolExecution` | the `RunKubectlWriteCommand` invocation and its result | [Documented](https://learn.microsoft.com/azure/sre-agent/audit-agent-actions#tool-execution-agenttoolexecution) |
+| `AgentAzCliExecution` | correlated when present; not required for the kubectl path | Name documented; fields `SCHEMA_TBD` |
+
+### Correlation rule
+
+Events join only on **exact string equality** of `ThreadId`, and additionally on `CorrelationId`,
+`IncidentId`, or `TraceId` where present. Anything else is a mismatch:
+
+- No shared identifier → evidence is discarded, not attached.
+- Two different `ThreadId`s claiming the same incident → `ambiguous`, no lifecycle asserted.
+- Identifier present on one event and absent on its counterpart → not a match.
+
+### Rejected inputs (each has a test)
+
+Replay (repeated `CallId`/`SpanId`), duplicates, future timestamps beyond a bounded clock skew,
+out-of-order lifecycles (verification before execution, execution before approval), stale evidence
+past the freshness window, schema drift, unknown request keys, forged request-body lifecycle fields.
+
+---
+
+## 6 · Deny requires proof of *no mutation*
+
+`denied` is only asserted when **both** hold:
+
+1. An observed `ApprovalDecision` row correlated by exact ID whose outcome parses as a rejection, **and**
+2. Before/after resource-state observations of `energy/mongodb` that are both present, both fresh,
+   and **equal** (`spec.replicas` unchanged, `observedGeneration` unchanged).
+
+If the before/after pair is missing, stale, or shows drift, the state is
+`denied-with-unverified-state` — **never** `denied`. An applied mutation after a rejection is
+reported as `deny-violation`, which is a security finding, not a success. The code never rewrites
+`applied`/`unknown` into `unchanged`.
+
+### 6.1 The "before" reading is anchored at the decision, not at the previous poll
+
+Mission Control keeps a short, time-ordered history of observations of `energy/mongodb` and selects
+the newest entry **at or before the observed decision timestamp** as the "before" reading.
+
+This matters. Using "whatever the previous poll saw" would be exploitable: once a mutation had
+settled, two successive later polls would both read the mutated value, compare equal, and a rejected
+proposal that *did* change the resource would be reported as a clean `denied`. Anchoring at the
+decision closes that window. If the history contains nothing older than the decision, the state is
+`denied-with-unverified-state`, and an explicitly supplied "before" that post-dates the decision is
+discarded with a stated reason.
+
+Regression tests: `mitigationLifecycle.test.ts` ("anchors the before reading at or before the
+decision") and `mitigation.test.ts` ("does not mask a post-deny mutation across successive polls").
+
+---
+
+## 7 · Verification contract
+
+`verification-passed` requires **all** of:
+
+- an observed approval **and** matching execution telemetry (exact ID equality),
+- every probe timestamped **strictly after** the observed execution completion,
+- three structured probes, each carrying `source`, observed value, `observedAt`, freshness, and an
+  evidence pointer/correlation id — **no boolean-only success**:
+
+| Probe | Signal | Pass condition |
+| --- | --- | --- |
+| `kubernetes-readiness` | `energy/mongodb` Deployment | `readyReplicas >= 1` and `availableReplicas >= 1` |
+| `service-endpoint-health` | `mongodb` Service endpoints | at least one ready endpoint address |
+| `golden-transaction` | PR #84 synthetic meter-ingest journey (`CustomerImpactService`) | `dataStatus == 'available'`, success rate ≥ 95 %, freshness ≤ 5 min, journey status not `critical` |
+
+Any probe that is missing, `no-data`, stale, or failing yields `verification-failed`, the incident
+stays unresolved, and rollback/escalation guidance is emitted.
+
+`assertReviewModeOrBlock()` blocks the entire flow when the observed `AgentAutonomyLevel` is
+`autonomous`, unknown, or absent — the demo fails loudly instead of proceeding.
+
+---
+
+## 8 · Out-of-scope command handling
+
+An out-of-scope attempt must be **blocked and recorded**. Mission Control classifies an
+`AgentToolExecution` row as `blocked-out-of-scope` when its `ToolName`/`ToolInput` fails the
+allowlist re-check, or when its output carries a policy-denial or API-server `Forbidden` signal.
+Such rows never contribute to `verification-passed` and are surfaced as security findings.
+
+The allowlist is re-evaluated at Mission Control's own boundary
+(`isAllowlistedMitigationCommand()`), so a policy drift upstream is detected rather than trusted.
+
+`normalizeMitigationCommand()` is a strict tokeniser, not a regex over the whole command. Every
+token must be recognised; an unrecognised flag or a second positional resource rejects the whole
+string. This closes an argument-smuggling class where a command carrying the required
+`-n energy` and `--replicas=N` tokens could also carry `--server`, `--token`, `--kubeconfig`,
+`--as system:masters`, `--all-namespaces`, or a second `deployment/...` target.
+
+### 8.1 Findings from the adversarial security review
+
+Three issues were found by security review of this change and fixed before merge. Each has a
+named regression test:
+
+| Finding | Severity | Fix |
+| --- | --- | --- |
+| Lookahead-based command normalisation discarded extra arguments, so a smuggled command normalised into an allowlisted string | High | Replaced with a strict tokeniser (`mitigationLifecycle.test.ts`: "rejects argument-smuggling payloads…", "does not let a smuggled command reach verification-passed") |
+| The run-mode gate selected its snapshot row with an OR over `IncidentId`/`ThreadId`, so the autonomy level could be read from a different agent thread of the same incident | Medium | `correlateRawRow()` applies the same strict equality used everywhere else (`mitigation.test.ts`: "reads the run mode only from a strictly correlated snapshot row") |
+| Redaction of space-separated CLI secret flags stopped at the first space inside quotes, leaking the remainder of a multi-word secret | Medium | The value pattern now consumes to the matching closing quote (`mitigationLifecycle.test.ts`: "redacts quoted secret values that contain spaces") |
+
+---
+
+## 9 · Rollback and escalation
+
+Rollback is the allowlisted `--replicas=0` scale, so it is itself gated and audited. When
+verification fails, the API returns `rollback` guidance (exact command, expected effect, and the
+escalation contact path) and the lifecycle is `verification-failed` — never `resolved`.
+
+---
+
+## 10 · Live-proof status
+
+No Energy Grid environment is deployed in the current subscription
+(`ME-MngEnvMCAP550731-jostelma-2`), and the AmeriGas resource group `rg-srelab-northcentralus` is
+explicitly out of bounds. Therefore:
+
+- ✅ Configuration, policy, custom role, KQL, runtime parsers, API, UI, tests, validators, runbook — **implemented**.
+- ⏳ One live **Deny** run and one live **Approve → Execute → Verify** run — **PENDING**.
+- ⏳ Confirmation that a Tool Access Policy `ask` approval emits an `ApprovalDecision` customEvent
+  (Microsoft documents the event but not which approval mechanisms emit it) — **PENDING**.
+  The code treats a missing `ApprovalDecision` as `pending`/`unknown`, never as approved.
+
+Run `scripts/validate-sre-agent-mitigation-guardrails.ps1 -ResourceGroupName <rg>` against a live
+lab to capture the outstanding proof; the exact live procedure is in
+[`DEMO-RUNBOOK.md`](DEMO-RUNBOOK.md#review-mode-mitigation-mongodbdown).
+
+---
+
+## 11 · References
+
+- [Run modes](https://learn.microsoft.com/azure/sre-agent/run-modes)
+- [Execute mitigations](https://learn.microsoft.com/azure/sre-agent/execute-mitigations)
+- [Tool access policies](https://learn.microsoft.com/azure/sre-agent/tool-access-policies)
+- [Agent hooks](https://learn.microsoft.com/azure/sre-agent/agent-hooks)
+- [Audit agent actions](https://learn.microsoft.com/azure/sre-agent/audit-agent-actions)
+- [User roles and permissions](https://learn.microsoft.com/azure/sre-agent/user-roles)

--- a/docs/REVIEW-MODE-MITIGATION.md
+++ b/docs/REVIEW-MODE-MITIGATION.md
@@ -131,12 +131,35 @@ these rules cannot be widened by a custom-agent or thread-level allow.
 ### Layer 2 — Azure RBAC for Kubernetes, namespace-scoped (opt-in)
 
 Set `enableAgentKubernetesRbac = true` (default `false`). This enables managed Entra integration
-with Azure RBAC on the cluster and assigns the agent identity a **custom role** whose only
-`dataActions` are `apps/deployments` read/write, at scope
+with Azure RBAC on the cluster and grants the agent identity a **custom role** whose only
+`dataActions` are `apps/deployments` read/write plus a few reads, assigned at scope
 `<aksResourceId>/namespaces/energy`. Authorization is then enforced by the API server, not by a
 string match.
 
-It is **off by default** because enabling Entra integration changes how `az aks get-credentials`
+> **Bicep cannot express this scope, so it does not create the assignment.**
+> Azure RBAC for Kubernetes Authorization scopes a namespace grant to the extension-resource path
+> `<aksResourceId>/namespaces/<namespace>`
+> ([manage-azure-rbac](https://learn.microsoft.com/azure/aks/manage-azure-rbac)). That path is not a
+> deployable ARM resource type, so Bicep has no symbolic reference to target and `scope:` cannot
+> name it. Writing `scope: aks` instead silently produces a **cluster-wide** grant.
+>
+> A cluster-wide `dataActions` grant labelled "namespace-scoped" is worse than no Layer 2 at all,
+> because the operator is told a boundary exists that does not. So:
+>
+> - `infra/bicep/modules/sre-agent-mitigation-role.bicep` creates **only the role definition**, and
+>   outputs `namespaceRoleAssignmentCreatedByTemplate = false` plus the exact required
+>   `namespaceAssignmentScope`.
+> - `scripts/configure-sre-agent-mitigation-guardrails.ps1 -Apply` creates the assignment
+>   idempotently with `az role assignment create --scope <aksId>/namespaces/energy`, then **reads it
+>   back and asserts the scope the service returned** matches exactly.
+> - Any assignment found at the bare cluster scope is reported as `CLUSTER-WIDE GRANT` and fails;
+>   any other namespace is reported as `OUT-OF-SCOPE GRANT` and fails. Neither is ever reported as
+>   namespace enforcement.
+> - `scripts/validate-sre-agent-mitigation-guardrails.ps1` and
+>   `tests/static/test_review_mode_mitigation_rbac.py` fail the build if a `roleAssignments`
+>   resource referencing the dataActions role reappears in the template.
+
+Layer 2 is **off by default** because enabling Entra integration changes how `az aks get-credentials`
 issues operator kubeconfigs, and this repository has no live environment in which to validate that
 change (§10). `scripts/deploy.ps1` already switches to `--admin` when the flag is on.
 
@@ -281,15 +304,18 @@ string. This closes an argument-smuggling class where a command carrying the req
 `-n energy` and `--replicas=N` tokens could also carry `--server`, `--token`, `--kubeconfig`,
 `--as system:masters`, `--all-namespaces`, or a second `deployment/...` target.
 
-### 8.1 Findings from the adversarial security review
+### 8.1 Findings from adversarial security and peer review
 
-Three issues were found by security review of this change and fixed before merge. Each has a
-named regression test:
+Six issues were found by review of this change and fixed before merge. Each has a named
+regression test:
 
 | Finding | Severity | Fix |
 | --- | --- | --- |
 | Lookahead-based command normalisation discarded extra arguments, so a smuggled command normalised into an allowlisted string | High | Replaced with a strict tokeniser (`mitigationLifecycle.test.ts`: "rejects argument-smuggling payloads…", "does not let a smuggled command reach verification-passed") |
+| Layer 2's Kubernetes `dataActions` assignment was written at `scope: aks` — a **cluster-wide** grant — while code, docs and script all claimed `<aksId>/namespaces/energy` | High | Template no longer creates the assignment; the configure script creates it at the exact namespace scope and verifies the returned scope (`tests/static/test_review_mode_mitigation_rbac.py`, validator guard) |
 | The run-mode gate selected its snapshot row with an OR over `IncidentId`/`ThreadId`, so the autonomy level could be read from a different agent thread of the same incident | Medium | `correlateRawRow()` applies the same strict equality used everywhere else (`mitigation.test.ts`: "reads the run mode only from a strictly correlated snapshot row") |
+| `agent-tool-execution` filtered only on `threadId`, so an incident-only correlation degraded to a workspace-wide top-N query that could drop the incident's tool rows | Medium | The template and its allowed parameters now accept `incidentId` too (`SreAgentEvidenceService.test.ts`, `mitigation.test.ts`: "filters tool execution by incidentId when no threadId is known") |
+| Out-of-scope `ToolEnd` rows were excluded from the security scan, so a disallowed operation that **succeeded** produced no finding — quieter than a mere attempt | Medium | All non-allowlisted rows are flagged regardless of event type, deduped by `CallId`/`SpanId` (`mitigationLifecycle.test.ts`: "flags an out-of-scope call represented ONLY by a successful ToolEnd") |
 | Redaction of space-separated CLI secret flags stopped at the first space inside quotes, leaking the remainder of a multi-word secret | Medium | The value pattern now consumes to the matching closing quote (`mitigationLifecycle.test.ts`: "redacts quoted secret values that contain spaces") |
 
 ---

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -111,9 +111,15 @@ param aksApiServerAuthorizedIpRanges array = []
 @description('Enable ACR admin user account (not required for default deploy path)')
 param acrAdminUserEnabled bool = false
 
-@description('SRE Agent access level. Low = Reader + Log Analytics Reader (diagnosis only, default for external/unknown contexts). High = adds Contributor at resource-group scope (required for remediation demos). Set explicitly in main.bicepparam for internal demo runs.')
-@allowed(['High', 'Low'])
+@description('SRE Agent access level. Low = Reader + Log Analytics Reader (diagnosis only, default for external/unknown contexts). High = adds Contributor at resource-group scope (legacy broad remediation demos). Mitigation = Reader + Log Analytics Reader plus the narrow AKS-scoped custom role required by the issue #80 Review-mode mitigation path, with NO Contributor. Set explicitly in main.bicepparam for internal demo runs.')
+@allowed(['High', 'Low', 'Mitigation'])
 param sreAgentAccessLevel string = 'Low'
+
+@description('Deploy the least-privilege custom role for the issue #80 Review-mode mitigation path (docs/REVIEW-MODE-MITIGATION.md §3). Grants only managedClusters/read + listClusterUserCredential/action at the AKS resource scope.')
+param enableReviewModeMitigation bool = false
+
+@description('Opt in to Azure RBAC for Kubernetes so the mitigation boundary is enforced by the API server at namespace scope rather than only by the tool access policy (docs/REVIEW-MODE-MITIGATION.md §3 Layer 2). Off by default because enabling managed Entra integration changes how operators obtain a kubeconfig.')
+param enableAgentKubernetesRbac bool = false
 
 @description('Connect Azure Monitor as the SRE Agent incident platform via the documented Microsoft.App/agents incidentManagementConfiguration ARM property (issue #76). This is additive: the Action Group -> Mission Control webhook fallback (deployActionGroup/incidentWebhookServiceUri) keeps working whether or not this is enabled. Set to "None" to leave the agent disconnected from any incident platform.')
 @allowed(['AzureMonitor', 'None'])
@@ -272,6 +278,24 @@ module sreAgent 'modules/sre-agent.bicep' = if (deploySreAgent) {
   }
 }
 
+// Least-privilege custom role for the Review-mode mitigation path (issue #80).
+// Deliberately separate from the accessLevel matrix so the narrow AKS-scoped grant is auditable
+// on its own and can be deployed without ever assigning Contributor.
+module sreAgentMitigationRole 'modules/sre-agent-mitigation-role.bicep' = if (deploySreAgent && enableReviewModeMitigation) {
+  scope: resourceGroup
+  name: 'deploy-sre-agent-mitigation-role'
+  params: {
+    aksClusterName: names.aks
+    principalId: sreAgent!.outputs.managedIdentityPrincipalId
+    uniqueSuffix: uniqueSuffix
+    enableKubernetesDataActions: enableAgentKubernetesRbac
+    namespaceName: 'energy'
+  }
+  dependsOn: [
+    aks
+  ]
+}
+
 // Observability Stack - Managed Grafana and Prometheus (optional)
 module observability 'modules/observability.bicep' = if (deployObservability) {
   scope: resourceGroup
@@ -355,4 +379,9 @@ output sreAgentManagedIdentityId string = deploySreAgent ? sreAgent!.outputs.man
 output sreAgentManagedIdentityPrincipalId string = deploySreAgent ? sreAgent!.outputs.managedIdentityPrincipalId : ''
 output sreAgentIncidentPlatformType string = deploySreAgent ? sreAgent!.outputs.incidentPlatformType : 'None'
 output sreAgentIncidentPlatformConfigured bool = deploySreAgent ? sreAgent!.outputs.incidentPlatformConfigured : false
+output sreAgentContributorAssigned bool = deploySreAgent ? sreAgent!.outputs.contributorAssigned : false
+output sreAgentActionMode string = deploySreAgent ? sreAgent!.outputs.actionConfigurationMode : 'None'
+output reviewModeMitigationEnabled bool = deploySreAgent && enableReviewModeMitigation
+output reviewModeMitigationRoleId string = (deploySreAgent && enableReviewModeMitigation) ? sreAgentMitigationRole!.outputs.mitigationRoleDefinitionId : ''
+output agentKubernetesRbacEnabled bool = deploySreAgent && enableReviewModeMitigation && enableAgentKubernetesRbac
 output activityLogDiagnosticSettingName string = activityLogDiagnostics.outputs.diagnosticSettingName

--- a/infra/bicep/modules/sre-agent-mitigation-role.bicep
+++ b/infra/bicep/modules/sre-agent-mitigation-role.bicep
@@ -1,0 +1,129 @@
+// =============================================================================
+// SRE Agent — Energy Grid Mitigation Operator custom role (issue #80)
+// =============================================================================
+// Replaces broad Contributor for the Review-mode mitigation path documented in
+// docs/REVIEW-MODE-MITIGATION.md §3 (Layer 3).
+//
+// The agent needs exactly two control-plane operations to run the one allowlisted
+// kubectl action: read the cluster, and obtain a cluster-user kubeconfig. Nothing else.
+// Scoped to the AKS resource, NOT the resource group.
+//
+// The optional dataActions block (Layer 2) is only meaningful when the cluster has
+// managed Entra integration with Azure RBAC enabled. Azure RBAC for Kubernetes cannot
+// filter by resource name, so the namespace-scoped assignment is the narrowest boundary
+// Azure supports here.
+// Docs: https://learn.microsoft.com/azure/aks/manage-azure-rbac
+// =============================================================================
+
+targetScope = 'resourceGroup'
+
+@description('Name of the AKS cluster the agent may obtain credentials for.')
+param aksClusterName string
+
+@description('Principal ID of the SRE Agent user-assigned managed identity.')
+param principalId string
+
+@description('Unique suffix used to keep the custom role definition name unique per deployment.')
+param uniqueSuffix string
+
+@description('When true, also grant namespace-scoped Kubernetes dataActions. Requires the cluster to have managed Entra integration with Azure RBAC enabled.')
+param enableKubernetesDataActions bool = false
+
+@description('Kubernetes namespace the agent may act within when enableKubernetesDataActions is true.')
+param namespaceName string = 'energy'
+
+resource aks 'Microsoft.ContainerService/managedClusters@2024-02-01' existing = {
+  name: aksClusterName
+}
+
+// -----------------------------------------------------------------------------
+// Control-plane custom role: read + cluster-user credential ONLY.
+// Deliberately excludes listClusterAdminCredential, runCommand, write, and delete.
+// -----------------------------------------------------------------------------
+resource mitigationRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(aks.id, 'sre-agent-mitigation-operator', uniqueSuffix)
+  properties: {
+    roleName: 'SRE Agent Energy Grid Mitigation Operator (${uniqueSuffix})'
+    description: 'Least-privilege role for the Energy Grid Review-mode mitigation path (issue #80): read the AKS cluster and obtain a cluster-user kubeconfig. Grants no write, no admin credential, and no runCommand.'
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: [
+          'Microsoft.ContainerService/managedClusters/read'
+          'Microsoft.ContainerService/managedClusters/listClusterUserCredential/action'
+        ]
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      aks.id
+    ]
+  }
+}
+
+resource mitigationRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(aks.id, principalId, mitigationRole.id)
+  scope: aks
+  properties: {
+    roleDefinitionId: mitigationRole.id
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Layer 2 (opt-in): namespace-scoped Kubernetes dataActions enforced by the API server.
+// -----------------------------------------------------------------------------
+resource namespaceRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (enableKubernetesDataActions) {
+  name: guid(aks.id, 'sre-agent-mitigation-k8s', uniqueSuffix)
+  properties: {
+    roleName: 'SRE Agent Energy Grid Deployment Scaler (${uniqueSuffix})'
+    description: 'Namespace-scoped Kubernetes dataActions permitting the agent to read and scale Deployments in a single namespace. Grants no pod exec, no secret access, and no delete.'
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: []
+        notActions: []
+        dataActions: [
+          'Microsoft.ContainerService/managedClusters/apps/deployments/read'
+          'Microsoft.ContainerService/managedClusters/apps/deployments/write'
+          'Microsoft.ContainerService/managedClusters/pods/read'
+          'Microsoft.ContainerService/managedClusters/services/read'
+          'Microsoft.ContainerService/managedClusters/events/read'
+        ]
+        notDataActions: [
+          'Microsoft.ContainerService/managedClusters/secrets/read'
+          'Microsoft.ContainerService/managedClusters/pods/exec/action'
+        ]
+      }
+    ]
+    assignableScopes: [
+      aks.id
+    ]
+  }
+}
+
+resource namespaceRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (enableKubernetesDataActions) {
+  name: guid(aks.id, principalId, 'sre-agent-mitigation-k8s', namespaceName)
+  scope: aks
+  properties: {
+    // Namespace scoping is expressed via the assignment scope path documented for Azure RBAC
+    // for Kubernetes Authorization. The deployment script narrows this to
+    // <aksResourceId>/namespaces/<namespaceName>; see configure-sre-agent-mitigation-guardrails.ps1.
+    roleDefinitionId: namespaceRole!.id
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+    description: 'Namespace-scoped to ${namespaceName} by scripts/configure-sre-agent-mitigation-guardrails.ps1.'
+  }
+}
+
+// =============================================================================
+// OUTPUTS
+// =============================================================================
+
+output mitigationRoleDefinitionId string = mitigationRole.id
+output mitigationRoleName string = mitigationRole.properties.roleName
+output kubernetesDataActionsEnabled bool = enableKubernetesDataActions
+output namespaceRoleDefinitionId string = enableKubernetesDataActions ? namespaceRole!.id : ''

--- a/infra/bicep/modules/sre-agent-mitigation-role.bicep
+++ b/infra/bicep/modules/sre-agent-mitigation-role.bicep
@@ -75,12 +75,30 @@ resource mitigationRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-
 
 // -----------------------------------------------------------------------------
 // Layer 2 (opt-in): namespace-scoped Kubernetes dataActions enforced by the API server.
+//
+// IMPORTANT -- why the role DEFINITION is here but the role ASSIGNMENT is not.
+//
+// Azure RBAC for Kubernetes Authorization scopes a namespace grant to the extension-resource path
+// `<aksResourceId>/namespaces/<namespace>` (https://learn.microsoft.com/azure/aks/manage-azure-rbac).
+// That path is NOT an ARM resource this module can target: Bicep's `scope:` accepts a resource
+// symbolic reference or an existing-resource reference, and `Microsoft.ContainerService/
+// managedClusters/namespaces` is not a deployable ARM resource type, so there is no symbolic
+// reference to point at. Writing `scope: aks` instead silently produces a CLUSTER-WIDE grant.
+//
+// A cluster-wide dataActions grant labelled "namespace-scoped" is worse than no Layer 2 at all,
+// because the operator is told the API server is enforcing a boundary that does not exist. So this
+// module deliberately creates ONLY the role definition, and
+// scripts/configure-sre-agent-mitigation-guardrails.ps1 creates the assignment at the exact
+// namespace scope via `az role assignment create --scope <aksId>/namespaces/energy`, then reads the
+// assignment back and asserts the returned scope matches exactly.
+//
+// See docs/REVIEW-MODE-MITIGATION.md section 3 (Layer 2).
 // -----------------------------------------------------------------------------
 resource namespaceRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (enableKubernetesDataActions) {
   name: guid(aks.id, 'sre-agent-mitigation-k8s', uniqueSuffix)
   properties: {
     roleName: 'SRE Agent Energy Grid Deployment Scaler (${uniqueSuffix})'
-    description: 'Namespace-scoped Kubernetes dataActions permitting the agent to read and scale Deployments in a single namespace. Grants no pod exec, no secret access, and no delete.'
+    description: 'Kubernetes dataActions permitting the agent to read and scale Deployments. Intended to be ASSIGNED ONLY at <aksResourceId>/namespaces/${namespaceName} by scripts/configure-sre-agent-mitigation-guardrails.ps1. Grants no pod exec, no secret access, and no delete.'
     type: 'CustomRole'
     permissions: [
       {
@@ -99,25 +117,18 @@ resource namespaceRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if
         ]
       }
     ]
+    // Assignable at the cluster so the namespace child scope beneath it is assignable. The
+    // ASSIGNMENT itself is created at the namespace path, never here.
     assignableScopes: [
       aks.id
     ]
   }
 }
 
-resource namespaceRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (enableKubernetesDataActions) {
-  name: guid(aks.id, principalId, 'sre-agent-mitigation-k8s', namespaceName)
-  scope: aks
-  properties: {
-    // Namespace scoping is expressed via the assignment scope path documented for Azure RBAC
-    // for Kubernetes Authorization. The deployment script narrows this to
-    // <aksResourceId>/namespaces/<namespaceName>; see configure-sre-agent-mitigation-guardrails.ps1.
-    roleDefinitionId: namespaceRole!.id
-    principalId: principalId
-    principalType: 'ServicePrincipal'
-    description: 'Namespace-scoped to ${namespaceName} by scripts/configure-sre-agent-mitigation-guardrails.ps1.'
-  }
-}
+// NOTE: there is intentionally NO Microsoft.Authorization/roleAssignments resource for
+// `namespaceRole`. See the comment block above. Do not add one at `scope: aks` -- that is a
+// cluster-wide grant, and validate-sre-agent-mitigation-guardrails.ps1 fails the build if one
+// reappears.
 
 // =============================================================================
 // OUTPUTS
@@ -127,3 +138,12 @@ output mitigationRoleDefinitionId string = mitigationRole.id
 output mitigationRoleName string = mitigationRole.properties.roleName
 output kubernetesDataActionsEnabled bool = enableKubernetesDataActions
 output namespaceRoleDefinitionId string = enableKubernetesDataActions ? namespaceRole!.id : ''
+output namespaceRoleName string = enableKubernetesDataActions ? namespaceRole!.properties.roleName : ''
+
+// The EXACT scope at which the namespace role must be assigned. Emitted so the configure script
+// and the validator both compare against one authoritative value instead of rebuilding the path.
+output namespaceAssignmentScope string = enableKubernetesDataActions ? '${aks.id}/namespaces/${namespaceName}' : ''
+
+// Explicit, machine-readable statement that this module does NOT create the Layer 2 assignment.
+// docs/REVIEW-MODE-MITIGATION.md section 3 explains why, and the configure script creates it.
+output namespaceRoleAssignmentCreatedByTemplate bool = false

--- a/infra/bicep/modules/sre-agent.bicep
+++ b/infra/bicep/modules/sre-agent.bicep
@@ -15,8 +15,8 @@ param location string
 @description('Tags to apply to resources')
 param tags object
 
-@description('The access level for the SRE Agent (High = Reader + Contributor + Log Analytics Reader, Low = Reader + Log Analytics Reader)')
-@allowed(['High', 'Low'])
+@description('The access level for the SRE Agent. High = Reader + Contributor + Log Analytics Reader (broad, legacy lab flows). Low = Reader + Log Analytics Reader (diagnosis only). Mitigation = Reader + Log Analytics Reader ONLY at resource-group scope, with the narrow AKS-scoped custom role supplied separately by modules/sre-agent-mitigation-role.bicep (issue #80, docs/REVIEW-MODE-MITIGATION.md §3 Layer 3). Mitigation deliberately grants NO Contributor.')
+@allowed(['High', 'Low', 'Mitigation'])
 param accessLevel string = 'High'
 
 @description('Application Insights App ID')
@@ -48,12 +48,25 @@ var roleDefinitions = {
     '92aaf0da-9dab-42b6-94a3-d43ce8d16293' // Log Analytics Reader
     'acdd72a7-3385-48ef-bd42-f606fba81ae7' // Reader
   ]
+  // Issue #80: the Review-mode mitigation path must NOT hold Contributor. The single write it
+  // needs is granted by the AKS-scoped custom role in modules/sre-agent-mitigation-role.bicep.
+  Mitigation: [
+    '92aaf0da-9dab-42b6-94a3-d43ce8d16293' // Log Analytics Reader
+    'acdd72a7-3385-48ef-bd42-f606fba81ae7' // Reader
+  ]
   High: [
     '92aaf0da-9dab-42b6-94a3-d43ce8d16293' // Log Analytics Reader
     'acdd72a7-3385-48ef-bd42-f606fba81ae7' // Reader
     'b24988ac-6180-42a0-ab88-20f7382dd24c' // Contributor
   ]
 }
+
+// The ARM actionConfiguration.accessLevel enum only accepts High/Low. 'Mitigation' is this repo's
+// own selector for a least-privilege Azure RBAC posture; the agent is still permitted to ATTEMPT
+// write actions (accessLevel High) because what it can actually do is bounded by its assigned
+// roles -- "The agent's actions are constrained only by the permissions assigned to its managed
+// identity" (https://learn.microsoft.com/azure/sre-agent/execute-mitigations).
+var actionAccessLevel = accessLevel == 'Low' ? 'Low' : 'High'
 
 // Monitoring Contributor is required in addition to the accessLevel matrix above so the agent's
 // managed identity can see and acknowledge Azure Monitor alerts once incidentPlatform = 'AzureMonitor'.
@@ -107,7 +120,7 @@ var baseAgentProperties = {
     managedResources: []
   }
   actionConfiguration: {
-    accessLevel: accessLevel
+    accessLevel: actionAccessLevel
     identity: managedIdentity.id
     mode: 'Review'
   }
@@ -171,3 +184,9 @@ output managedIdentityId string = managedIdentity.id
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId
 output incidentPlatformType string = incidentPlatform
 output incidentPlatformConfigured bool = incidentPlatform == 'AzureMonitor'
+output accessLevelSelector string = accessLevel
+output contributorAssigned bool = accessLevel == 'High'
+// Agent-level default run mode. Issue #80 requires this to remain 'Review'; per-response-plan
+// autonomy still has to be observed at runtime, because Microsoft documents the response-plan
+// default as Autonomous (https://learn.microsoft.com/azure/sre-agent/run-modes).
+output actionConfigurationMode string = 'Review'

--- a/infra/sre-agent/tool-access-policy.json
+++ b/infra/sre-agent/tool-access-policy.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://learn.microsoft.com/azure/sre-agent/tool-access-policies",
+  "_comment": [
+    "Global tool access policy for the Energy Grid lab's Review-mode mitigation path (issue #80).",
+    "Apply with scripts/configure-sre-agent-mitigation-guardrails.ps1, which PUTs the `permissions`",
+    "object to /api/v2/agent/settings/global as documented at",
+    "https://learn.microsoft.com/azure/sre-agent/tool-access-policies#global-policies.",
+    "",
+    "Evaluation order is deny -> allow -> ask -> default (Microsoft Learn, same page). Only the",
+    "global scope may deny, so these deny rules cannot be widened by a custom-agent or thread-level",
+    "allow. The single ask pattern pair is the ONLY write action this lab permits, and it is pinned",
+    "to one deployment in one namespace.",
+    "",
+    "Design rationale, blast radius, rollback and verification contract: docs/REVIEW-MODE-MITIGATION.md"
+  ],
+  "permissions": {
+    "deny": [
+      "RunKubectlWriteCommand(kubectl delete *)",
+      "RunKubectlWriteCommand(kubectl exec *)",
+      "RunKubectlWriteCommand(kubectl port-forward *)",
+      "RunKubectlWriteCommand(kubectl cp *)",
+      "RunKubectlWriteCommand(kubectl attach *)",
+      "RunKubectlWriteCommand(kubectl proxy *)",
+      "RunKubectlWriteCommand(kubectl drain *)",
+      "RunKubectlWriteCommand(kubectl cordon *)",
+      "RunKubectlWriteCommand(kubectl taint *)",
+      "RunKubectlWriteCommand(kubectl replace *)",
+      "RunKubectlWriteCommand(kubectl patch *)",
+      "RunKubectlWriteCommand(kubectl apply *)",
+      "RunKubectlWriteCommand(kubectl create *)",
+      "RunKubectlWriteCommand(kubectl edit *)",
+      "RunKubectlWriteCommand(* --all-namespaces *)",
+      "RunKubectlWriteCommand(* -A *)",
+      "RunAzCliWriteCommands",
+      "bash(az * delete *)",
+      "bash(az * remove *)",
+      "bash(az keyvault *)",
+      "bash(az aks command invoke *)",
+      "bash(az role assignment *)",
+      "bash(kubectl delete *)",
+      "bash(kubectl exec *)",
+      "ExecutePythonCode",
+      "RunInTerminal",
+      "RunShellCommand",
+      "GeneratePdfReport"
+    ],
+    "ask": [
+      "RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=1)",
+      "RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=0)"
+    ],
+    "allow": [
+      "RunAzCliReadCommands",
+      "RunKubectlReadCommand(kubectl get *)",
+      "RunKubectlReadCommand(kubectl describe *)",
+      "RunKubectlReadCommand(kubectl logs *)",
+      "RunKubectlReadCommand(kubectl top *)"
+    ]
+  }
+}

--- a/mission-control/backend/src/routes/mitigation.test.ts
+++ b/mission-control/backend/src/routes/mitigation.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Tests for the Review-mode mitigation orchestration and its REST surface (issue #80).
+ *
+ * The central guarantee: a caller can supply correlation identifiers and a query window, and
+ * NOTHING else. Any attempt to assert lifecycle state, approval, execution, or verification is a
+ * 400 -- never a silent drop, and never accepted.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach } from 'node:test';
+import Fastify from 'fastify';
+
+import {
+  ReviewModeMitigationRequestError,
+  ReviewModeMitigationService,
+  buildGuardrails,
+  clearMitigationBaselines,
+  normalizeMitigationRequest,
+  type ReviewModeMitigationDependencies,
+} from '../services/ReviewModeMitigationService.js';
+import { registerMitigationRoutes } from './mitigation.js';
+import { MITIGATION_TARGET } from '../services/sre-agent/mitigationLifecycle.js';
+import type { CustomerImpactResponse, InventoryResponse } from '../types/index.js';
+
+const NOW = new Date('2026-05-01T12:00:00.000Z');
+const T = (offsetSeconds: number) => new Date(NOW.getTime() + offsetSeconds * 1000).toISOString();
+const THREAD_ID = 'thread-aaaabbbb-0000-cccc-1111';
+const INCIDENT_ID = 'INC0PL8K7AL0J';
+
+function inventoryFixture(desiredReplicas: number, readyPods: number): InventoryResponse {
+  return {
+    namespace: 'energy',
+    updatedAt: T(-20),
+    orphanPods: [],
+    services: [],
+    events: [],
+    deployments: [
+      {
+        name: MITIGATION_TARGET.name,
+        namespace: MITIGATION_TARGET.namespace,
+        desiredReplicas,
+        readyPods,
+        runningPods: readyPods,
+        replicas: desiredReplicas,
+        updatedReplicas: desiredReplicas,
+        availableReplicas: readyPods,
+        severity: readyPods > 0 ? 'healthy' : 'critical',
+        status: readyPods > 0 ? 'healthy' : 'critical',
+        reason: readyPods > 0 ? '' : 'ScaledToZero',
+        restarts: 0,
+        age: '5m',
+        updatedAt: T(-20),
+        labels: {},
+        annotations: {},
+        selectorLabels: {},
+        pods: [],
+        services: [],
+        endpointReadiness: [
+          { serviceName: MITIGATION_TARGET.name, ready: readyPods, notReady: 0, total: Math.max(readyPods, 1), addresses: [] },
+        ],
+        recentEvents: [],
+      },
+    ],
+  } as InventoryResponse;
+}
+
+function impactFixture(healthy: boolean): CustomerImpactResponse {
+  return {
+    journey: 'meter-ingest',
+    status: healthy ? 'healthy' : 'critical',
+    kubernetesDataStatus: 'available',
+    evidenceSources: ['synthetic'],
+    affectedStage: 'ingest',
+    recoveryCondition: 'success rate restored',
+    collectedAt: T(-20),
+    telemetry: {
+      dataStatus: 'available',
+      source: 'synthetic meter ingest',
+      runCount: 20,
+      successCount: healthy ? 20 : 2,
+      failureCount: healthy ? 0 : 18,
+      successRatePct: healthy ? 100 : 10,
+      lastSuccess: T(-20),
+      lastSuccessAgeSeconds: 20,
+    },
+  } as CustomerImpactResponse;
+}
+
+interface FixtureRows {
+  incident?: Record<string, unknown>[];
+  approval?: Record<string, unknown>[];
+  tool?: Record<string, unknown>[];
+  azCli?: Record<string, unknown>[];
+}
+
+function makeDependencies(
+  rows: FixtureRows,
+  inventory: InventoryResponse | undefined,
+  impact: CustomerImpactResponse | undefined,
+  before?: ReturnType<NonNullable<ReviewModeMitigationDependencies['resourceStateBefore']>>,
+): ReviewModeMitigationDependencies & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    now: () => NOW,
+    resourceStateBefore: before ? () => before : undefined,
+    evidence: {
+      async execute(templateName: string, params: Record<string, unknown>) {
+        calls.push(`${templateName}:${JSON.stringify(params)}`);
+        const map: Record<string, Record<string, unknown>[]> = {
+          'incident-activity-snapshot': rows.incident ?? [],
+          'approval-decisions': rows.approval ?? [],
+          'agent-tool-execution': rows.tool ?? [],
+          'agent-az-cli-execution': rows.azCli ?? [],
+        };
+        const selected = map[templateName] ?? [];
+        return { templateName, rowCount: selected.length, rows: selected } as never;
+      },
+    },
+    kube: {
+      async getInventory() {
+        if (!inventory) throw new Error('kubectl unavailable');
+        return inventory;
+      },
+    },
+    customerImpact: {
+      async getCustomerImpact() {
+        if (!impact) throw new Error('log analytics unavailable');
+        return impact;
+      },
+    },
+  };
+}
+
+const reviewIncidentRow = {
+  timestamp: T(-600),
+  IncidentId: INCIDENT_ID,
+  ThreadId: THREAD_ID,
+  AgentAutonomyLevel: 'review',
+  IncidentMitigatedByAgent: 'False',
+};
+
+beforeEach(() => clearMitigationBaselines());
+
+// -----------------------------------------------------------------------------
+// Request validation
+// -----------------------------------------------------------------------------
+
+describe('mitigation request validation', () => {
+  it('accepts only observed correlation identifiers and a window', () => {
+    const request = normalizeMitigationRequest({ threadId: THREAD_ID, incidentId: INCIDENT_ID, minutes: 30 });
+    assert.deepEqual(request, { threadId: THREAD_ID, incidentId: INCIDENT_ID, minutes: 30 });
+  });
+
+  it('rejects forged lifecycle assertions rather than dropping them silently', () => {
+    for (const forged of [
+      { state: 'verification-passed' },
+      { approval: { outcome: 'approved' } },
+      { execution: { completedAt: T(0) } },
+      { verification: { allProbesPassed: true } },
+      { incidentResolved: true },
+      { probes: [] },
+      { resourceStateAfter: {} },
+      { effectiveRunMode: 'review' },
+    ]) {
+      assert.throws(
+        () => normalizeMitigationRequest({ threadId: THREAD_ID, ...forged }),
+        (error: unknown) => error instanceof ReviewModeMitigationRequestError && /Unknown request field/.test((error as Error).message),
+        `expected rejection for ${JSON.stringify(forged)}`,
+      );
+    }
+  });
+
+  it('rejects malformed identifiers and out-of-range windows', () => {
+    assert.throws(() => normalizeMitigationRequest({ threadId: 'bad id with spaces' }), ReviewModeMitigationRequestError);
+    assert.throws(() => normalizeMitigationRequest({ threadId: 'x'.repeat(200) }), ReviewModeMitigationRequestError);
+    assert.throws(() => normalizeMitigationRequest({ minutes: 0 }), ReviewModeMitigationRequestError);
+    assert.throws(() => normalizeMitigationRequest({ minutes: 99999 }), ReviewModeMitigationRequestError);
+    assert.throws(() => normalizeMitigationRequest([1, 2, 3]), ReviewModeMitigationRequestError);
+  });
+
+  it('treats an empty request as valid but correlation-free', () => {
+    assert.deepEqual(normalizeMitigationRequest({}), {});
+    assert.deepEqual(normalizeMitigationRequest(undefined), {});
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Orchestration
+// -----------------------------------------------------------------------------
+
+describe('mitigation orchestration', () => {
+  it('passes only template-supported parameters to each evidence template', async () => {
+    const deps = makeDependencies({ incident: [reviewIncidentRow] }, inventoryFixture(0, 0), impactFixture(false));
+    await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+
+    const toolCall = deps.calls.find(call => call.startsWith('agent-tool-execution'))!;
+    assert.ok(!toolCall.includes('incidentId'), 'agent-tool-execution does not filter by incidentId');
+    const snapshotCall = deps.calls.find(call => call.startsWith('incident-activity-snapshot'))!;
+    assert.ok(!snapshotCall.includes('threadId'), 'incident-activity-snapshot does not filter by threadId');
+  });
+
+  it('blocks the flow when the observed run mode is autonomous', async () => {
+    const deps = makeDependencies(
+      { incident: [{ ...reviewIncidentRow, AgentAutonomyLevel: 'autonomous' }] },
+      inventoryFixture(1, 1),
+      impactFixture(true),
+    );
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+    assert.equal(result.evidence.state, 'blocked-run-mode');
+    assert.equal(result.evidence.incidentResolved, false);
+  });
+
+  it('reads the run mode only from a strictly correlated snapshot row', async () => {
+    // Security regression: an OR over IncidentId/ThreadId short-circuited on IncidentId, so the
+    // autonomy level could be read from a DIFFERENT agent thread of the same incident -- which
+    // would present an ungated autonomous write as a human-approved Review-mode mitigation.
+    const reviewThreadRow = { ...reviewIncidentRow, ThreadId: 'thread-review-0000', AgentAutonomyLevel: 'review' };
+    const autonomousThreadRow = { ...reviewIncidentRow, ThreadId: THREAD_ID, AgentAutonomyLevel: 'autonomous' };
+
+    const deps = makeDependencies(
+      { incident: [reviewThreadRow, autonomousThreadRow] },
+      inventoryFixture(1, 1),
+      impactFixture(true),
+    );
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({
+      threadId: THREAD_ID,
+      incidentId: INCIDENT_ID,
+    });
+
+    assert.equal(result.evidence.effectiveRunMode, 'autonomous');
+    assert.equal(result.evidence.state, 'blocked-run-mode');
+    assert.equal(result.evidence.incidentResolved, false);
+  });
+
+  it('blocks when no snapshot row strictly correlates', async () => {
+    const foreign = { ...reviewIncidentRow, ThreadId: 'thread-other', IncidentId: 'INC-OTHER' };
+    const deps = makeDependencies({ incident: [foreign] }, inventoryFixture(1, 1), impactFixture(true));
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID });
+    assert.equal(result.evidence.effectiveRunMode, 'unknown');
+    assert.equal(result.evidence.state, 'blocked-run-mode');
+  });
+
+  it('does not resolve the incident when Kubernetes and telemetry are unavailable', async () => {
+    const deps = makeDependencies({ incident: [reviewIncidentRow] }, undefined, undefined);
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+    assert.equal(result.evidence.incidentResolved, false);
+    assert.ok(result.evidenceSources.some(source => source.includes('unavailable')));
+    assert.ok(result.evidence.verification.probes.every(probe => probe.status !== 'pass'));
+  });
+
+  it('derives verification-passed from a complete observed chain', async () => {
+    const approval = {
+      timestamp: T(-300),
+      ThreadId: THREAD_ID,
+      IncidentId: INCIDENT_ID,
+      RawDimensions: { Decision: 'Approved' },
+    };
+    const command = JSON.stringify({ command: 'kubectl scale deployment/mongodb -n energy --replicas=1' });
+    const deps = makeDependencies(
+      {
+        incident: [reviewIncidentRow],
+        approval: [approval],
+        tool: [
+          { timestamp: T(-250), EventType: 'ToolStart', ToolName: 'RunKubectlWriteCommand', ToolInput: command, ThreadId: THREAD_ID, CallId: 'c1' },
+          { timestamp: T(-200), EventType: 'ToolEnd', ToolName: 'RunKubectlWriteCommand', ToolInput: command, ToolOutput: 'deployment.apps/mongodb scaled', ThreadId: THREAD_ID, CallId: 'c2' },
+        ],
+      },
+      inventoryFixture(1, 1),
+      impactFixture(true),
+      {
+        source: 'fixture',
+        resource: MITIGATION_TARGET.resource,
+        observedAt: T(-400),
+        specReplicas: 0,
+        readyReplicas: 0,
+        evidencePointer: 'fixture://before',
+      },
+    );
+
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+    assert.equal(result.evidence.state, 'verification-passed');
+    assert.equal(result.evidence.incidentResolved, true);
+    assert.equal(result.evidence.verification.probes.length, 3);
+  });
+
+  it('derives denied from an observed rejection plus an unchanged before/after pair', async () => {
+    const deps = makeDependencies(
+      {
+        incident: [reviewIncidentRow],
+        approval: [{ timestamp: T(-300), ThreadId: THREAD_ID, IncidentId: INCIDENT_ID, RawDimensions: { Decision: 'Rejected' } }],
+      },
+      inventoryFixture(0, 0),
+      impactFixture(false),
+      {
+        source: 'fixture',
+        resource: MITIGATION_TARGET.resource,
+        observedAt: T(-400),
+        specReplicas: 0,
+        readyReplicas: 0,
+        evidencePointer: 'fixture://before',
+      },
+    );
+
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+    assert.equal(result.evidence.state, 'denied');
+    assert.equal(result.evidence.resourceState?.mutation, 'unchanged');
+    assert.equal(result.evidence.incidentResolved, false);
+  });
+
+  it('reports denied-with-unverified-state when no earlier observation exists', async () => {
+    const deps = makeDependencies(
+      {
+        incident: [reviewIncidentRow],
+        approval: [{ timestamp: T(-300), ThreadId: THREAD_ID, IncidentId: INCIDENT_ID, RawDimensions: { Decision: 'Rejected' } }],
+      },
+      inventoryFixture(0, 0),
+      impactFixture(false),
+    );
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+    assert.equal(result.evidence.state, 'denied-with-unverified-state');
+  });
+
+  it('does not mask a post-deny mutation across successive polls', async () => {
+    // Regression for the sliding-window bug: poll while the resource is still 0, let a rejection be
+    // recorded, then poll again after the resource has changed. The second poll must NOT compare
+    // two post-decision readings and report a clean `denied`.
+    const rejection = { timestamp: T(-300), ThreadId: THREAD_ID, IncidentId: INCIDENT_ID, RawDimensions: { Decision: 'Rejected' } };
+
+    // First poll: pre-decision reading (replicas 0) enters the history.
+    const before = makeDependencies({ incident: [reviewIncidentRow] }, inventoryFixture(0, 0), impactFixture(false));
+    before.now = () => new Date(NOW.getTime() - 400_000);
+    const service = new ReviewModeMitigationService(before);
+    await service.getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+
+    // Later poll: the resource has been mutated to 1 despite the rejection.
+    const after = makeDependencies({ incident: [reviewIncidentRow], approval: [rejection] }, inventoryFixture(1, 1), impactFixture(true));
+    const mutated = new ReviewModeMitigationService(after);
+    const result = await mutated.getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
+
+    assert.notEqual(result.evidence.state, 'denied');
+    assert.equal(result.evidence.incidentResolved, false);
+  });
+
+  it('handles concurrent polls without cross-contaminating baselines', async () => {
+    const service = new ReviewModeMitigationService(
+      makeDependencies({ incident: [reviewIncidentRow] }, inventoryFixture(0, 0), impactFixture(false)),
+    );
+    const results = await Promise.all([
+      service.getMitigationEvidence({ threadId: THREAD_ID }),
+      service.getMitigationEvidence({ threadId: 'thread-other-1111' }),
+      service.getMitigationEvidence({ incidentId: INCIDENT_ID }),
+    ]);
+    assert.equal(results.length, 3);
+    assert.ok(results.every(result => result.evidence.incidentResolved === false));
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Guardrail disclosure
+// -----------------------------------------------------------------------------
+
+describe('guardrail disclosure', () => {
+  it('always discloses the demo-only permission breadth and the read-only approval surface', () => {
+    const guardrails = buildGuardrails();
+    assert.ok(guardrails.disclosures.some(item => /DEMO-ONLY PERMISSION BREADTH/.test(item)));
+    assert.ok(guardrails.disclosures.some(item => /READ-ONLY for approval/.test(item)));
+    assert.ok(guardrails.disclosures.some(item => /does not trigger the native Review-mode/i.test(item)));
+    assert.equal(guardrails.targetResource, MITIGATION_TARGET.resource);
+    assert.equal(guardrails.allowlistedCommands.length, 2);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// REST surface
+// -----------------------------------------------------------------------------
+
+describe('mitigation routes', () => {
+  async function buildApp(deps: ReviewModeMitigationDependencies) {
+    const app = Fastify();
+    registerMitigationRoutes(app, new ReviewModeMitigationService(deps));
+    await app.ready();
+    return app;
+  }
+
+  it('exposes the guardrail contract and never advertises a local approval control', async () => {
+    const app = await buildApp(makeDependencies({}, inventoryFixture(0, 0), impactFixture(false)));
+    const response = await app.inject({ method: 'GET', url: '/api/mitigation/guardrails' });
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.approvalSurface.missionControlCanApprove, false);
+    assert.equal(body.designDocument, 'docs/REVIEW-MODE-MITIGATION.md');
+    await app.close();
+  });
+
+  it('rejects forged lifecycle fields with 400', async () => {
+    const app = await buildApp(makeDependencies({}, inventoryFixture(0, 0), impactFixture(false)));
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mitigation/evidence',
+      payload: { threadId: THREAD_ID, state: 'verification-passed', incidentResolved: true },
+    });
+    assert.equal(response.statusCode, 400);
+    assert.match(response.json().error, /Unknown request field/);
+    await app.close();
+  });
+
+  it('returns derived evidence for a valid query', async () => {
+    const app = await buildApp(makeDependencies({ incident: [reviewIncidentRow] }, inventoryFixture(0, 0), impactFixture(false)));
+    const response = await app.inject({ method: 'GET', url: `/api/mitigation/evidence?threadId=${THREAD_ID}&incidentId=${INCIDENT_ID}` });
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.scenario, 'MongoDBDown');
+    assert.equal(body.evidence.incidentResolved, false);
+    assert.ok(Array.isArray(body.guardrails.disclosures));
+    await app.close();
+  });
+
+  it('rejects an invalid identifier in the query string', async () => {
+    const app = await buildApp(makeDependencies({}, inventoryFixture(0, 0), impactFixture(false)));
+    const response = await app.inject({ method: 'GET', url: '/api/mitigation/evidence?threadId=has%20spaces' });
+    assert.equal(response.statusCode, 400);
+    await app.close();
+  });
+});

--- a/mission-control/backend/src/routes/mitigation.test.ts
+++ b/mission-control/backend/src/routes/mitigation.test.ts
@@ -194,10 +194,59 @@ describe('mitigation orchestration', () => {
     const deps = makeDependencies({ incident: [reviewIncidentRow] }, inventoryFixture(0, 0), impactFixture(false));
     await new ReviewModeMitigationService(deps).getMitigationEvidence({ threadId: THREAD_ID, incidentId: INCIDENT_ID });
 
+    // agent-tool-execution filters by BOTH identifiers so an incident-only correlation cannot
+    // degrade into a workspace-wide top-N query.
     const toolCall = deps.calls.find(call => call.startsWith('agent-tool-execution'))!;
-    assert.ok(!toolCall.includes('incidentId'), 'agent-tool-execution does not filter by incidentId');
+    assert.ok(toolCall.includes('incidentId'), 'agent-tool-execution must filter by incidentId when available');
+    assert.ok(toolCall.includes('threadId'), 'agent-tool-execution must filter by threadId when available');
+
     const snapshotCall = deps.calls.find(call => call.startsWith('incident-activity-snapshot'))!;
     assert.ok(!snapshotCall.includes('threadId'), 'incident-activity-snapshot does not filter by threadId');
+  });
+
+  it('filters tool execution by incidentId when no threadId is known', async () => {
+    // Regression: the primary UI path can supply an incidentId without a threadId.
+    const deps = makeDependencies({ incident: [reviewIncidentRow] }, inventoryFixture(0, 0), impactFixture(false));
+    await new ReviewModeMitigationService(deps).getMitigationEvidence({ incidentId: INCIDENT_ID });
+
+    const toolCall = deps.calls.find(call => call.startsWith('agent-tool-execution'))!;
+    assert.ok(toolCall.includes('incidentId'), 'incident-only correlation must still filter tool rows');
+    assert.ok(!toolCall.includes('threadId'), 'no threadId was observed, so none is sent');
+  });
+
+  it('correlates the incident-only path exactly despite concurrent-thread noise', async () => {
+    // The server-side filter narrows to this incident; post-query correlation must still reject
+    // rows from a different incident that the query may have returned.
+    const command = JSON.stringify({ command: 'kubectl scale deployment/mongodb -n energy --replicas=1' });
+    const noise = { timestamp: T(-240), EventType: 'ToolEnd', ToolName: 'RunKubectlWriteCommand', ToolInput: command, IncidentId: 'INC-OTHER', ThreadId: 'thread-other', CallId: 'noise' };
+
+    const deps = makeDependencies(
+      {
+        incident: [{ ...reviewIncidentRow, ThreadId: undefined }],
+        approval: [{ timestamp: T(-300), IncidentId: INCIDENT_ID, RawDimensions: { Decision: 'Approved' } }],
+        tool: [
+          noise,
+          { timestamp: T(-250), EventType: 'ToolStart', ToolName: 'RunKubectlWriteCommand', ToolInput: command, IncidentId: INCIDENT_ID, CallId: 'c1' },
+          { timestamp: T(-200), EventType: 'ToolEnd', ToolName: 'RunKubectlWriteCommand', ToolInput: command, ToolOutput: 'deployment.apps/mongodb scaled', IncidentId: INCIDENT_ID, CallId: 'c2' },
+        ],
+      },
+      inventoryFixture(1, 1),
+      impactFixture(true),
+      {
+        source: 'fixture',
+        resource: MITIGATION_TARGET.resource,
+        observedAt: T(-400),
+        specReplicas: 0,
+        readyReplicas: 0,
+        evidencePointer: 'fixture://before',
+      },
+    );
+
+    const result = await new ReviewModeMitigationService(deps).getMitigationEvidence({ incidentId: INCIDENT_ID });
+    assert.equal(result.evidence.state, 'verification-passed');
+    // The foreign row was rejected, not counted as this incident's execution.
+    assert.ok(result.evidence.rejectedEvidence.some(reason => /AgentToolExecution.*mismatch/i.test(reason)));
+    assert.equal(result.evidence.execution?.callId, 'c2');
   });
 
   it('blocks the flow when the observed run mode is autonomous', async () => {

--- a/mission-control/backend/src/routes/mitigation.ts
+++ b/mission-control/backend/src/routes/mitigation.ts
@@ -1,0 +1,89 @@
+/**
+ * REST surface for the Review-mode mitigation evidence flow (issue #80).
+ *
+ * Mission Control is READ-ONLY here. There is deliberately no local Approve/Deny endpoint:
+ * Microsoft does not document a supported external approval operation, and issue #80 forbids
+ * mirroring an approval button that does not invoke one. Approval happens in the Azure SRE Agent
+ * portal, and Mission Control only observes the resulting audit telemetry.
+ *
+ * Design gate: docs/REVIEW-MODE-MITIGATION.md
+ */
+
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import {
+  ReviewModeMitigationRequestError,
+  ReviewModeMitigationService,
+  buildGuardrails,
+  normalizeMitigationRequest,
+} from '../services/ReviewModeMitigationService.js';
+import { redactSensitiveText } from '../services/sre-agent/redaction.js';
+
+let sharedService: ReviewModeMitigationService | undefined;
+
+export function getReviewModeMitigationService(): ReviewModeMitigationService {
+  sharedService ??= new ReviewModeMitigationService();
+  return sharedService;
+}
+
+/** Test seam so integration tests can inject deterministic fixtures. */
+export function setReviewModeMitigationServiceForTesting(service: ReviewModeMitigationService | undefined): void {
+  sharedService = service;
+}
+
+export function registerMitigationRoutes(
+  app: FastifyInstance,
+  service: ReviewModeMitigationService = getReviewModeMitigationService(),
+): void {
+  // Static, always-available description of the action design and enforcement boundary.
+  app.get('/api/mitigation/guardrails', async (_req, reply) =>
+    reply.send({
+      scenario: 'MongoDBDown',
+      guardrails: buildGuardrails(),
+      approvalSurface: {
+        missionControlCanApprove: false,
+        reason:
+          'Approve/Deny is performed by an SRE Agent Administrator in the Azure SRE Agent portal. Microsoft does not document a supported external approval operation, so Mission Control does not present a local approval control.',
+        portalDocumentation: 'https://learn.microsoft.com/azure/sre-agent/run-modes',
+      },
+      designDocument: 'docs/REVIEW-MODE-MITIGATION.md',
+    }),
+  );
+
+  app.get<{ Querystring: Record<string, unknown> }>('/api/mitigation/evidence', async (req, reply) => {
+    try {
+      const request = normalizeMitigationRequest(req.query ?? {});
+      return reply.send(await service.getMitigationEvidence(request));
+    } catch (error) {
+      return sendMitigationError(reply, error);
+    }
+  });
+
+  app.post<{ Body: unknown }>('/api/mitigation/evidence', async (req, reply) => {
+    try {
+      const request = normalizeMitigationRequest(req.body ?? {});
+      return reply.send(await service.getMitigationEvidence(request));
+    } catch (error) {
+      return sendMitigationError(reply, error);
+    }
+  });
+}
+
+function sendMitigationError(reply: FastifyReply, error: unknown) {
+  if (error instanceof ReviewModeMitigationRequestError) {
+    return reply.status(error.statusCode).send({
+      error: error.message,
+      kind: 'denied',
+      remediation:
+        'Supply only observed correlation identifiers (threadId, correlationId, incidentId, traceId) and an optional minutes window. Lifecycle state is always derived from audit telemetry.',
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return reply.status(503).send({
+    error: `The Review-mode mitigation evidence request failed: ${redactSensitiveText(message).slice(0, 500)}`,
+    kind: 'unknown',
+    remediation: 'Verify Azure sign-in, Log Analytics workspace configuration, and cluster access, then retry.',
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/mission-control/backend/src/routes/rehearsals.ts
+++ b/mission-control/backend/src/routes/rehearsals.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import {
   advanceRehearsalRun,
+  attachRehearsalMitigationEvidence,
   createRehearsalRun,
   getRehearsalScenarioNames,
   getRehearsalState,
@@ -10,6 +11,8 @@ import {
   resumeRehearsalRun,
   updateRehearsalEvidence,
 } from '../services/RehearsalWorkflowService.js';
+import { getReviewModeMitigationService } from './mitigation.js';
+import { normalizeMitigationRequest, ReviewModeMitigationRequestError } from '../services/ReviewModeMitigationService.js';
 import type {
   AdvanceRehearsalRunRequest,
   CreateRehearsalRunRequest,
@@ -47,6 +50,22 @@ export function registerRehearsalRoutes(app: FastifyInstance): void {
       return reply.send({ run });
     } catch (error) {
       return reply.status(400).send({ error: getErrorMessage(error) });
+    }
+  });
+
+  // Captures Review-mode mitigation evidence onto a rehearsal run (issue #80).
+  // The body may only carry OBSERVED correlation identifiers: the evidence itself is re-derived
+  // here from audit telemetry, so a caller can never write a fabricated approval or recovery into
+  // the rehearsal package.
+  app.post<{ Params: { scenarioName: string }; Body: unknown }>('/api/rehearsals/:scenarioName/mitigation-evidence', async (req, reply) => {
+    try {
+      const request = normalizeMitigationRequest(req.body ?? {});
+      const derived = await getReviewModeMitigationService().getMitigationEvidence(request);
+      const run = await attachRehearsalMitigationEvidence(req.params.scenarioName as never, derived.evidence);
+      return reply.send({ run, guardrails: derived.guardrails, evidenceSources: derived.evidenceSources });
+    } catch (error) {
+      const status = error instanceof ReviewModeMitigationRequestError ? error.statusCode : 400;
+      return reply.status(status).send({ error: getErrorMessage(error) });
     }
   });
 

--- a/mission-control/backend/src/server.ts
+++ b/mission-control/backend/src/server.ts
@@ -19,6 +19,7 @@ import { registerIncidentRoutes } from './routes/incidents.js';
 import { registerRehearsalRoutes } from './routes/rehearsals.js';
 import { registerCustomerImpactRoutes } from './routes/customer-impact.js';
 import { getSreAgentService, registerSreAgentRoutes } from './routes/sre-agent.js';
+import { registerMitigationRoutes } from './routes/mitigation.js';
 import { addScenarioJsonBodyCompatibility } from './utils/jsonBodyCompatibility.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -92,6 +93,7 @@ async function start() {
   registerRehearsalRoutes(app);
   registerCustomerImpactRoutes(app);
   registerSreAgentRoutes(app);
+  registerMitigationRoutes(app);
 
   // The SRE Agent adapter owns a child MCP server process; stop it with the backend so
   // no orphaned process keeps an Azure session open after shutdown.

--- a/mission-control/backend/src/services/RehearsalWorkflowService.test.ts
+++ b/mission-control/backend/src/services/RehearsalWorkflowService.test.ts
@@ -11,7 +11,9 @@ import {
   resetRehearsalRun,
   resumeRehearsalRun,
   updateRehearsalEvidence,
+  attachRehearsalMitigationEvidence,
 } from './RehearsalWorkflowService.js';
+import type { ReviewModeMitigationEvidence } from './sre-agent/mitigationLifecycle.js';
 
 async function withTempState<T>(operation: (stateDir: string) => Promise<T>): Promise<T> {
   const tempDir = await mkdtemp(join(tmpdir(), 'rehearsal-workflow-'));
@@ -165,5 +167,73 @@ test('ServiceMismatch supports interruption, resume, and reset while keeping por
     assert.equal(reset.status, 'reset');
     assert.equal(reset.phase, 'preflight');
     assert.equal(reset.gateStatus, 'PASS_WITH_PENDING_HUMAN_PORTAL');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review-mode mitigation evidence persistence (issue #80)
+// ---------------------------------------------------------------------------
+
+function mitigationEvidence(overrides: Partial<ReviewModeMitigationEvidence> = {}): ReviewModeMitigationEvidence {
+  return {
+    state: 'proposed',
+    incidentResolved: false,
+    effectiveRunMode: 'review',
+    runModeBlocked: false,
+    scenario: 'MongoDBDown',
+    targetResource: 'energy/mongodb',
+    proposedCommand: 'kubectl scale deployment/mongodb -n energy --replicas=1',
+    correlation: { threadId: 'thread-1' },
+    verification: { probes: [], missingProbes: [], allProbesPassed: false, postDatesExecution: false },
+    guidance: {},
+    stale: false,
+    schemaMismatch: false,
+    securityFindings: [],
+    rejectedEvidence: [],
+    limitations: [],
+    ...overrides,
+  };
+}
+
+test('rehearsal persists derived mitigation evidence with its capture timestamp', async () => {
+  await withTempState(async () => {
+    await createRehearsalRun({ scenarioName: 'MongoDBDown' });
+    const run = await attachRehearsalMitigationEvidence('MongoDBDown', mitigationEvidence({ state: 'denied' }));
+    assert.equal(run.mitigationEvidence?.state, 'denied');
+    assert.ok(run.mitigationEvidenceCapturedAt);
+    assert.equal(run.mitigationEvidence?.incidentResolved, false);
+  });
+});
+
+test('rehearsal refuses to persist a resolved incident without verification-passed', async () => {
+  await withTempState(async () => {
+    await createRehearsalRun({ scenarioName: 'MongoDBDown' });
+    await assert.rejects(
+      () => attachRehearsalMitigationEvidence('MongoDBDown', mitigationEvidence({ state: 'proposed', incidentResolved: true })),
+      /without a verification-passed state/,
+    );
+  });
+});
+
+test('rehearsal refuses to persist verification-passed whose probes did not pass', async () => {
+  await withTempState(async () => {
+    await createRehearsalRun({ scenarioName: 'MongoDBDown' });
+    await assert.rejects(
+      () => attachRehearsalMitigationEvidence('MongoDBDown', mitigationEvidence({
+        state: 'verification-passed',
+        incidentResolved: true,
+        verification: { probes: [], missingProbes: ['golden-transaction'], allProbesPassed: false, postDatesExecution: true },
+      })),
+      /probes did not all pass/,
+    );
+  });
+});
+
+test('rehearsal mitigation evidence requires an existing run', async () => {
+  await withTempState(async () => {
+    await assert.rejects(
+      () => attachRehearsalMitigationEvidence('MongoDBDown', mitigationEvidence()),
+      /Rehearsal run not found/,
+    );
   });
 });

--- a/mission-control/backend/src/services/RehearsalWorkflowService.ts
+++ b/mission-control/backend/src/services/RehearsalWorkflowService.ts
@@ -5,6 +5,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:pat
 import { fileURLToPath } from 'node:url';
 import { submitIncident } from './IncidentHandoffService.js';
 import type {
+  ReviewModeMitigationEvidence,
   AdvanceRehearsalRunRequest,
   CreateRehearsalRunRequest,
   InterruptRehearsalRunRequest,
@@ -791,6 +792,42 @@ export async function updateRehearsalEvidence(request: UpdateRehearsalEvidenceRe
     run.notes = request.notes ?? run.notes;
     run.updatedAt = new Date().toISOString();
     await persistEvidenceArtifacts(run);
+    run.gateStatus = calculateGateStatus(run);
+    run.customerReady = run.gateStatus === 'PASS';
+    run.runManifest = buildRunManifest(run);
+    await saveState(state);
+    return run;
+  });
+}
+
+/**
+ * Persists Review-mode mitigation evidence onto a rehearsal run (issue #80).
+ *
+ * The caller MUST pass evidence that was derived from observed telemetry by
+ * ReviewModeMitigationService. This function refuses to persist evidence that claims an unproven
+ * recovery, so a rehearsal package can never contain a fabricated `verification-passed`.
+ */
+export async function attachRehearsalMitigationEvidence(
+  scenarioName: RehearsalScenarioName,
+  evidence: ReviewModeMitigationEvidence,
+): Promise<RehearsalRun> {
+  if (evidence.incidentResolved && evidence.state !== 'verification-passed') {
+    throw new Error('Refusing to persist mitigation evidence that reports a resolved incident without a verification-passed state.');
+  }
+  if (evidence.state === 'verification-passed' && !evidence.verification.allProbesPassed) {
+    throw new Error('Refusing to persist verification-passed evidence whose probes did not all pass.');
+  }
+
+  return withRehearsalMutationLock(async () => {
+    const state = await readState();
+    const normalized = normalizeScenarioName(scenarioName);
+    const run = state.runs.find((candidate: RehearsalRun) => candidate.scenarioName === normalized);
+    if (!run) {
+      throw new Error(`Rehearsal run not found: ${normalized}`);
+    }
+    run.mitigationEvidence = evidence;
+    run.mitigationEvidenceCapturedAt = new Date().toISOString();
+    run.updatedAt = run.mitigationEvidenceCapturedAt;
     run.gateStatus = calculateGateStatus(run);
     run.customerReady = run.gateStatus === 'PASS';
     run.runManifest = buildRunManifest(run);

--- a/mission-control/backend/src/services/ReviewModeMitigationService.ts
+++ b/mission-control/backend/src/services/ReviewModeMitigationService.ts
@@ -218,7 +218,7 @@ export class ReviewModeMitigationService {
     const [incidentRows, approvalRows, toolRows, azCliRows] = await Promise.all([
       query('incident-activity-snapshot', { incidentId: request.incidentId }),
       query('approval-decisions', { threadId: request.threadId, incidentId: request.incidentId }),
-      query('agent-tool-execution', { threadId: request.threadId }),
+      query('agent-tool-execution', { threadId: request.threadId, incidentId: request.incidentId }),
       query('agent-az-cli-execution', { threadId: request.threadId, incidentId: request.incidentId }),
     ]);
 

--- a/mission-control/backend/src/services/ReviewModeMitigationService.ts
+++ b/mission-control/backend/src/services/ReviewModeMitigationService.ts
@@ -1,0 +1,309 @@
+/**
+ * Orchestrates the Review-mode mitigation evidence flow (issue #80).
+ *
+ * Responsibilities:
+ *  1. Query the governed, canned SRE Agent evidence templates for the correlated incident.
+ *  2. Observe live Kubernetes + customer-impact signals and turn them into structured probes.
+ *  3. Hand everything to the pure derivation in `mitigationLifecycle.ts`.
+ *
+ * This service NEVER accepts a lifecycle state, approval, execution result, or verification
+ * outcome from the caller. The request may only supply OBSERVED correlation identifiers and
+ * query bounds; unknown keys are rejected outright.
+ *
+ * Design gate: docs/REVIEW-MODE-MITIGATION.md
+ */
+
+import { KubeInputError } from './KubeClient.js';
+import { KubeClient } from './KubeClient.js';
+import { CustomerImpactService } from './CustomerImpactService.js';
+import { SreAgentEvidenceQueryError, SreAgentEvidenceService } from './SreAgentEvidenceService.js';
+import {
+  ALLOWLISTED_MITIGATION_COMMANDS,
+  MITIGATION_TARGET,
+  ROLLBACK_COMMAND,
+  correlateRawRow,
+  deriveMitigationLifecycle,
+  parseApprovalDecisionRows,
+  type MitigationCorrelationKey,
+  type ResourceStateObservation,
+  type ReviewModeMitigationEvidence,
+} from './sre-agent/mitigationLifecycle.js';
+import {
+  buildVerificationProbes,
+  observeMitigationResourceState,
+} from './sre-agent/mitigationProbes.js';
+import type { CustomerImpactResponse, InventoryResponse } from '../types/index.js';
+
+const ID_PATTERN = /^[A-Za-z0-9_.:-]{1,100}$/;
+const DEFAULT_WINDOW_MINUTES = 60;
+const MAX_WINDOW_MINUTES = 24 * 60;
+
+/** Every key a caller may send. Anything else is rejected rather than silently ignored. */
+export const MITIGATION_REQUEST_KEYS = Object.freeze([
+  'threadId',
+  'correlationId',
+  'incidentId',
+  'traceId',
+  'minutes',
+]);
+
+export interface ReviewModeMitigationRequest {
+  threadId?: string;
+  correlationId?: string;
+  incidentId?: string;
+  traceId?: string;
+  minutes?: number;
+}
+
+export interface ReviewModeMitigationGuardrails {
+  policyDocument: string;
+  allowlistedCommands: readonly string[];
+  rollbackCommand: string;
+  targetResource: string;
+  /** Loud, non-suppressible disclosures about permission breadth (docs §4). */
+  disclosures: string[];
+  references: string[];
+}
+
+export interface ReviewModeMitigationResponse {
+  scenario: 'MongoDBDown';
+  evidence: ReviewModeMitigationEvidence;
+  guardrails: ReviewModeMitigationGuardrails;
+  evidenceSources: string[];
+  collectedAt: string;
+}
+
+export class ReviewModeMitigationRequestError extends Error {
+  constructor(message: string, public readonly statusCode = 400) {
+    super(message);
+    this.name = 'ReviewModeMitigationRequestError';
+  }
+}
+
+/**
+ * Validates the request body/query. Rejects unknown keys, and rejects any attempt to assert
+ * lifecycle data (a forged `state`, `approved`, `verification`, ... key is a 400, not a silent drop).
+ */
+export function normalizeMitigationRequest(raw: unknown): ReviewModeMitigationRequest {
+  if (raw === undefined || raw === null) return {};
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new ReviewModeMitigationRequestError('The mitigation evidence request must be an object.');
+  }
+
+  const bag = raw as Record<string, unknown>;
+  const unknownKeys = Object.keys(bag).filter(key => !MITIGATION_REQUEST_KEYS.includes(key));
+  if (unknownKeys.length > 0) {
+    throw new ReviewModeMitigationRequestError(
+      `Unknown request field(s): ${unknownKeys.join(', ')}. Mission Control derives the mitigation lifecycle from observed audit telemetry only; callers may supply correlation identifiers and a query window, never lifecycle state, approval, execution, or verification results.`,
+    );
+  }
+
+  const request: ReviewModeMitigationRequest = {};
+  for (const key of ['threadId', 'correlationId', 'incidentId', 'traceId'] as const) {
+    const value = bag[key];
+    if (value === undefined || value === null) continue;
+    if (typeof value !== 'string' || !ID_PATTERN.test(value.trim())) {
+      throw new ReviewModeMitigationRequestError(`'${key}' must be a short identifier matching ${ID_PATTERN}.`);
+    }
+    request[key] = value.trim();
+  }
+
+  if (bag.minutes !== undefined && bag.minutes !== null) {
+    const minutes = typeof bag.minutes === 'number' ? bag.minutes : Number.parseInt(String(bag.minutes), 10);
+    if (!Number.isFinite(minutes) || minutes < 1 || minutes > MAX_WINDOW_MINUTES) {
+      throw new ReviewModeMitigationRequestError(`'minutes' must be an integer between 1 and ${MAX_WINDOW_MINUTES}.`);
+    }
+    request.minutes = Math.trunc(minutes);
+  }
+
+  return request;
+}
+
+export interface ReviewModeMitigationDependencies {
+  evidence: Pick<SreAgentEvidenceService, 'execute'>;
+  kube: Pick<KubeClient, 'getInventory'>;
+  customerImpact: Pick<CustomerImpactService, 'getCustomerImpact'>;
+  now: () => Date;
+  /** Injected so tests can supply a captured pre-action observation. */
+  resourceStateBefore?: () => ResourceStateObservation | undefined;
+}
+
+function defaultDependencies(): ReviewModeMitigationDependencies {
+  return {
+    evidence: new SreAgentEvidenceService(),
+    kube: new KubeClient(),
+    customerImpact: new CustomerImpactService(),
+    now: () => new Date(),
+  };
+}
+
+/**
+ * Time-ordered observations of the target resource, per correlation key.
+ *
+ * A single rolling "previous reading" would be unsafe: once a mutation had settled, two later polls
+ * would both read the mutated value and a rejected proposal that DID change the resource could be
+ * reported as a clean `denied`. Keeping a short history lets the derivation anchor its "before"
+ * reading at or before the decision timestamp instead.
+ */
+const resourceStateHistory = new Map<string, ResourceStateObservation[]>();
+const HISTORY_MAX_KEYS = 64;
+const HISTORY_MAX_ENTRIES = 32;
+
+export function recordMitigationObservation(key: string, observation: ResourceStateObservation): void {
+  if (!resourceStateHistory.has(key) && resourceStateHistory.size >= HISTORY_MAX_KEYS) {
+    const oldest = resourceStateHistory.keys().next().value;
+    if (oldest !== undefined) resourceStateHistory.delete(oldest);
+  }
+  const entries = resourceStateHistory.get(key) ?? [];
+  // De-duplicate identical consecutive readings so the history spans a useful time range.
+  const last = entries[entries.length - 1];
+  if (last && last.observedAt === observation.observedAt) return;
+  entries.push(observation);
+  while (entries.length > HISTORY_MAX_ENTRIES) entries.shift();
+  resourceStateHistory.set(key, entries);
+}
+
+export function getMitigationObservationHistory(key: string): ResourceStateObservation[] {
+  return [...(resourceStateHistory.get(key) ?? [])];
+}
+
+export function clearMitigationBaselines(): void {
+  resourceStateHistory.clear();
+}
+
+function baselineKey(correlation: MitigationCorrelationKey): string {
+  return [correlation.threadId, correlation.correlationId, correlation.incidentId, correlation.traceId]
+    .map(value => value ?? '')
+    .join('|');
+}
+
+export class ReviewModeMitigationService {
+  constructor(private readonly dependencies: ReviewModeMitigationDependencies = defaultDependencies()) {}
+
+  async getMitigationEvidence(request: ReviewModeMitigationRequest): Promise<ReviewModeMitigationResponse> {
+    const now = this.dependencies.now();
+    const minutes = request.minutes ?? DEFAULT_WINDOW_MINUTES;
+    const correlation: MitigationCorrelationKey = {
+      threadId: request.threadId,
+      correlationId: request.correlationId,
+      incidentId: request.incidentId,
+      traceId: request.traceId,
+    };
+
+    const evidenceSources: string[] = [];
+    let schemaMismatch = false;
+
+    const query = async (
+      templateName: string,
+      params: Record<string, unknown>,
+    ): Promise<Record<string, unknown>[]> => {
+      try {
+        const scrubbed = Object.fromEntries(
+          Object.entries({ minutes, ...params }).filter(([, value]) => value !== undefined),
+        );
+        const response = await this.dependencies.evidence.execute(templateName, scrubbed);
+        evidenceSources.push(`${templateName} (${response.rowCount} row(s), window ${minutes}m)`);
+        return response.rows;
+      } catch (error) {
+        if (error instanceof SreAgentEvidenceQueryError && error.schemaMismatch) {
+          schemaMismatch = true;
+        }
+        evidenceSources.push(`${templateName} (unavailable: ${error instanceof Error ? error.message.slice(0, 160) : 'unknown error'})`);
+        return [];
+      }
+    };
+
+    // Each template only accepts the parameters its KQL actually filters on; passing an
+    // unsupported parameter is rejected by SreAgentEvidenceService rather than ignored.
+    const [incidentRows, approvalRows, toolRows, azCliRows] = await Promise.all([
+      query('incident-activity-snapshot', { incidentId: request.incidentId }),
+      query('approval-decisions', { threadId: request.threadId, incidentId: request.incidentId }),
+      query('agent-tool-execution', { threadId: request.threadId }),
+      query('agent-az-cli-execution', { threadId: request.threadId, incidentId: request.incidentId }),
+    ]);
+
+    // The effective run mode must come from a STRICTLY correlated incident row. An OR over
+    // IncidentId/ThreadId would short-circuit and could read the autonomy level from a different
+    // agent thread of the same incident (see correlateRawRow).
+    const matchedIncident = incidentRows.find(row => correlateRawRow(row, correlation) === 'match');
+
+    const observedAutonomyLevel =
+      typeof matchedIncident?.AgentAutonomyLevel === 'string' ? matchedIncident.AgentAutonomyLevel : undefined;
+    const incidentMitigatedByAgent =
+      typeof matchedIncident?.IncidentMitigatedByAgent === 'string'
+        ? matchedIncident.IncidentMitigatedByAgent.toLowerCase() === 'true'
+        : undefined;
+
+    let inventory: InventoryResponse | undefined;
+    try {
+      inventory = await this.dependencies.kube.getInventory();
+      evidenceSources.push('kubernetes inventory (live)');
+    } catch {
+      evidenceSources.push('kubernetes inventory (unavailable)');
+    }
+
+    let impact: CustomerImpactResponse | undefined;
+    try {
+      impact = await this.dependencies.customerImpact.getCustomerImpact();
+      evidenceSources.push('customer-impact golden transaction (PR #84)');
+    } catch {
+      evidenceSources.push('customer-impact golden transaction (unavailable)');
+    }
+
+    const probes = buildVerificationProbes(inventory, impact, now);
+    const after = observeMitigationResourceState(inventory, 'after');
+    const key = baselineKey(correlation);
+    const hasKey = key.replace(/\|/g, '').length > 0;
+
+    // Read the history BEFORE appending the current reading, so the current reading can never be
+    // selected as its own "before".
+    const history = hasKey ? getMitigationObservationHistory(key) : [];
+    if (after && hasKey) recordMitigationObservation(key, after);
+
+    const evidence = deriveMitigationLifecycle({
+      now,
+      correlation,
+      observedAutonomyLevel,
+      incidentMitigatedByAgent,
+      approvalRows,
+      toolExecutionRows: toolRows,
+      azCliRows,
+      resourceStateBefore: this.dependencies.resourceStateBefore?.(),
+      resourceStateHistory: history,
+      resourceStateAfter: after,
+      probes,
+      schemaMismatch,
+    });
+
+    return {
+      scenario: 'MongoDBDown',
+      evidence,
+      guardrails: buildGuardrails(),
+      evidenceSources,
+      collectedAt: now.toISOString(),
+    };
+  }
+}
+
+export function buildGuardrails(): ReviewModeMitigationGuardrails {
+  return {
+    policyDocument: 'infra/sre-agent/tool-access-policy.json',
+    allowlistedCommands: ALLOWLISTED_MITIGATION_COMMANDS,
+    rollbackCommand: ROLLBACK_COMMAND,
+    targetResource: MITIGATION_TARGET.resource,
+    disclosures: [
+      'DEMO-ONLY PERMISSION BREADTH: unless the deployment sets enableAgentKubernetesRbac = true, the agent obtains a cluster-user kubeconfig whose in-cluster authority is broader than the single Deployment this action needs. The tool access policy still constrains what the agent will run. See docs/REVIEW-MODE-MITIGATION.md §4.',
+      'Mission Control is READ-ONLY for approval. Approve/Deny is performed in the Azure SRE Agent portal by an SRE Agent Administrator; no local approval button exists because Microsoft does not document a supported external approval operation.',
+      'A Kubernetes write does not trigger the native Review-mode Approve/Deny button on its own. The approval gate here is a global Tool Access Policy `ask` rule combined with response-plan run mode Review. See docs/REVIEW-MODE-MITIGATION.md §1.',
+    ],
+    references: [
+      'https://learn.microsoft.com/azure/sre-agent/run-modes',
+      'https://learn.microsoft.com/azure/sre-agent/tool-access-policies',
+      'https://learn.microsoft.com/azure/sre-agent/execute-mitigations',
+      'https://learn.microsoft.com/azure/sre-agent/audit-agent-actions',
+    ],
+  };
+}
+
+/** Re-exported so the route layer can surface a consistent error for malformed identifiers. */
+export { KubeInputError, parseApprovalDecisionRows };

--- a/mission-control/backend/src/services/SreAgentEvidenceService.test.ts
+++ b/mission-control/backend/src/services/SreAgentEvidenceService.test.ts
@@ -166,3 +166,42 @@ test('SRE Agent evidence denied/unavailable error responses keep honest, empty e
   assert.equal(schemaMismatch.metadata.schemaMismatch, true);
   assert.ok(schemaMismatch.metadata.limitations.some(limitation => limitation.includes('telemetry schema')));
 });
+
+// ---------------------------------------------------------------------------
+// agent-tool-execution incidentId filtering (issue #80 review blocker 2)
+// ---------------------------------------------------------------------------
+
+test('agent-tool-execution filters by incidentId, threadId, or both', () => {
+  const from = new Date('2026-01-01T00:00:00Z');
+  const to = new Date('2026-01-01T01:00:00Z');
+
+  // Incident-only: the primary Mission Control path can have an incidentId without a threadId.
+  // Without this filter the query degrades to a workspace-wide top-N whose `take` can silently
+  // drop this incident's tool rows.
+  const incidentOnly = normalizeSreAgentEvidenceRequest('agent-tool-execution', { incidentId: 'INC-42' });
+  const incidentOnlyKql = buildSreAgentEvidenceKql(incidentOnly, from, to);
+  assert.match(incidentOnlyKql, /tostring\(customDimensions\.IncidentId\) == "INC-42"/);
+  assert.doesNotMatch(incidentOnlyKql, /customDimensions\.ThreadId\) ==/);
+
+  const threadOnly = normalizeSreAgentEvidenceRequest('agent-tool-execution', { threadId: 'thread-1' });
+  const threadOnlyKql = buildSreAgentEvidenceKql(threadOnly, from, to);
+  assert.match(threadOnlyKql, /tostring\(customDimensions\.ThreadId\) == "thread-1"/);
+  assert.doesNotMatch(threadOnlyKql, /customDimensions\.IncidentId\) ==/);
+
+  const both = normalizeSreAgentEvidenceRequest('agent-tool-execution', { threadId: 'thread-1', incidentId: 'INC-42' });
+  const bothKql = buildSreAgentEvidenceKql(both, from, to);
+  assert.match(bothKql, /tostring\(customDimensions\.ThreadId\) == "thread-1"/);
+  assert.match(bothKql, /tostring\(customDimensions\.IncidentId\) == "INC-42"/);
+
+  // The row projection must expose IncidentId so post-query correlation can compare it exactly.
+  assert.match(bothKql, /IncidentId = tostring\(customDimensions\.IncidentId\)/);
+});
+
+test('agent-tool-execution accepts incidentId as an allowed parameter', () => {
+  assert.doesNotThrow(() => normalizeSreAgentEvidenceRequest('agent-tool-execution', { incidentId: 'INC-42' }));
+  // Unrelated parameters remain rejected.
+  assert.throws(
+    () => normalizeSreAgentEvidenceRequest('agent-tool-execution', { impactedService: 'mongodb' }),
+    KubeInputError,
+  );
+});

--- a/mission-control/backend/src/services/SreAgentEvidenceService.ts
+++ b/mission-control/backend/src/services/SreAgentEvidenceService.ts
@@ -24,6 +24,7 @@ export const SRE_AGENT_EVENT_NAMES = {
   agentExecution: 'AgentExecution',
   agentToolExecution: 'AgentToolExecution',
   approvalDecision: 'ApprovalDecision',
+  agentAzCliExecution: 'AgentAzCliExecution',
 } as const;
 
 export const SRE_AGENT_EVIDENCE_TEMPLATES = [
@@ -31,6 +32,7 @@ export const SRE_AGENT_EVIDENCE_TEMPLATES = [
   'agent-execution-lifecycle',
   'agent-tool-execution',
   'approval-decisions',
+  'agent-az-cli-execution',
   'incident-thread-timeline',
 ] as const satisfies readonly SreAgentEvidenceTemplateName[];
 
@@ -119,8 +121,8 @@ function evidenceLimitations(templateName: SreAgentEvidenceTemplateName, rowCoun
     'Rows are bounded, redacted, and time-window limited before returning to Mission Control.',
     'Zero rows means no native telemetry was observed in this window -- this is reported as unknown/pending evidence, never as a healthy or mitigated incident.',
   ];
-  if (templateName === 'agent-execution-lifecycle' || templateName === 'approval-decisions') {
-    limitations.push('SCHEMA_TBD: AgentExecution and ApprovalDecision field names beyond the shared correlation fields are not individually enumerated in Microsoft Learn as of this implementation; only documented shared fields plus a raw customDimensions projection are returned. See docs/CAPABILITY-CONTRACTS.md SS8.');
+  if (templateName === 'agent-execution-lifecycle' || templateName === 'approval-decisions' || templateName === 'agent-az-cli-execution') {
+    limitations.push('SCHEMA_TBD: AgentExecution, ApprovalDecision, and AgentAzCliExecution field names beyond the shared correlation fields are not individually enumerated in Microsoft Learn as of this implementation; only documented shared fields plus a raw customDimensions projection are returned. See docs/CAPABILITY-CONTRACTS.md SS8.');
   }
   if (rowCount === 0) {
     limitations.push('No rows may mean the response plan has not fired yet, the agent is not connected to Azure Monitor as an incident platform, or the correlation filter (threadId/incidentId/impactedService) did not match -- not that the agent is idle or healthy.');
@@ -210,6 +212,9 @@ export function buildSreAgentEvidenceKql(request: SreAgentEvidenceQueryRequest, 
         '    SubAgentName = tostring(customDimensions.SubAgentName),',
         '    CallId = tostring(customDimensions.CallId),',
         '    ThreadId = tostring(customDimensions.ThreadId),',
+        '    IncidentId = tostring(customDimensions.IncidentId),',
+        '    TraceId = tostring(customDimensions.TraceId),',
+        '    SpanId = tostring(customDimensions.SpanId),',
         '    CorrelationId = tostring(customDimensions.CorrelationId)',
         '| order by timestamp desc',
         `| take ${limit}`,
@@ -239,8 +244,12 @@ export function buildSreAgentEvidenceKql(request: SreAgentEvidenceQueryRequest, 
     case 'approval-decisions': {
       // SCHEMA_TBD: Microsoft Learn shows only `project timestamp, customDimensions` for
       // ApprovalDecision without an itemized field table (docs/CAPABILITY-CONTRACTS.md SS8).
+      // The shared correlation fields ARE documented, so they are projected explicitly and the
+      // raw bag is preserved so the runtime parser can scan for the outcome without us inventing
+      // a field name. See services/sre-agent/mitigationLifecycle.ts.
       const filters = [`name == "${SRE_AGENT_EVENT_NAMES.approvalDecision}"`];
       if (request.threadId) filters.push(`tostring(customDimensions.ThreadId) == ${kqlString(request.threadId)}`);
+      if (request.incidentId) filters.push(`tostring(customDimensions.IncidentId) == ${kqlString(request.incidentId)}`);
       return [
         'customEvents',
         `| where ${filters.join(' and ')}`,
@@ -248,6 +257,32 @@ export function buildSreAgentEvidenceKql(request: SreAgentEvidenceQueryRequest, 
         '| project timestamp,',
         '    ThreadId = tostring(customDimensions.ThreadId),',
         '    CorrelationId = tostring(customDimensions.CorrelationId),',
+        '    IncidentId = tostring(customDimensions.IncidentId),',
+        '    TraceId = tostring(customDimensions.TraceId),',
+        '    SpanId = tostring(customDimensions.SpanId),',
+        '    RawDimensions = customDimensions',
+        '| order by timestamp desc',
+        `| take ${limit}`,
+      ].join('\n');
+    }
+    case 'agent-az-cli-execution': {
+      // SCHEMA_TBD: Microsoft Learn names AgentAzCliExecution ("Azure CLI commands run by the
+      // agent") but does not itemize its dimensions. Shared correlation fields are documented and
+      // projected explicitly; everything else stays in the raw bag for the runtime parser.
+      const filters = [`name == "${SRE_AGENT_EVENT_NAMES.agentAzCliExecution}"`];
+      if (request.threadId) filters.push(`tostring(customDimensions.ThreadId) == ${kqlString(request.threadId)}`);
+      if (request.incidentId) filters.push(`tostring(customDimensions.IncidentId) == ${kqlString(request.incidentId)}`);
+      return [
+        'customEvents',
+        `| where ${filters.join(' and ')}`,
+        windowFilter,
+        '| project timestamp,',
+        '    ThreadId = tostring(customDimensions.ThreadId),',
+        '    CorrelationId = tostring(customDimensions.CorrelationId),',
+        '    IncidentId = tostring(customDimensions.IncidentId),',
+        '    TraceId = tostring(customDimensions.TraceId),',
+        '    SpanId = tostring(customDimensions.SpanId),',
+        '    CallId = tostring(customDimensions.CallId),',
         '    RawDimensions = customDimensions',
         '| order by timestamp desc',
         `| take ${limit}`,
@@ -343,7 +378,8 @@ function rejectUnknownParams(templateName: SreAgentEvidenceTemplateName, rawPara
     'incident-activity-snapshot': new Set([...base, 'incidentId', 'impactedService']),
     'agent-execution-lifecycle': new Set([...base, 'threadId']),
     'agent-tool-execution': new Set([...base, 'threadId']),
-    'approval-decisions': new Set([...base, 'threadId']),
+    'approval-decisions': new Set([...base, 'threadId', 'incidentId']),
+    'agent-az-cli-execution': new Set([...base, 'threadId', 'incidentId']),
     'incident-thread-timeline': new Set([...base, 'threadId']),
   };
   for (const key of Object.keys(rawParams)) {

--- a/mission-control/backend/src/services/SreAgentEvidenceService.ts
+++ b/mission-control/backend/src/services/SreAgentEvidenceService.ts
@@ -198,8 +198,12 @@ export function buildSreAgentEvidenceKql(request: SreAgentEvidenceQueryRequest, 
       ].join('\n');
     }
     case 'agent-tool-execution': {
+      // Filter by BOTH identifiers when available. The primary Mission Control path can have an
+      // incidentId without a threadId; filtering on threadId alone would then fall back to a
+      // workspace-wide top-N query whose `take` could drop this incident's tool rows entirely.
       const filters = [`name == "${SRE_AGENT_EVENT_NAMES.agentToolExecution}"`];
       if (request.threadId) filters.push(`tostring(customDimensions.ThreadId) == ${kqlString(request.threadId)}`);
+      if (request.incidentId) filters.push(`tostring(customDimensions.IncidentId) == ${kqlString(request.incidentId)}`);
       return [
         'customEvents',
         `| where ${filters.join(' and ')}`,
@@ -377,7 +381,7 @@ function rejectUnknownParams(templateName: SreAgentEvidenceTemplateName, rawPara
   const allowedByTemplate: Record<SreAgentEvidenceTemplateName, Set<string>> = {
     'incident-activity-snapshot': new Set([...base, 'incidentId', 'impactedService']),
     'agent-execution-lifecycle': new Set([...base, 'threadId']),
-    'agent-tool-execution': new Set([...base, 'threadId']),
+    'agent-tool-execution': new Set([...base, 'threadId', 'incidentId']),
     'approval-decisions': new Set([...base, 'threadId', 'incidentId']),
     'agent-az-cli-execution': new Set([...base, 'threadId', 'incidentId']),
     'incident-thread-timeline': new Set([...base, 'threadId']),

--- a/mission-control/backend/src/services/sre-agent/mitigationLifecycle.test.ts
+++ b/mission-control/backend/src/services/sre-agent/mitigationLifecycle.test.ts
@@ -1,0 +1,772 @@
+/**
+ * Adversarial tests for the Review-mode mitigation lifecycle (issue #80).
+ *
+ * These tests exist because the previous attempt (closed PR #85) accepted caller-supplied lifecycle
+ * types: success could be fabricated, deny was asserted without evidence, and identifiers were never
+ * compared. Every test below attacks one of those failure modes with deterministic fixtures.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  ALLOWLISTED_MITIGATION_COMMANDS,
+  MITIGATION_TARGET,
+  ROLLBACK_COMMAND,
+  correlateRow,
+  deriveMitigationLifecycle,
+  extractToolCommand,
+  isAllowlistedMitigationCommand,
+  normalizeMitigationCommand,
+  parseApprovalDecisionRows,
+  parseAzCliExecutionRows,
+  parseToolExecutionRows,
+  resolveEffectiveRunMode,
+  resolveMutationState,
+  selectPreDecisionObservation,
+  type MitigationCorrelationKey,
+  type ResourceStateObservation,
+  type VerificationProbeEvidence,
+} from './mitigationLifecycle.js';
+
+// -----------------------------------------------------------------------------
+// Deterministic fixtures
+// -----------------------------------------------------------------------------
+
+const NOW = new Date('2026-05-01T12:00:00.000Z');
+const T = (offsetSeconds: number) => new Date(NOW.getTime() + offsetSeconds * 1000).toISOString();
+
+const THREAD_ID = 'thread-aaaabbbb-0000-cccc-1111';
+const CORRELATION_ID = 'corr-7f3a19';
+const INCIDENT_ID = 'INC0PL8K7AL0J';
+const TRACE_ID = 'trace-2b9c44de';
+
+const KEY: MitigationCorrelationKey = {
+  threadId: THREAD_ID,
+  correlationId: CORRELATION_ID,
+  incidentId: INCIDENT_ID,
+  traceId: TRACE_ID,
+};
+
+const RESTORE_COMMAND = ALLOWLISTED_MITIGATION_COMMANDS[0]!;
+
+function approvalRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    timestamp: T(-300),
+    ThreadId: THREAD_ID,
+    CorrelationId: CORRELATION_ID,
+    IncidentId: INCIDENT_ID,
+    TraceId: TRACE_ID,
+    RawDimensions: { Decision: 'Approved' },
+    ...overrides,
+  };
+}
+
+function toolRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    timestamp: T(-240),
+    EventType: 'ToolStart',
+    ToolName: 'RunKubectlWriteCommand',
+    ToolInput: JSON.stringify({ command: RESTORE_COMMAND }),
+    CallId: 'call_0001',
+    ThreadId: THREAD_ID,
+    CorrelationId: CORRELATION_ID,
+    IncidentId: INCIDENT_ID,
+    TraceId: TRACE_ID,
+    ...overrides,
+  };
+}
+
+function toolEndRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return toolRow({
+    timestamp: T(-200),
+    EventType: 'ToolEnd',
+    ToolOutput: 'deployment.apps/mongodb scaled',
+    CallId: 'call_0002',
+    ...overrides,
+  });
+}
+
+function probe(
+  name: VerificationProbeEvidence['probe'],
+  status: VerificationProbeEvidence['status'] = 'pass',
+  observedAt = T(-60),
+): VerificationProbeEvidence {
+  return {
+    probe: name,
+    status,
+    source: `fixture:${name}`,
+    observedValue: `${name}=${status}`,
+    observedAt,
+    freshnessSeconds: 60,
+    evidencePointer: `fixture://${name}`,
+  };
+}
+
+function passingProbes(observedAt = T(-60)): VerificationProbeEvidence[] {
+  return [
+    probe('kubernetes-readiness', 'pass', observedAt),
+    probe('service-endpoint-health', 'pass', observedAt),
+    probe('golden-transaction', 'pass', observedAt),
+  ];
+}
+
+function state(observedAt: string, specReplicas: number, generation?: number): ResourceStateObservation {
+  return {
+    source: 'fixture',
+    resource: MITIGATION_TARGET.resource,
+    observedAt,
+    specReplicas,
+    readyReplicas: specReplicas,
+    observedGeneration: generation,
+    evidencePointer: 'fixture://state',
+  };
+}
+
+function derive(overrides: Partial<Parameters<typeof deriveMitigationLifecycle>[0]> = {}) {
+  return deriveMitigationLifecycle({
+    now: NOW,
+    correlation: KEY,
+    observedAutonomyLevel: 'review',
+    ...overrides,
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Command allowlist
+// -----------------------------------------------------------------------------
+
+describe('mitigation command allowlist', () => {
+  it('accepts the exact restore and rollback commands', () => {
+    assert.equal(isAllowlistedMitigationCommand(RESTORE_COMMAND), true);
+    assert.equal(isAllowlistedMitigationCommand(ROLLBACK_COMMAND), true);
+  });
+
+  it('accepts documented equivalent spellings without widening the boundary', () => {
+    assert.equal(isAllowlistedMitigationCommand('kubectl  scale   deployment/mongodb --namespace energy --replicas 1'), true);
+    assert.equal(isAllowlistedMitigationCommand('kubectl scale deployment mongodb -n energy --replicas=1'), true);
+    assert.equal(normalizeMitigationCommand('kubectl scale deployment/mongodb --replicas=1 -n energy'), RESTORE_COMMAND);
+  });
+
+  it('rejects out-of-scope resources, namespaces and replica counts', () => {
+    for (const command of [
+      'kubectl scale deployment/meter-service -n energy --replicas=1',
+      'kubectl scale deployment/mongodb -n kube-system --replicas=1',
+      'kubectl scale deployment/mongodb -n energy --replicas=99',
+      'kubectl delete deployment/mongodb -n energy',
+      'kubectl exec -it mongodb -n energy -- sh',
+      'kubectl scale deployment/mongodb --all-namespaces --replicas=1',
+    ]) {
+      assert.equal(isAllowlistedMitigationCommand(command), false, `expected reject: ${command}`);
+    }
+  });
+
+  it('rejects shell-chained bypass attempts that would otherwise normalise into the allowlist', () => {
+    for (const command of [
+      'kubectl scale deployment/mongodb -n energy --replicas=1; kubectl delete ns energy',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 && rm -rf /',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 | tee /tmp/x',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 `whoami`',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 $(id)',
+      'kubectl scale deployment/mongodb -n energy --replicas=1\nkubectl delete pod --all',
+    ]) {
+      assert.equal(isAllowlistedMitigationCommand(command), false, `expected reject: ${command}`);
+    }
+  });
+
+  it('rejects argument-smuggling payloads that carry the required tokens plus extras', () => {
+    // Security regression: an earlier lookahead-based normaliser accepted every one of these,
+    // because it only checked that `-n energy` and `--replicas=N` appeared somewhere and then
+    // rebuilt a canonical string, discarding all other arguments.
+    for (const command of [
+      'kubectl scale deployment/mongodb deployment/grid-api statefulset/vault -n energy --replicas=0',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 --server https://evil.example.com --token abc123 --insecure-skip-tls-verify',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 --kubeconfig /attacker/kubeconfig',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 --as system:masters',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 --all-namespaces',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 -A',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 --context attacker',
+      'kubectl scale --all-namespaces deployment/mongodb -n energy --replicas=1',
+      'kubectl scale deployment/mongodb -n energy -n kube-system --replicas=1',
+      'kubectl scale deployment/mongodb -n energy --replicas=1 --replicas=9',
+    ]) {
+      assert.equal(isAllowlistedMitigationCommand(command), false, `expected reject: ${command}`);
+      assert.notEqual(normalizeMitigationCommand(command), RESTORE_COMMAND, `must not normalise into the allowlist: ${command}`);
+    }
+  });
+
+  it('does not let a smuggled command reach verification-passed', () => {
+    const smuggled = JSON.stringify({
+      command: 'kubectl scale deployment/mongodb deployment/grid-api -n energy --replicas=1 --server https://evil.example.com',
+    });
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [toolRow({ ToolInput: smuggled }), toolEndRow({ ToolInput: smuggled })],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.notEqual(evidence.state, 'verification-passed');
+    assert.equal(evidence.incidentResolved, false);
+    assert.equal(evidence.execution, undefined);
+    assert.ok(evidence.securityFindings.some(finding => /Out-of-scope tool call/.test(finding)));
+  });
+
+  it('rejects a scale of a different resource kind or a non-numeric replica count', () => {
+    for (const command of [
+      'kubectl scale statefulset/mongodb -n energy --replicas=1',
+      'kubectl scale deployment/mongodb -n energy --replicas=one',
+      'kubectl scale deployment/mongodb --replicas=1',
+      'kubectl scale deployment/mongodb -n energy',
+      'kubectl get deployment/mongodb -n energy --replicas=1',
+      'kubectl scale',
+    ]) {
+      assert.equal(isAllowlistedMitigationCommand(command), false, `expected reject: ${command}`);
+    }
+  });
+
+  it('rejects non-string and oversized input', () => {
+    assert.equal(isAllowlistedMitigationCommand(undefined), false);
+    assert.equal(isAllowlistedMitigationCommand(42), false);
+    assert.equal(isAllowlistedMitigationCommand(`${RESTORE_COMMAND} ${'x'.repeat(600)}`), false);
+  });
+
+  it('extracts the command from JSON and bare tool inputs', () => {
+    assert.equal(extractToolCommand(JSON.stringify({ command: RESTORE_COMMAND })), RESTORE_COMMAND);
+    assert.equal(extractToolCommand(RESTORE_COMMAND), RESTORE_COMMAND);
+    assert.equal(extractToolCommand(undefined), undefined);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Runtime parsers
+// -----------------------------------------------------------------------------
+
+describe('runtime parsers', () => {
+  it('drops rows with missing or unparsable timestamps rather than substituting now', () => {
+    assert.equal(parseApprovalDecisionRows([{ ThreadId: THREAD_ID }]).length, 0);
+    assert.equal(parseApprovalDecisionRows([approvalRow({ timestamp: 'not-a-date' })]).length, 0);
+    assert.equal(parseToolExecutionRows([toolRow({ timestamp: undefined })]).length, 0);
+    assert.equal(parseAzCliExecutionRows([{ timestamp: '' }]).length, 0);
+  });
+
+  it('reads outcomes from nested and flattened dimension bags', () => {
+    assert.equal(parseApprovalDecisionRows([approvalRow()])[0]!.outcome, 'approved');
+    assert.equal(parseApprovalDecisionRows([approvalRow({ RawDimensions: { Outcome: 'Rejected' } })])[0]!.outcome, 'rejected');
+    assert.equal(parseApprovalDecisionRows([approvalRow({ RawDimensions: JSON.stringify({ Decision: 'deny' }) })])[0]!.outcome, 'rejected');
+  });
+
+  it('resolves an unrecognised approval outcome to unknown, never approved', () => {
+    const parsed = parseApprovalDecisionRows([approvalRow({ RawDimensions: { Something: 'maybe' } })]);
+    assert.equal(parsed[0]!.outcome, 'unknown');
+    assert.equal(parsed[0]!.outcomeSource, undefined);
+  });
+
+  it('classifies allowlisted, blocked and failed tool rows', () => {
+    const [allowed] = parseToolExecutionRows([toolRow()]);
+    assert.equal(allowed!.allowlisted, true);
+    assert.equal(allowed!.blocked, false);
+
+    const [outOfScope] = parseToolExecutionRows([toolRow({ ToolInput: JSON.stringify({ command: 'kubectl delete ns energy' }) })]);
+    assert.equal(outOfScope!.allowlisted, false);
+
+    const [blocked] = parseToolExecutionRows([
+      toolEndRow({ ToolOutput: 'Error from server (Forbidden): deployments.apps "mongodb" is forbidden' }),
+    ]);
+    assert.equal(blocked!.blocked, true);
+
+    const [wrongTool] = parseToolExecutionRows([toolRow({ ToolName: 'RunShellCommand' })]);
+    assert.equal(wrongTool!.allowlisted, false);
+  });
+
+  it('redacts secrets out of tool input and output', () => {
+    const [row] = parseToolExecutionRows([
+      toolRow({
+        ToolInput: 'kubectl scale deployment/mongodb -n energy --replicas=1 --token=supersecretvalue123',
+        ToolOutput: 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payloadpayload.signaturesig',
+      }),
+    ]);
+    assert.ok(!row!.toolInput!.includes('supersecretvalue123'), 'token must be redacted');
+    assert.ok(!row!.toolOutput!.includes('eyJhbGciOiJIUzI1NiJ9'), 'JWT must be redacted');
+    assert.ok(row!.toolOutput!.includes('REDACTED'));
+  });
+
+  it('redacts quoted secret values that contain spaces', () => {
+    // Security regression: the value pattern previously stopped at the first space inside quotes,
+    // leaking the remainder of the secret into the response body.
+    const [row] = parseToolExecutionRows([
+      toolRow({
+        ToolInput: 'az login -u svc --password "Winter 2026 Grid!" --admin-password \'Correct Horse Battery\'',
+        ToolOutput: 'az storage blob list --sas-token "sv=2021 sig=AAAABBBBCCCC"',
+      }),
+    ]);
+    for (const leaked of ['2026', 'Grid!', 'Horse', 'Battery', 'sig=AAAABBBBCCCC']) {
+      assert.ok(!row!.toolInput!.includes(leaked) || !row!.toolOutput!.includes(leaked), `leaked '${leaked}'`);
+    }
+    assert.ok(!row!.toolInput!.includes('Winter'), 'password must be redacted');
+    assert.ok(!row!.toolInput!.includes('Correct'), 'admin-password must be redacted');
+    assert.ok(!row!.toolOutput!.includes('sig=AAAABBBBCCCC'), 'sas-token must be redacted');
+  });
+
+  it('redacts az cli commands', () => {
+    const [row] = parseAzCliExecutionRows([
+      { timestamp: T(-100), ThreadId: THREAD_ID, RawDimensions: { Command: 'az login --password hunter2secretpw' } },
+    ]);
+    assert.ok(!row!.command!.includes('hunter2secretpw'));
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Correlation
+// -----------------------------------------------------------------------------
+
+describe('exact identifier correlation', () => {
+  it('matches only on exact equality', () => {
+    assert.equal(correlateRow({ threadId: THREAD_ID }, KEY), 'match');
+    assert.equal(correlateRow({ threadId: `${THREAD_ID} ` }, KEY), 'mismatch');
+    assert.equal(correlateRow({ threadId: THREAD_ID.toUpperCase() }, KEY), 'mismatch');
+  });
+
+  it('treats a differing shared identifier as a mismatch even when another matches', () => {
+    assert.equal(correlateRow({ threadId: THREAD_ID, incidentId: 'INC-OTHER' }, KEY), 'mismatch');
+  });
+
+  it('never guesses when no identifier overlaps', () => {
+    assert.equal(correlateRow({}, KEY), 'insufficient');
+    assert.equal(correlateRow({ spanId: 'span-1' } as never, KEY), 'insufficient');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Run mode gate
+// -----------------------------------------------------------------------------
+
+describe('effective run mode gate', () => {
+  it('parses documented autonomy values', () => {
+    assert.equal(resolveEffectiveRunMode('review'), 'review');
+    assert.equal(resolveEffectiveRunMode('Review'), 'review');
+    assert.equal(resolveEffectiveRunMode('autonomous'), 'autonomous');
+    assert.equal(resolveEffectiveRunMode(undefined), 'unknown');
+    assert.equal(resolveEffectiveRunMode('something-new'), 'unknown');
+  });
+
+  it('blocks loudly when the effective mode is autonomous', () => {
+    const evidence = derive({
+      observedAutonomyLevel: 'autonomous',
+      approvalRows: [approvalRow()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'blocked-run-mode');
+    assert.equal(evidence.runModeBlocked, true);
+    assert.equal(evidence.incidentResolved, false);
+    assert.ok(evidence.securityFindings.some(finding => /AUTONOMOUS/i.test(finding)));
+  });
+
+  it('blocks when the effective mode cannot be observed', () => {
+    const evidence = derive({ observedAutonomyLevel: undefined, approvalRows: [approvalRow()] });
+    assert.equal(evidence.state, 'blocked-run-mode');
+    assert.equal(evidence.effectiveRunMode, 'unknown');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Correlation preconditions and schema drift
+// -----------------------------------------------------------------------------
+
+describe('preconditions', () => {
+  it('refuses to attach evidence without any correlation identifier', () => {
+    const evidence = derive({ correlation: {}, approvalRows: [approvalRow()] });
+    assert.equal(evidence.state, 'ambiguous');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports schema drift instead of a lifecycle state', () => {
+    const evidence = derive({ schemaMismatch: true, approvalRows: [approvalRow()], probes: passingProbes() });
+    assert.equal(evidence.state, 'no-evidence');
+    assert.equal(evidence.schemaMismatch, true);
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports `proposed` when nothing has been decided yet', () => {
+    const evidence = derive({});
+    assert.equal(evidence.state, 'proposed');
+    assert.equal(evidence.incidentResolved, false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Forgery, replay, ordering
+// -----------------------------------------------------------------------------
+
+describe('evidence forgery resistance', () => {
+  it('discards an approval whose identifiers belong to a different incident', () => {
+    const evidence = derive({
+      approvalRows: [approvalRow({ ThreadId: 'thread-attacker', CorrelationId: 'corr-attacker', IncidentId: 'INC-OTHER', TraceId: 'trace-other' })],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.approval, undefined);
+    assert.notEqual(evidence.state, 'verification-passed');
+    assert.ok(evidence.rejectedEvidence.some(reason => /ApprovalDecision.*mismatch/i.test(reason)));
+  });
+
+  it('rejects future-dated events beyond the clock-skew budget', () => {
+    const evidence = derive({
+      approvalRows: [approvalRow({ timestamp: T(3600) })],
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.approval, undefined);
+    assert.ok(evidence.rejectedEvidence.some(reason => /future/i.test(reason)));
+  });
+
+  it('deduplicates replayed events', () => {
+    const replayed = approvalRow({ RawDimensions: { Decision: 'Approved' }, CallId: 'call_dup' });
+    const evidence = derive({
+      approvalRows: [replayed, { ...replayed }, { ...replayed }],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.ok(evidence.rejectedEvidence.some(reason => /duplicate\/replayed/i.test(reason)));
+    assert.equal(evidence.state, 'verification-passed');
+  });
+
+  it('flags execution that precedes approval as a governance failure', () => {
+    const evidence = derive({
+      approvalRows: [approvalRow({ timestamp: T(-100) })],
+      toolExecutionRows: [toolRow({ timestamp: T(-500) }), toolEndRow({ timestamp: T(-450) })],
+      resourceStateBefore: state(T(-600), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'execution-failed');
+    assert.ok(evidence.securityFindings.some(finding => /Ordering violation/i.test(finding)));
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports execution without approval as a failure, never a mitigation', () => {
+    const evidence = derive({
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'execution-failed');
+    assert.ok(evidence.securityFindings.some(finding => /no correlated ApprovalDecision/i.test(finding)));
+  });
+
+  it('does not trust IncidentMitigatedByAgent without approval or execution telemetry', () => {
+    const evidence = derive({ incidentMitigatedByAgent: true, probes: passingProbes() });
+    assert.equal(evidence.state, 'proposed');
+    assert.equal(evidence.incidentResolved, false);
+    assert.ok(evidence.securityFindings.some(finding => /IncidentMitigatedByAgent=true/.test(finding)));
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Deny path
+// -----------------------------------------------------------------------------
+
+describe('deny path', () => {
+  const rejection = () => approvalRow({ RawDimensions: { Decision: 'Rejected' } });
+
+  it('reports `denied` only with a rejection AND proof of no mutation', () => {
+    const evidence = derive({
+      approvalRows: [rejection()],
+      resourceStateBefore: state(T(-400), 0, 3),
+      resourceStateAfter: state(T(-30), 0, 3),
+    });
+    assert.equal(evidence.state, 'denied');
+    assert.equal(evidence.resourceState?.mutation, 'unchanged');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('never reports `denied` without before/after evidence', () => {
+    const evidence = derive({ approvalRows: [rejection()] });
+    assert.equal(evidence.state, 'denied-with-unverified-state');
+    assert.equal(evidence.resourceState?.mutation, 'unknown');
+  });
+
+  it('never rewrites a partial observation into `unchanged`', () => {
+    const evidence = derive({
+      approvalRows: [rejection()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: undefined,
+    });
+    assert.equal(evidence.state, 'denied-with-unverified-state');
+    assert.equal(evidence.resourceState?.mutation, 'unknown');
+  });
+
+  it('raises a deny violation when the resource mutated after a rejection', () => {
+    const evidence = derive({
+      approvalRows: [rejection()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+    });
+    assert.equal(evidence.state, 'deny-violation');
+    assert.ok(evidence.securityFindings.some(finding => /DENY VIOLATION/.test(finding)));
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('anchors the before reading at or before the decision, not at the previous poll', () => {
+    // Regression: a mutation that has already settled must not be masked by two later readings.
+    // History spans the decision; the pre-decision reading is 0, the current reading is 1.
+    const evidence = derive({
+      approvalRows: [rejection()],
+      resourceStateHistory: [state(T(-600), 0), state(T(-500), 0), state(T(-120), 1), state(T(-60), 1)],
+      resourceStateAfter: state(T(-30), 1),
+    });
+    assert.equal(evidence.state, 'deny-violation');
+    assert.equal(evidence.resourceState?.mutation, 'applied');
+  });
+
+  it('reports unverified state when the history contains nothing older than the decision', () => {
+    const evidence = derive({
+      approvalRows: [rejection()],
+      resourceStateHistory: [state(T(-120), 1), state(T(-60), 1)],
+      resourceStateAfter: state(T(-30), 1),
+    });
+    assert.equal(evidence.state, 'denied-with-unverified-state');
+    assert.equal(evidence.resourceState?.mutation, 'unknown');
+  });
+
+  it('discards an explicit before reading that post-dates the decision', () => {
+    const evidence = derive({
+      approvalRows: [rejection()],
+      resourceStateBefore: state(T(-10), 0),
+      resourceStateAfter: state(T(-5), 0),
+    });
+    assert.equal(evidence.state, 'denied-with-unverified-state');
+    assert.ok(evidence.rejectedEvidence.some(reason => /post-dates the decision/.test(reason)));
+  });
+
+  it('selectPreDecisionObservation never returns a post-decision reading', () => {
+    const history = [state(T(-600), 0), state(T(-120), 1), state(T(-60), 1)];
+    const decisionMs = Date.parse(T(-300));
+    assert.equal(selectPreDecisionObservation(history, decisionMs)?.observedAt, T(-600));
+    assert.equal(selectPreDecisionObservation(history, Date.parse(T(-700))), undefined);
+    assert.equal(selectPreDecisionObservation([], decisionMs), undefined);
+    assert.equal(selectPreDecisionObservation(history, undefined), undefined);
+  });
+
+  it('treats stale before/after evidence as unverified', () => {
+    const evidence = derive({
+      approvalRows: [rejection()],
+      resourceStateBefore: state(T(-7200), 0),
+      resourceStateAfter: state(T(-3600), 0),
+    });
+    assert.equal(evidence.state, 'denied-with-unverified-state');
+  });
+
+  it('rejects an out-of-order before/after pair', () => {
+    const mutation = resolveMutationState(state(T(-30), 0), state(T(-400), 0), NOW.getTime(), 900);
+    assert.equal(mutation.mutation, 'unknown');
+    assert.match(mutation.reason, /out of order/i);
+  });
+
+  it('refuses to compare observations of a different resource', () => {
+    const foreign: ResourceStateObservation = { ...state(T(-30), 0), resource: 'energy/meter-service' };
+    const mutation = resolveMutationState(state(T(-400), 0), foreign, NOW.getTime(), 900);
+    assert.equal(mutation.mutation, 'unknown');
+  });
+
+  it('detects mutation via observedGeneration even when replicas match', () => {
+    const mutation = resolveMutationState(state(T(-400), 0, 3), state(T(-30), 0, 4), NOW.getTime(), 900);
+    assert.equal(mutation.mutation, 'applied');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Approve / execute / verify path
+// -----------------------------------------------------------------------------
+
+describe('approve, execute and verify path', () => {
+  const approved = () => approvalRow({ RawDimensions: { Decision: 'Approved' } });
+
+  it('reports `approved` when execution telemetry has not appeared', () => {
+    const evidence = derive({ approvalRows: [approved()], probes: passingProbes() });
+    assert.equal(evidence.state, 'approved');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports `executing` while only a ToolStart is observed', () => {
+    const evidence = derive({ approvalRows: [approved()], toolExecutionRows: [toolRow()], probes: passingProbes() });
+    assert.equal(evidence.state, 'executing');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports `execution-blocked` when the enforcement boundary refused the call', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow({ ToolOutput: 'Error from server (Forbidden): RBAC: access denied' })],
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'execution-blocked');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports `verification-failed` when a probe is missing', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: [probe('kubernetes-readiness'), probe('service-endpoint-health')],
+    });
+    assert.equal(evidence.state, 'verification-failed');
+    assert.deepEqual(evidence.verification.missingProbes, ['golden-transaction']);
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports `verification-failed` when the functional probe has no data', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: [probe('kubernetes-readiness'), probe('service-endpoint-health'), probe('golden-transaction', 'no-data')],
+    });
+    assert.equal(evidence.state, 'verification-failed');
+    assert.ok(evidence.guidance.rollbackCommand);
+    assert.equal(evidence.guidance.rollbackCommand, ROLLBACK_COMMAND);
+  });
+
+  it('reports `verification-failed` when a probe is stale', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: [probe('kubernetes-readiness'), probe('service-endpoint-health'), probe('golden-transaction', 'stale')],
+    });
+    assert.equal(evidence.state, 'verification-failed');
+  });
+
+  it('rejects verification collected BEFORE the execution completed', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow({ timestamp: T(-100) })],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(T(-500)),
+    });
+    assert.equal(evidence.state, 'verification-failed');
+    assert.equal(evidence.verification.postDatesExecution, false);
+  });
+
+  it('rejects probes with no timestamp', () => {
+    const untimed = passingProbes().map(item => ({ ...item, observedAt: undefined, freshnessSeconds: undefined }));
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: untimed,
+    });
+    assert.equal(evidence.state, 'verification-failed');
+  });
+
+  it('cannot be padded with duplicate passing probes', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: [probe('kubernetes-readiness'), probe('kubernetes-readiness'), probe('kubernetes-readiness')],
+    });
+    assert.equal(evidence.state, 'verification-failed');
+    assert.equal(evidence.verification.probes.length, 1);
+  });
+
+  it('refuses to claim recovery when the resource never actually changed', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 1),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'verification-failed');
+  });
+
+  it('reports `verification-passed` only for the complete, ordered, fresh chain', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow()],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'verification-passed');
+    assert.equal(evidence.incidentResolved, true);
+    assert.equal(evidence.verification.allProbesPassed, true);
+    assert.equal(evidence.verification.postDatesExecution, true);
+    assert.equal(evidence.approval?.outcome, 'approved');
+    assert.equal(evidence.execution?.allowlisted, true);
+    // Structured evidence, not booleans.
+    for (const item of evidence.verification.probes) {
+      assert.ok(item.source && item.observedValue && item.observedAt && item.evidencePointer);
+    }
+  });
+
+  it('classifies the allowlisted rollback as `rolled-back`, not recovery', () => {
+    const rollbackInput = JSON.stringify({ command: ROLLBACK_COMMAND });
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow({ ToolInput: rollbackInput }), toolEndRow({ ToolInput: rollbackInput })],
+      resourceStateBefore: state(T(-400), 1),
+      resourceStateAfter: state(T(-30), 0),
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'rolled-back');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('reports `execution-failed` when the approved action errored', () => {
+    const evidence = derive({
+      approvalRows: [approved()],
+      toolExecutionRows: [toolRow(), toolEndRow({ ToolOutput: 'error: timed out waiting for the condition' })],
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'execution-failed');
+    assert.equal(evidence.guidance.rollbackCommand, ROLLBACK_COMMAND);
+  });
+
+  it('reports `proposed` when the approval outcome is unreadable (SCHEMA_TBD)', () => {
+    const evidence = derive({ approvalRows: [approvalRow({ RawDimensions: { Note: 'n/a' } })] });
+    assert.equal(evidence.state, 'proposed');
+    assert.equal(evidence.approval?.outcome, 'unknown');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Allowlist bypass at the evidence boundary
+// -----------------------------------------------------------------------------
+
+describe('allowlist enforcement at the evidence boundary', () => {
+  it('records an out-of-scope tool call as a security finding and never as progress', () => {
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [toolRow({ ToolInput: JSON.stringify({ command: 'kubectl delete deployment/mongodb -n energy' }) })],
+      probes: passingProbes(),
+    });
+    assert.ok(evidence.securityFindings.some(finding => /Out-of-scope tool call/.test(finding)));
+    assert.equal(evidence.state, 'approved');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('does not let an out-of-scope execution satisfy the execution requirement', () => {
+    const bad = JSON.stringify({ command: 'kubectl scale deployment/meter-service -n energy --replicas=5' });
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [toolRow({ ToolInput: bad }), toolEndRow({ ToolInput: bad })],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.state, 'approved');
+    assert.equal(evidence.execution, undefined);
+  });
+});

--- a/mission-control/backend/src/services/sre-agent/mitigationLifecycle.test.ts
+++ b/mission-control/backend/src/services/sre-agent/mitigationLifecycle.test.ts
@@ -757,6 +757,89 @@ describe('allowlist enforcement at the evidence boundary', () => {
     assert.equal(evidence.incidentResolved, false);
   });
 
+  it('flags an out-of-scope call represented ONLY by a successful ToolEnd', () => {
+    // Security regression: ToolEnd rows were excluded from the out-of-scope scan, so a disallowed
+    // operation that actually COMPLETED produced no finding -- quieter than a mere attempt.
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [
+        toolEndRow({
+          ToolInput: JSON.stringify({ command: 'kubectl delete deployment/mongodb -n energy' }),
+          ToolOutput: 'deployment.apps "mongodb" deleted',
+          CallId: 'call_destructive',
+        }),
+      ],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    const findings = evidence.securityFindings.filter(finding => /Out-of-scope tool call/.test(finding));
+    assert.equal(findings.length, 1, 'a completed out-of-scope call must raise exactly one finding');
+    assert.match(findings[0]!, /ToolEnd/);
+    assert.match(findings[0]!, /COMPLETED/);
+    // It must never satisfy execution or verification.
+    assert.equal(evidence.execution, undefined);
+    assert.notEqual(evidence.state, 'verification-passed');
+    assert.equal(evidence.incidentResolved, false);
+  });
+
+  it('dedupes a ToolStart/ToolEnd pair for the same out-of-scope call by CallId', () => {
+    const bad = JSON.stringify({ command: 'kubectl delete ns energy' });
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [
+        toolRow({ ToolInput: bad, CallId: 'call_same' }),
+        toolEndRow({ ToolInput: bad, ToolOutput: 'namespace "energy" deleted', CallId: 'call_same' }),
+      ],
+      probes: passingProbes(),
+    });
+    const findings = evidence.securityFindings.filter(finding => /Out-of-scope tool call/.test(finding));
+    assert.equal(findings.length, 1, 'a Start/End pair is one attempt, not two');
+    // The ToolEnd row wins because it carries the outcome.
+    assert.match(findings[0]!, /ToolEnd/);
+  });
+
+  it('falls back to SpanId then command text when CallId is absent', () => {
+    const bad = JSON.stringify({ command: 'kubectl exec mongodb -n energy -- sh' });
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [
+        toolRow({ ToolInput: bad, CallId: undefined, SpanId: 'span-1' }),
+        toolEndRow({ ToolInput: bad, CallId: undefined, SpanId: 'span-1' }),
+      ],
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.securityFindings.filter(finding => /Out-of-scope tool call/.test(finding)).length, 1);
+  });
+
+  it('reports distinct out-of-scope calls separately', () => {
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [
+        toolEndRow({ ToolInput: JSON.stringify({ command: 'kubectl delete ns energy' }), CallId: 'call_a' }),
+        toolEndRow({ ToolInput: JSON.stringify({ command: 'kubectl exec mongodb -n energy -- sh' }), CallId: 'call_b' }),
+      ],
+      probes: passingProbes(),
+    });
+    assert.equal(evidence.securityFindings.filter(finding => /Out-of-scope tool call/.test(finding)).length, 2);
+  });
+
+  it('does not let a disallowed successful ToolEnd reach verification-passed alongside a valid one', () => {
+    // Even when a legitimate allowlisted execution exists, the disallowed completion must surface.
+    const evidence = derive({
+      approvalRows: [approvalRow({ RawDimensions: { Decision: 'Approved' } })],
+      toolExecutionRows: [
+        toolRow(),
+        toolEndRow(),
+        toolEndRow({ ToolInput: JSON.stringify({ command: 'kubectl delete ns energy' }), CallId: 'call_evil' }),
+      ],
+      resourceStateBefore: state(T(-400), 0),
+      resourceStateAfter: state(T(-30), 1),
+      probes: passingProbes(),
+    });
+    assert.ok(evidence.securityFindings.some(finding => /Out-of-scope tool call/.test(finding) && /COMPLETED/.test(finding)));
+  });
+
   it('does not let an out-of-scope execution satisfy the execution requirement', () => {
     const bad = JSON.stringify({ command: 'kubectl scale deployment/meter-service -n energy --replicas=5' });
     const evidence = derive({

--- a/mission-control/backend/src/services/sre-agent/mitigationLifecycle.ts
+++ b/mission-control/backend/src/services/sre-agent/mitigationLifecycle.ts
@@ -942,11 +942,30 @@ export function deriveMitigationLifecycle(input: DeriveMitigationLifecycleInput)
   }
 
   // --- Out-of-scope / blocked attempts are security findings, never progress -------------------
-  const outOfScope = tools.filter(row => !row.allowlisted && row.eventType !== 'ToolEnd');
-  for (const row of outOfScope) {
+  //
+  // Every non-allowlisted row is reported regardless of EventType. Excluding `ToolEnd` (as an
+  // earlier revision did) meant a disallowed operation that SUCCEEDED and was represented only by
+  // its ToolEnd row produced no security finding at all -- the completion of a forbidden action was
+  // quieter than its attempt. Start/End pairs for the same call are deduped by CallId (falling back
+  // to SpanId, then the command text) so one attempt yields one finding.
+  const outOfScopeByCall = new Map<string, ParsedToolExecutionRow>();
+  for (const row of tools) {
+    if (row.allowlisted) continue;
     const command = extractToolCommand(row.toolInput);
+    const identity = row.callId ?? row.spanId ?? `${row.toolName ?? 'unknown'}|${command ?? 'unknown'}`;
+    const existing = outOfScopeByCall.get(identity);
+    // Prefer the ToolEnd row: it carries the outcome, which is the more serious evidence.
+    if (!existing || (existing.eventType !== 'ToolEnd' && row.eventType === 'ToolEnd')) {
+      outOfScopeByCall.set(identity, row);
+    }
+  }
+  for (const row of outOfScopeByCall.values()) {
+    const command = extractToolCommand(row.toolInput);
+    const outcome = row.eventType === 'ToolEnd'
+      ? (row.blocked ? 'It was blocked at the enforcement boundary.' : 'It COMPLETED -- treat this as a policy bypass until proven otherwise.')
+      : 'It must not have executed.';
     securityFindings.push(
-      `Out-of-scope tool call observed at ${row.observedAt}: tool='${row.toolName ?? 'unknown'}' command='${(command ?? 'unknown').slice(0, 200)}'. It is outside the allowlist in docs/REVIEW-MODE-MITIGATION.md §3 and must not have executed.`,
+      `Out-of-scope tool call observed at ${row.observedAt} (${row.eventType}): tool='${row.toolName ?? 'unknown'}' command='${(command ?? 'unknown').slice(0, 200)}'. It is outside the allowlist in docs/REVIEW-MODE-MITIGATION.md §3. ${outcome}`,
     );
   }
   const blockedRows = tools.filter(row => row.blocked);

--- a/mission-control/backend/src/services/sre-agent/mitigationLifecycle.ts
+++ b/mission-control/backend/src/services/sre-agent/mitigationLifecycle.ts
@@ -1,0 +1,1171 @@
+/**
+ * Review-mode mitigation lifecycle (issue #80).
+ *
+ * This module derives the mitigation lifecycle **exclusively from observed, runtime-validated
+ * Azure SRE Agent audit telemetry**. It never accepts a lifecycle state, an approval, an execution,
+ * or a verification result from a request body or any other caller assertion.
+ *
+ * Design gate, blast radius, permission boundary and rollback plan: docs/REVIEW-MODE-MITIGATION.md
+ *
+ * Hard rules enforced here:
+ *  - Events join only on EXACT string equality of ThreadId / CorrelationId / IncidentId / TraceId.
+ *    An identifier present on both sides that differs is a mismatch and the row is discarded.
+ *  - `denied` requires an observed rejection AND before/after resource state proving no mutation.
+ *    `applied` / `unknown` mutation is NEVER rewritten into `unchanged`.
+ *  - `verification-passed` requires an observed approval, matching execution telemetry, and three
+ *    structured probes that all post-date execution. Booleans alone are never sufficient.
+ *  - An effective run mode other than `review` blocks the flow loudly.
+ *  - Replayed, duplicated, future-dated and out-of-order rows are rejected with a stated reason.
+ *
+ * Telemetry field names come from
+ * https://learn.microsoft.com/azure/sre-agent/audit-agent-actions. Fields Microsoft does not
+ * itemise (ApprovalDecision outcome, AgentAzCliExecution dimensions) are marked SCHEMA_TBD per
+ * docs/CAPABILITY-CONTRACTS.md §8 and resolve to `unknown` rather than a guess.
+ */
+
+import { redactSensitiveText } from './redaction.js';
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/** Freshness budget for every observed row and probe, in seconds. */
+export const DEFAULT_MITIGATION_STALE_SECONDS = 15 * 60;
+
+/** Tolerated forward clock skew. Anything beyond this is treated as a fabricated future timestamp. */
+export const DEFAULT_MAX_CLOCK_SKEW_SECONDS = 120;
+
+/** The single remediation the Energy Grid lab permits, plus its rollback. */
+export const MITIGATION_TARGET = Object.freeze({
+  namespace: 'energy',
+  kind: 'Deployment',
+  name: 'mongodb',
+  resource: 'energy/mongodb',
+  restoreReplicas: 1,
+  rollbackReplicas: 0,
+});
+
+export const ALLOWLISTED_MITIGATION_COMMANDS: readonly string[] = Object.freeze([
+  'kubectl scale deployment/mongodb -n energy --replicas=1',
+  'kubectl scale deployment/mongodb -n energy --replicas=0',
+]);
+
+export const ALLOWLISTED_MITIGATION_TOOLS: readonly string[] = Object.freeze(['RunKubectlWriteCommand']);
+
+export const ROLLBACK_COMMAND = 'kubectl scale deployment/mongodb -n energy --replicas=0';
+
+/** Shell metacharacters that must never appear in an allowlisted command. */
+const SHELL_METACHARACTERS = /[;&|`$><\n\r\\]|\$\(/;
+
+/**
+ * Candidate dimension keys that may carry the ApprovalDecision outcome.
+ * SCHEMA_TBD: Microsoft Learn publishes only `project timestamp, customDimensions` for
+ * ApprovalDecision, so the exact key is unknown. We scan a bounded candidate list and report
+ * `unknown` when none matches -- never a default of "approved".
+ */
+const APPROVAL_OUTCOME_KEYS = Object.freeze([
+  'Decision', 'ApprovalDecision', 'Outcome', 'Approved', 'Action', 'Status', 'Result', 'UserDecision',
+]);
+
+const APPROVED_TOKENS = Object.freeze(['approve', 'approved', 'accept', 'accepted', 'allow', 'allowed', 'yes', 'true', 'confirm', 'confirmed']);
+const REJECTED_TOKENS = Object.freeze(['deny', 'denied', 'reject', 'rejected', 'decline', 'declined', 'no', 'false', 'cancel', 'cancelled', 'canceled']);
+
+/** Signals in tool output that indicate the call was blocked rather than executed. */
+const BLOCKED_OUTPUT_PATTERNS: readonly RegExp[] = Object.freeze([
+  /\bforbidden\b/i,
+  /\bis not allowed\b/i,
+  /\bdenied by (policy|tool access policy)\b/i,
+  /\bblocked by (policy|tool access policy)\b/i,
+  /\bcannot (get|list|update|patch|scale) resource\b/i,
+  /\buser .* cannot \w+ resource\b/i,
+  /\bRBAC: access denied\b/i,
+  /\bnot authorized\b/i,
+  /\berror from server \(forbidden\)/i,
+]);
+
+const FAILED_OUTPUT_PATTERNS: readonly RegExp[] = Object.freeze([
+  /\berror\b/i,
+  /\bfailed\b/i,
+  /\btimed out\b/i,
+  /\bunable to\b/i,
+]);
+
+// -----------------------------------------------------------------------------
+// Public types
+// -----------------------------------------------------------------------------
+
+export type ReviewModeMitigationState =
+  | 'no-evidence'
+  | 'blocked-run-mode'
+  | 'ambiguous'
+  | 'proposed'
+  | 'denied'
+  | 'denied-with-unverified-state'
+  | 'deny-violation'
+  | 'approved'
+  | 'executing'
+  | 'execution-blocked'
+  | 'execution-failed'
+  | 'verification-passed'
+  | 'verification-failed'
+  | 'rolled-back';
+
+export type MitigationRunMode = 'review' | 'autonomous' | 'unknown';
+export type MitigationApprovalOutcome = 'approved' | 'rejected' | 'unknown';
+export type MitigationMutationState = 'unchanged' | 'applied' | 'unknown';
+
+export type VerificationProbeName = 'kubernetes-readiness' | 'service-endpoint-health' | 'golden-transaction';
+export type VerificationProbeStatus = 'pass' | 'fail' | 'no-data' | 'stale' | 'error';
+
+export const REQUIRED_VERIFICATION_PROBES: readonly VerificationProbeName[] = Object.freeze([
+  'kubernetes-readiness',
+  'service-endpoint-health',
+  'golden-transaction',
+]);
+
+/**
+ * Structured verification evidence. Deliberately NOT a boolean: every probe must state where the
+ * value came from, what the value was, when it was observed, how fresh it is, and how to find the
+ * underlying evidence.
+ */
+export interface VerificationProbeEvidence {
+  probe: VerificationProbeName;
+  status: VerificationProbeStatus;
+  source: string;
+  observedValue: string;
+  observedAt?: string;
+  freshnessSeconds?: number;
+  threshold?: string;
+  evidencePointer: string;
+  correlationId?: string;
+  detail?: string;
+}
+
+/** A point-in-time observation of the target resource, used to prove mutation or its absence. */
+export interface ResourceStateObservation {
+  source: string;
+  resource: string;
+  observedAt: string;
+  specReplicas?: number;
+  readyReplicas?: number;
+  observedGeneration?: number;
+  evidencePointer: string;
+}
+
+/** Exact identifiers a row must match to be admitted as evidence. */
+export interface MitigationCorrelationKey {
+  threadId?: string;
+  correlationId?: string;
+  incidentId?: string;
+  traceId?: string;
+}
+
+export interface ParsedApprovalDecisionRow {
+  observedAt: string;
+  outcome: MitigationApprovalOutcome;
+  outcomeSource?: string;
+  threadId?: string;
+  correlationId?: string;
+  incidentId?: string;
+  traceId?: string;
+  spanId?: string;
+  callId?: string;
+}
+
+export interface ParsedToolExecutionRow {
+  observedAt: string;
+  eventType: 'ToolStart' | 'ToolEnd' | 'unknown';
+  toolName?: string;
+  toolInput?: string;
+  toolOutput?: string;
+  callId?: string;
+  subAgentName?: string;
+  threadId?: string;
+  correlationId?: string;
+  traceId?: string;
+  spanId?: string;
+  allowlisted: boolean;
+  blocked: boolean;
+  failed: boolean;
+}
+
+export interface ParsedAzCliExecutionRow {
+  observedAt: string;
+  command?: string;
+  exitCode?: number;
+  succeeded?: boolean;
+  callId?: string;
+  threadId?: string;
+  correlationId?: string;
+  traceId?: string;
+  spanId?: string;
+}
+
+export interface MitigationApprovalEvidence {
+  outcome: MitigationApprovalOutcome;
+  observedAt: string;
+  outcomeSource?: string;
+  threadId?: string;
+  correlationId?: string;
+  incidentId?: string;
+  traceId?: string;
+  freshnessSeconds: number;
+  stale: boolean;
+}
+
+export interface MitigationExecutionEvidence {
+  toolName: string;
+  command?: string;
+  startedAt?: string;
+  completedAt?: string;
+  callId?: string;
+  threadId?: string;
+  correlationId?: string;
+  traceId?: string;
+  allowlisted: boolean;
+  blocked: boolean;
+  failed: boolean;
+  azCliCorrelated: boolean;
+  freshnessSeconds: number;
+  stale: boolean;
+}
+
+export interface MitigationResourceStateEvidence {
+  before?: ResourceStateObservation;
+  after?: ResourceStateObservation;
+  mutation: MitigationMutationState;
+  reason: string;
+}
+
+export interface MitigationVerificationEvidence {
+  probes: VerificationProbeEvidence[];
+  missingProbes: VerificationProbeName[];
+  allProbesPassed: boolean;
+  earliestProbeAt?: string;
+  postDatesExecution: boolean;
+}
+
+export interface MitigationGuidance {
+  rollbackCommand?: string;
+  rollbackRationale?: string;
+  escalation?: string;
+}
+
+export interface ReviewModeMitigationEvidence {
+  state: ReviewModeMitigationState;
+  /** True only for `verification-passed`. Every other state leaves the incident unresolved. */
+  incidentResolved: boolean;
+  effectiveRunMode: MitigationRunMode;
+  runModeBlocked: boolean;
+  scenario: 'MongoDBDown';
+  targetResource: string;
+  proposedCommand: string;
+  correlation: MitigationCorrelationKey;
+  approval?: MitigationApprovalEvidence;
+  execution?: MitigationExecutionEvidence;
+  resourceState?: MitigationResourceStateEvidence;
+  verification: MitigationVerificationEvidence;
+  guidance: MitigationGuidance;
+  observedAt?: string;
+  stale: boolean;
+  schemaMismatch: boolean;
+  securityFindings: string[];
+  rejectedEvidence: string[];
+  limitations: string[];
+}
+
+// -----------------------------------------------------------------------------
+// Primitive coercion helpers (shared discipline: never substitute a value we did not observe)
+// -----------------------------------------------------------------------------
+
+function toOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toTimestampMs(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function toOptionalInteger(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!/^-?\d+$/.test(trimmed)) return undefined;
+    const parsed = Number.parseInt(trimmed, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+/** Reads a customDimensions-style bag whether it arrived flattened or nested. */
+function readDimension(row: Record<string, unknown>, key: string): unknown {
+  if (row[key] !== undefined) return row[key];
+  const raw = row.RawDimensions ?? row.customDimensions;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return (raw as Record<string, unknown>)[key];
+  }
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return (parsed as Record<string, unknown>)[key];
+      }
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function readSharedIds(row: Record<string, unknown>) {
+  return {
+    threadId: toOptionalString(readDimension(row, 'ThreadId')),
+    correlationId: toOptionalString(readDimension(row, 'CorrelationId')),
+    incidentId: toOptionalString(readDimension(row, 'IncidentId')),
+    traceId: toOptionalString(readDimension(row, 'TraceId')),
+    spanId: toOptionalString(readDimension(row, 'SpanId')),
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Command allowlist (re-checked at Mission Control's own boundary, not trusted upstream)
+// -----------------------------------------------------------------------------
+
+/**
+ * Canonicalises a kubectl command so that documented equivalent spellings compare equal, without
+ * ever loosening the boundary.
+ *
+ * This is a strict tokeniser, deliberately NOT a regex over the whole string. An earlier
+ * lookahead-based implementation only checked that `-n energy` and `--replicas=N` appeared
+ * *somewhere* and then rebuilt a canonical string, silently discarding every other argument -- so
+ * `kubectl scale deployment/mongodb deployment/grid-api -n energy --replicas=1 --server https://evil
+ * --as system:masters` normalised into an allowlisted command. Every token must now be recognised;
+ * anything unexpected rejects the whole command.
+ */
+export function normalizeMitigationCommand(raw: string): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.length > 512) return undefined;
+  if (SHELL_METACHARACTERS.test(trimmed)) return undefined;
+
+  const tokens = trimmed.split(/\s+/);
+  if (tokens.length < 2 || tokens[0] !== 'kubectl' || tokens[1] !== 'scale') return undefined;
+
+  let target: string | undefined;
+  let namespace: string | undefined;
+  let replicas: string | undefined;
+
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+
+    if (token === '-n' || token === '--namespace') {
+      if (namespace !== undefined) return undefined; // repeated flag
+      const value = tokens[index + 1];
+      if (!value || value.startsWith('-')) return undefined;
+      namespace = value;
+      index += 1;
+      continue;
+    }
+
+    const namespaceInline = /^--namespace=(.+)$/.exec(token);
+    if (namespaceInline) {
+      if (namespace !== undefined) return undefined;
+      namespace = namespaceInline[1]!;
+      continue;
+    }
+
+    if (token === '--replicas') {
+      if (replicas !== undefined) return undefined;
+      const value = tokens[index + 1];
+      if (!value || value.startsWith('-')) return undefined;
+      replicas = value;
+      index += 1;
+      continue;
+    }
+
+    const replicasInline = /^--replicas=(.+)$/.exec(token);
+    if (replicasInline) {
+      if (replicas !== undefined) return undefined;
+      replicas = replicasInline[1]!;
+      continue;
+    }
+
+    // `kubectl scale deployment mongodb ...` -- the space-separated resource spelling.
+    if (target === undefined && /^deployments?(?:\.apps)?$/.test(token)) {
+      const value = tokens[index + 1];
+      if (!value || value.startsWith('-')) return undefined;
+      target = `deployment/${value}`;
+      index += 1;
+      continue;
+    }
+
+    // Any other flag is unrecognised. This is what rejects --server, --token, --kubeconfig,
+    // --as, --context, --insecure-skip-tls-verify, --all-namespaces and -A.
+    if (token.startsWith('-')) return undefined;
+
+    // At most one positional resource. A second one (e.g. another deployment) is a smuggled target.
+    if (target !== undefined) return undefined;
+    target = token;
+  }
+
+  if (target === undefined || namespace === undefined || replicas === undefined) return undefined;
+  if (!/^\d+$/.test(replicas)) return undefined;
+
+  const canonicalTarget = /^deployments?(?:\.apps)?\/(.+)$/.exec(target);
+  const normalizedTarget = canonicalTarget ? `deployment/${canonicalTarget[1]!}` : target;
+
+  return `kubectl scale ${normalizedTarget} -n ${namespace} --replicas=${replicas}`;
+}
+
+/** True only for the exact allowlisted restore/rollback commands. */
+export function isAllowlistedMitigationCommand(raw: unknown): boolean {
+  if (typeof raw !== 'string') return false;
+  const normalized = normalizeMitigationCommand(raw);
+  if (!normalized) return false;
+  return ALLOWLISTED_MITIGATION_COMMANDS.includes(normalized);
+}
+
+/** Extracts the command string from a `ToolInput` payload, which may be JSON or a bare string. */
+export function extractToolCommand(toolInput: string | undefined): string | undefined {
+  if (!toolInput) return undefined;
+  const trimmed = toolInput.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return trimmed;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === 'string') return parsed;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const bag = parsed as Record<string, unknown>;
+      for (const key of ['command', 'Command', 'cmd', 'script', 'input', 'arguments', 'args']) {
+        const value = bag[key];
+        if (typeof value === 'string' && value.trim()) return value.trim();
+      }
+    }
+  } catch {
+    return trimmed;
+  }
+  return trimmed;
+}
+
+// -----------------------------------------------------------------------------
+// Correlation
+// -----------------------------------------------------------------------------
+
+export type CorrelationVerdict = 'match' | 'mismatch' | 'insufficient';
+
+/**
+ * Compares a row's identifiers against the correlation key using exact string equality.
+ *
+ *  - Any identifier present on BOTH sides that differs => `mismatch` (hard reject; this is how a
+ *    forged or cross-incident row is caught).
+ *  - At least one identifier present on both sides and equal => `match`.
+ *  - No identifier present on both sides => `insufficient` (never assumed to match).
+ */
+export function correlateRow(
+  row: { threadId?: string; correlationId?: string; incidentId?: string; traceId?: string },
+  key: MitigationCorrelationKey,
+): CorrelationVerdict {
+  const fields: (keyof MitigationCorrelationKey)[] = ['threadId', 'correlationId', 'incidentId', 'traceId'];
+  let matched = false;
+  for (const field of fields) {
+    const expected = key[field];
+    const actual = row[field];
+    if (!expected || !actual) continue;
+    if (expected !== actual) return 'mismatch';
+    matched = true;
+  }
+  return matched ? 'match' : 'insufficient';
+}
+
+/**
+ * Correlates a RAW telemetry row (as returned by SreAgentEvidenceService) using the same strict
+ * rules as `correlateRow`.
+ *
+ * Callers must use this rather than an ad-hoc `row.IncidentId === x || row.ThreadId === y` check.
+ * An OR short-circuits: with a matching IncidentId it would never compare ThreadId, so a snapshot
+ * belonging to a DIFFERENT agent thread of the same incident would be accepted -- which matters
+ * most for the run-mode gate, where it could present an ungated autonomous write as a
+ * human-approved Review-mode mitigation.
+ */
+export function correlateRawRow(row: Record<string, unknown>, key: MitigationCorrelationKey): CorrelationVerdict {
+  return correlateRow(readSharedIds(row), key);
+}
+
+// -----------------------------------------------------------------------------
+// Row parsers -- each drops malformed rows instead of coercing them into something usable
+// -----------------------------------------------------------------------------
+
+function resolveApprovalOutcome(row: Record<string, unknown>): { outcome: MitigationApprovalOutcome; source?: string } {
+  for (const key of APPROVAL_OUTCOME_KEYS) {
+    const raw = readDimension(row, key);
+    if (raw === undefined || raw === null) continue;
+    const token = String(raw).trim().toLowerCase();
+    if (!token) continue;
+    if (APPROVED_TOKENS.includes(token)) return { outcome: 'approved', source: key };
+    if (REJECTED_TOKENS.includes(token)) return { outcome: 'rejected', source: key };
+  }
+  // SCHEMA_TBD: a decision row exists but no recognised outcome key. Report unknown, never guess.
+  return { outcome: 'unknown' };
+}
+
+export function parseApprovalDecisionRows(rawRows: Record<string, unknown>[]): ParsedApprovalDecisionRow[] {
+  const parsed: ParsedApprovalDecisionRow[] = [];
+  for (const row of rawRows) {
+    const observedAt = toOptionalString(row.timestamp) ?? toOptionalString(readDimension(row, 'LogTimestamp'));
+    if (!observedAt || toTimestampMs(observedAt) === undefined) continue;
+    const ids = readSharedIds(row);
+    const { outcome, source } = resolveApprovalOutcome(row);
+    parsed.push({
+      observedAt,
+      outcome,
+      outcomeSource: source,
+      ...ids,
+      callId: toOptionalString(readDimension(row, 'CallId')),
+    });
+  }
+  return parsed;
+}
+
+export function parseToolExecutionRows(rawRows: Record<string, unknown>[]): ParsedToolExecutionRow[] {
+  const parsed: ParsedToolExecutionRow[] = [];
+  for (const row of rawRows) {
+    const observedAt = toOptionalString(row.timestamp) ?? toOptionalString(readDimension(row, 'LogTimestamp'));
+    if (!observedAt || toTimestampMs(observedAt) === undefined) continue;
+
+    const rawEventType = toOptionalString(readDimension(row, 'EventType'));
+    const eventType: ParsedToolExecutionRow['eventType'] =
+      rawEventType === 'ToolStart' || rawEventType === 'ToolEnd' ? rawEventType : 'unknown';
+
+    const toolName = toOptionalString(readDimension(row, 'ToolName'));
+    const toolInput = toOptionalString(readDimension(row, 'ToolInput'));
+    const toolOutput = toOptionalString(readDimension(row, 'ToolOutput'));
+    const command = extractToolCommand(toolInput);
+
+    const allowlisted =
+      !!toolName && ALLOWLISTED_MITIGATION_TOOLS.includes(toolName) && isAllowlistedMitigationCommand(command);
+    const blocked = !!toolOutput && BLOCKED_OUTPUT_PATTERNS.some(pattern => pattern.test(toolOutput));
+    const failed = !blocked && !!toolOutput && FAILED_OUTPUT_PATTERNS.some(pattern => pattern.test(toolOutput));
+
+    parsed.push({
+      observedAt,
+      eventType,
+      toolName,
+      // Redact before the value can reach a response body, a log, or an evidence bundle.
+      toolInput: toolInput ? redactSensitiveText(toolInput).slice(0, 2_000) : undefined,
+      toolOutput: toolOutput ? redactSensitiveText(toolOutput).slice(0, 2_000) : undefined,
+      callId: toOptionalString(readDimension(row, 'CallId')),
+      subAgentName: toOptionalString(readDimension(row, 'SubAgentName')),
+      ...readSharedIds(row),
+      allowlisted,
+      blocked,
+      failed,
+    });
+  }
+  return parsed;
+}
+
+export function parseAzCliExecutionRows(rawRows: Record<string, unknown>[]): ParsedAzCliExecutionRow[] {
+  const parsed: ParsedAzCliExecutionRow[] = [];
+  for (const row of rawRows) {
+    const observedAt = toOptionalString(row.timestamp) ?? toOptionalString(readDimension(row, 'LogTimestamp'));
+    if (!observedAt || toTimestampMs(observedAt) === undefined) continue;
+    // SCHEMA_TBD: Microsoft names the AgentAzCliExecution event but does not itemise its fields.
+    const rawCommand = toOptionalString(readDimension(row, 'Command')) ?? toOptionalString(readDimension(row, 'AzCliCommand'));
+    const exitCode = toOptionalInteger(readDimension(row, 'ExitCode'));
+    const succeededRaw = toOptionalString(readDimension(row, 'Succeeded'));
+    parsed.push({
+      observedAt,
+      command: rawCommand ? redactSensitiveText(rawCommand).slice(0, 1_000) : undefined,
+      exitCode,
+      succeeded: succeededRaw === undefined ? undefined : succeededRaw.toLowerCase() === 'true',
+      callId: toOptionalString(readDimension(row, 'CallId')),
+      ...readSharedIds(row),
+    });
+  }
+  return parsed;
+}
+
+// -----------------------------------------------------------------------------
+// Temporal integrity
+// -----------------------------------------------------------------------------
+
+interface TemporalFilterResult<T> {
+  accepted: T[];
+  rejections: string[];
+}
+
+/**
+ * Rejects rows that are future-dated beyond the tolerated clock skew, and de-duplicates replayed
+ * rows. A replay is the same identity tuple (callId|spanId|correlationId + observedAt + kind)
+ * appearing more than once.
+ */
+function filterTemporalIntegrity<T extends { observedAt: string; callId?: string; spanId?: string; correlationId?: string }>(
+  rows: T[],
+  kind: string,
+  nowMs: number,
+  maxSkewSeconds: number,
+): TemporalFilterResult<T> {
+  const accepted: T[] = [];
+  const rejections: string[] = [];
+  const seen = new Set<string>();
+
+  for (const row of rows) {
+    const ms = toTimestampMs(row.observedAt);
+    if (ms === undefined) {
+      rejections.push(`${kind} row rejected: unparsable timestamp.`);
+      continue;
+    }
+    if (ms - nowMs > maxSkewSeconds * 1_000) {
+      rejections.push(
+        `${kind} row rejected: timestamp ${row.observedAt} is more than ${maxSkewSeconds}s in the future, which indicates a fabricated or clock-skewed event.`,
+      );
+      continue;
+    }
+    const identity = `${kind}|${row.callId ?? ''}|${row.spanId ?? ''}|${row.correlationId ?? ''}|${row.observedAt}`;
+    if (seen.has(identity)) {
+      rejections.push(`${kind} row rejected: duplicate/replayed event with identity already observed at ${row.observedAt}.`);
+      continue;
+    }
+    seen.add(identity);
+    accepted.push(row);
+  }
+
+  return { accepted, rejections };
+}
+
+function freshness(observedAt: string, nowMs: number): number {
+  return Math.max(0, Math.round((nowMs - (toTimestampMs(observedAt) ?? nowMs)) / 1_000));
+}
+
+// -----------------------------------------------------------------------------
+// Run mode
+// -----------------------------------------------------------------------------
+
+/**
+ * Resolves the EFFECTIVE run mode from observed telemetry. A response plan's configured mode is not
+ * trusted; only `AgentAutonomyLevel` as it was actually recorded for this incident counts.
+ */
+export function resolveEffectiveRunMode(autonomyLevel: string | undefined): MitigationRunMode {
+  const token = (autonomyLevel ?? '').trim().toLowerCase();
+  if (token === 'review') return 'review';
+  if (token === 'autonomous' || token === 'auto') return 'autonomous';
+  return 'unknown';
+}
+
+// -----------------------------------------------------------------------------
+// Resource state / mutation
+// -----------------------------------------------------------------------------
+
+/**
+ * Decides whether the target resource mutated between two observations.
+ * Returns `unknown` whenever the pair is incomplete or stale -- it NEVER downgrades an unknown or
+ * applied mutation into `unchanged`, because that is precisely how a denial could be faked.
+ */
+export function resolveMutationState(
+  before: ResourceStateObservation | undefined,
+  after: ResourceStateObservation | undefined,
+  nowMs: number,
+  staleSeconds: number,
+): MitigationResourceStateEvidence {
+  if (!before || !after) {
+    return {
+      before,
+      after,
+      mutation: 'unknown',
+      reason: 'Before/after resource-state observations are incomplete, so no claim about mutation can be made.',
+    };
+  }
+
+  if (before.resource !== MITIGATION_TARGET.resource || after.resource !== MITIGATION_TARGET.resource) {
+    return {
+      before,
+      after,
+      mutation: 'unknown',
+      reason: `Resource-state observations do not both target ${MITIGATION_TARGET.resource}; refusing to compare unrelated resources.`,
+    };
+  }
+
+  const beforeMs = toTimestampMs(before.observedAt);
+  const afterMs = toTimestampMs(after.observedAt);
+  if (beforeMs === undefined || afterMs === undefined) {
+    return { before, after, mutation: 'unknown', reason: 'A resource-state observation has an unusable timestamp.' };
+  }
+  if (afterMs < beforeMs) {
+    return { before, after, mutation: 'unknown', reason: 'The "after" observation predates the "before" observation; the pair is out of order.' };
+  }
+  if (freshness(after.observedAt, nowMs) > staleSeconds) {
+    return { before, after, mutation: 'unknown', reason: 'The "after" resource-state observation is stale; it cannot prove the current state.' };
+  }
+  if (before.specReplicas === undefined || after.specReplicas === undefined) {
+    return { before, after, mutation: 'unknown', reason: 'spec.replicas was not observed on both sides, so mutation cannot be determined.' };
+  }
+
+  const replicasChanged = before.specReplicas !== after.specReplicas;
+  const generationChanged =
+    before.observedGeneration !== undefined &&
+    after.observedGeneration !== undefined &&
+    before.observedGeneration !== after.observedGeneration;
+
+  if (replicasChanged || generationChanged) {
+    return {
+      before,
+      after,
+      mutation: 'applied',
+      reason: `Resource changed between observations (spec.replicas ${before.specReplicas} -> ${after.specReplicas}${generationChanged ? `, observedGeneration ${before.observedGeneration} -> ${after.observedGeneration}` : ''}).`,
+    };
+  }
+
+  return {
+    before,
+    after,
+    mutation: 'unchanged',
+    reason: `Resource unchanged between observations (spec.replicas remained ${before.specReplicas}).`,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Verification
+// -----------------------------------------------------------------------------
+
+function summarizeVerification(
+  probes: VerificationProbeEvidence[],
+  executionCompletedAtMs: number | undefined,
+): MitigationVerificationEvidence {
+  const byName = new Map<VerificationProbeName, VerificationProbeEvidence>();
+  for (const probe of probes) {
+    // Last writer wins per probe name so a caller cannot pad the array with a duplicate pass.
+    byName.set(probe.probe, probe);
+  }
+  const present = [...byName.values()];
+  const missingProbes = REQUIRED_VERIFICATION_PROBES.filter(name => !byName.has(name));
+
+  const probeTimes = present
+    .map(probe => toTimestampMs(probe.observedAt))
+    .filter((value): value is number => value !== undefined);
+  const earliest = probeTimes.length > 0 ? Math.min(...probeTimes) : undefined;
+
+  const postDatesExecution =
+    executionCompletedAtMs !== undefined &&
+    earliest !== undefined &&
+    probeTimes.length === present.length &&
+    earliest > executionCompletedAtMs;
+
+  const allProbesPassed =
+    missingProbes.length === 0 && present.length > 0 && present.every(probe => probe.status === 'pass');
+
+  return {
+    probes: present.sort((a, b) => a.probe.localeCompare(b.probe)),
+    missingProbes,
+    allProbesPassed,
+    earliestProbeAt: earliest !== undefined ? new Date(earliest).toISOString() : undefined,
+    postDatesExecution,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Lifecycle derivation
+// -----------------------------------------------------------------------------
+
+export interface DeriveMitigationLifecycleInput {
+  now?: Date;
+  /** Correlation identifiers previously OBSERVED for this incident (never operator-invented). */
+  correlation: MitigationCorrelationKey;
+  /** `AgentAutonomyLevel` as observed on the correlated IncidentActivitySnapshot row. */
+  observedAutonomyLevel?: string;
+  /** Whether the incident snapshot itself reported agent mitigation. */
+  incidentMitigatedByAgent?: boolean;
+  approvalRows?: Record<string, unknown>[];
+  toolExecutionRows?: Record<string, unknown>[];
+  azCliRows?: Record<string, unknown>[];
+  /**
+   * Explicit pre-decision observation. When omitted, one is selected from `resourceStateHistory`.
+   * Supplying this directly is intended for tests and for a caller that captured a genuine
+   * pre-decision reading.
+   */
+  resourceStateBefore?: ResourceStateObservation;
+  /**
+   * Time-ordered observations of the target resource. The "before" reading is chosen as the newest
+   * entry AT OR BEFORE the observed decision timestamp.
+   *
+   * This matters: using "the previous poll" instead would let the comparison window slide past a
+   * mutation. Once a mutation had settled, two later polls would both read the mutated value, and a
+   * rejected proposal that DID change the resource would be reported as a clean `denied`.
+   */
+  resourceStateHistory?: ResourceStateObservation[];
+  resourceStateAfter?: ResourceStateObservation;
+  probes?: VerificationProbeEvidence[];
+  staleSeconds?: number;
+  maxClockSkewSeconds?: number;
+  schemaMismatch?: boolean;
+}
+
+/**
+ * Picks the newest observation at or before `decisionAtMs`. Returns undefined when the history
+ * contains nothing old enough, so the caller reports `unknown` rather than comparing two
+ * post-decision readings.
+ */
+export function selectPreDecisionObservation(
+  history: ResourceStateObservation[] | undefined,
+  decisionAtMs: number | undefined,
+): ResourceStateObservation | undefined {
+  if (!history || history.length === 0 || decisionAtMs === undefined) return undefined;
+  let best: ResourceStateObservation | undefined;
+  let bestMs = Number.NEGATIVE_INFINITY;
+  for (const observation of history) {
+    const ms = toTimestampMs(observation.observedAt);
+    if (ms === undefined || ms > decisionAtMs) continue;
+    if (ms > bestMs) {
+      bestMs = ms;
+      best = observation;
+    }
+  }
+  return best;
+}
+
+/* eslint-disable-next-line complexity -- a single auditable decision table is safer here than
+   scattering the lifecycle rules across helpers that could drift apart. */
+export function deriveMitigationLifecycle(input: DeriveMitigationLifecycleInput): ReviewModeMitigationEvidence {
+  const now = input.now ?? new Date();
+  const nowMs = now.getTime();
+  const staleSeconds = input.staleSeconds ?? DEFAULT_MITIGATION_STALE_SECONDS;
+  const maxSkew = input.maxClockSkewSeconds ?? DEFAULT_MAX_CLOCK_SKEW_SECONDS;
+
+  const rejectedEvidence: string[] = [];
+  const securityFindings: string[] = [];
+  const limitations: string[] = [
+    'Every lifecycle state below is derived from observed Azure SRE Agent audit telemetry; Mission Control never accepts a lifecycle state, approval, or execution result asserted by a caller.',
+    'ApprovalDecision outcome fields are SCHEMA_TBD (docs/CAPABILITY-CONTRACTS.md §8); an unrecognised outcome resolves to `unknown`, never to `approved`.',
+  ];
+
+  const base = {
+    scenario: 'MongoDBDown' as const,
+    targetResource: MITIGATION_TARGET.resource,
+    proposedCommand: ALLOWLISTED_MITIGATION_COMMANDS[0]!,
+    correlation: input.correlation,
+    schemaMismatch: !!input.schemaMismatch,
+  };
+
+  const emptyVerification: MitigationVerificationEvidence = {
+    probes: [],
+    missingProbes: [...REQUIRED_VERIFICATION_PROBES],
+    allProbesPassed: false,
+    postDatesExecution: false,
+  };
+
+  if (input.schemaMismatch) {
+    return {
+      ...base,
+      state: 'no-evidence',
+      incidentResolved: false,
+      effectiveRunMode: 'unknown',
+      runModeBlocked: true,
+      verification: emptyVerification,
+      guidance: {
+        escalation: 'The audit telemetry schema no longer matches the documented event/field names. Re-validate against https://learn.microsoft.com/azure/sre-agent/audit-agent-actions before running the demo.',
+      },
+      stale: false,
+      securityFindings,
+      rejectedEvidence,
+      limitations: [...limitations, 'The evidence query failed schema validation, so no lifecycle state can be derived.'],
+    };
+  }
+
+  const hasCorrelationKey = Object.values(input.correlation).some(value => typeof value === 'string' && value.trim().length > 0);
+  if (!hasCorrelationKey) {
+    return {
+      ...base,
+      state: 'ambiguous',
+      incidentResolved: false,
+      effectiveRunMode: resolveEffectiveRunMode(input.observedAutonomyLevel),
+      runModeBlocked: true,
+      verification: emptyVerification,
+      guidance: { escalation: 'Provide an observed ThreadId, CorrelationId, IncidentId, or TraceId. Mission Control refuses to attach mitigation evidence without a precise identifier.' },
+      stale: false,
+      securityFindings,
+      rejectedEvidence: [...rejectedEvidence, 'No correlation identifier was supplied; all candidate evidence was discarded rather than matched heuristically.'],
+      limitations,
+    };
+  }
+
+  // --- Run-mode gate: must be observed as Review, loudly blocking otherwise. -------------------
+  const effectiveRunMode = resolveEffectiveRunMode(input.observedAutonomyLevel);
+  if (effectiveRunMode !== 'review') {
+    const detail =
+      effectiveRunMode === 'autonomous'
+        ? 'The response plan executed in AUTONOMOUS mode. Issue #80 forbids demonstrating autonomous execution; the approval gate did not apply.'
+        : 'The effective run mode could not be observed. Mission Control will not present an approval narrative it cannot prove.';
+    securityFindings.push(`Run-mode gate failed: effective mode is '${effectiveRunMode}', expected 'review'. ${detail}`);
+    return {
+      ...base,
+      state: 'blocked-run-mode',
+      incidentResolved: false,
+      effectiveRunMode,
+      runModeBlocked: true,
+      verification: emptyVerification,
+      guidance: {
+        escalation: 'Set the response plan Agent autonomy level to Review (https://learn.microsoft.com/azure/sre-agent/run-modes), re-run the scenario, and confirm AgentAutonomyLevel == "review" in IncidentActivitySnapshot before demonstrating this flow.',
+      },
+      stale: false,
+      securityFindings,
+      rejectedEvidence,
+      limitations,
+    };
+  }
+
+  // --- Parse + temporal integrity -------------------------------------------------------------
+  const approvalsParsed = filterTemporalIntegrity(parseApprovalDecisionRows(input.approvalRows ?? []), 'ApprovalDecision', nowMs, maxSkew);
+  const toolsParsed = filterTemporalIntegrity(parseToolExecutionRows(input.toolExecutionRows ?? []), 'AgentToolExecution', nowMs, maxSkew);
+  const azCliParsed = filterTemporalIntegrity(parseAzCliExecutionRows(input.azCliRows ?? []), 'AgentAzCliExecution', nowMs, maxSkew);
+  rejectedEvidence.push(...approvalsParsed.rejections, ...toolsParsed.rejections, ...azCliParsed.rejections);
+
+  // --- Exact-identifier correlation -----------------------------------------------------------
+  const approvals: ParsedApprovalDecisionRow[] = [];
+  for (const row of approvalsParsed.accepted) {
+    const verdict = correlateRow(row, input.correlation);
+    if (verdict === 'match') approvals.push(row);
+    else rejectedEvidence.push(`ApprovalDecision row at ${row.observedAt} rejected: identifier ${verdict} against the incident correlation key.`);
+  }
+
+  const tools: ParsedToolExecutionRow[] = [];
+  for (const row of toolsParsed.accepted) {
+    const verdict = correlateRow(row, input.correlation);
+    if (verdict === 'match') tools.push(row);
+    else rejectedEvidence.push(`AgentToolExecution row at ${row.observedAt} rejected: identifier ${verdict} against the incident correlation key.`);
+  }
+
+  const azCli: ParsedAzCliExecutionRow[] = [];
+  for (const row of azCliParsed.accepted) {
+    if (correlateRow(row, input.correlation) === 'match') azCli.push(row);
+  }
+
+  // --- Out-of-scope / blocked attempts are security findings, never progress -------------------
+  const outOfScope = tools.filter(row => !row.allowlisted && row.eventType !== 'ToolEnd');
+  for (const row of outOfScope) {
+    const command = extractToolCommand(row.toolInput);
+    securityFindings.push(
+      `Out-of-scope tool call observed at ${row.observedAt}: tool='${row.toolName ?? 'unknown'}' command='${(command ?? 'unknown').slice(0, 200)}'. It is outside the allowlist in docs/REVIEW-MODE-MITIGATION.md §3 and must not have executed.`,
+    );
+  }
+  const blockedRows = tools.filter(row => row.blocked);
+  for (const row of blockedRows) {
+    securityFindings.push(`Tool call at ${row.observedAt} was blocked by policy or the Kubernetes API server, as designed.`);
+  }
+
+  // --- Approval -------------------------------------------------------------------------------
+  const sortedApprovals = [...approvals].sort((a, b) => (toTimestampMs(b.observedAt) ?? 0) - (toTimestampMs(a.observedAt) ?? 0));
+  const latestApproval = sortedApprovals[0];
+  const approvalEvidence: MitigationApprovalEvidence | undefined = latestApproval
+    ? {
+        outcome: latestApproval.outcome,
+        observedAt: latestApproval.observedAt,
+        outcomeSource: latestApproval.outcomeSource,
+        threadId: latestApproval.threadId,
+        correlationId: latestApproval.correlationId,
+        incidentId: latestApproval.incidentId,
+        traceId: latestApproval.traceId,
+        freshnessSeconds: freshness(latestApproval.observedAt, nowMs),
+        stale: freshness(latestApproval.observedAt, nowMs) > staleSeconds,
+      }
+    : undefined;
+
+  // --- Execution ------------------------------------------------------------------------------
+  const allowlistedTools = tools.filter(row => row.allowlisted);
+  const executionStart = allowlistedTools.filter(row => row.eventType === 'ToolStart').sort((a, b) => (toTimestampMs(a.observedAt) ?? 0) - (toTimestampMs(b.observedAt) ?? 0))[0];
+  const executionEnd = allowlistedTools.filter(row => row.eventType === 'ToolEnd').sort((a, b) => (toTimestampMs(b.observedAt) ?? 0) - (toTimestampMs(a.observedAt) ?? 0))[0];
+  const executionAnchor = executionEnd ?? executionStart;
+
+  const executionEvidence: MitigationExecutionEvidence | undefined = executionAnchor
+    ? {
+        toolName: executionAnchor.toolName ?? 'unknown',
+        command: extractToolCommand(executionAnchor.toolInput),
+        startedAt: executionStart?.observedAt,
+        completedAt: executionEnd?.observedAt,
+        callId: executionAnchor.callId,
+        threadId: executionAnchor.threadId,
+        correlationId: executionAnchor.correlationId,
+        traceId: executionAnchor.traceId,
+        allowlisted: executionAnchor.allowlisted,
+        blocked: executionAnchor.blocked || (executionEnd?.blocked ?? false),
+        failed: executionEnd?.failed ?? false,
+        azCliCorrelated: azCli.length > 0,
+        freshnessSeconds: freshness(executionAnchor.observedAt, nowMs),
+        stale: freshness(executionAnchor.observedAt, nowMs) > staleSeconds,
+      }
+    : undefined;
+
+  const executionCompletedAtMs = executionEnd ? toTimestampMs(executionEnd.observedAt) : undefined;
+
+  // The "before" reading must predate the decision. An explicit one is trusted; otherwise select
+  // the newest historical observation at or before the decision, so the comparison window cannot
+  // slide past a mutation and turn a real change into a false `unchanged`.
+  const decisionAtMs = latestApproval ? toTimestampMs(latestApproval.observedAt) : undefined;
+  const selectedBefore = selectPreDecisionObservation(input.resourceStateHistory, decisionAtMs);
+  let resourceStateBefore = input.resourceStateBefore ?? selectedBefore;
+
+  if (resourceStateBefore && decisionAtMs !== undefined) {
+    const beforeMs = toTimestampMs(resourceStateBefore.observedAt);
+    if (beforeMs === undefined || beforeMs > decisionAtMs) {
+      rejectedEvidence.push(
+        `Resource-state "before" observation at ${resourceStateBefore.observedAt} post-dates the decision at ${latestApproval!.observedAt}; it cannot prove the pre-decision state and was discarded.`,
+      );
+      resourceStateBefore = undefined;
+    }
+  }
+
+  // --- Ordering integrity ---------------------------------------------------------------------
+  const approvalMs = latestApproval ? toTimestampMs(latestApproval.observedAt) : undefined;
+  const executionStartMs = executionStart ? toTimestampMs(executionStart.observedAt) : undefined;
+  const executionPrecedesApproval =
+    approvalMs !== undefined && executionStartMs !== undefined && executionStartMs < approvalMs;
+  if (executionPrecedesApproval) {
+    securityFindings.push(
+      `Ordering violation: an allowlisted execution started at ${executionStart!.observedAt}, before the approval recorded at ${latestApproval!.observedAt}. Execution must never precede approval in Review mode.`,
+    );
+  }
+
+  const resourceState = resolveMutationState(resourceStateBefore, input.resourceStateAfter, nowMs, staleSeconds);
+  const verification = summarizeVerification(input.probes ?? [], executionCompletedAtMs);
+
+  const observedAt = [latestApproval?.observedAt, executionAnchor?.observedAt]
+    .filter((value): value is string => !!value)
+    .sort((a, b) => (toTimestampMs(b) ?? 0) - (toTimestampMs(a) ?? 0))[0];
+  const stale = observedAt ? freshness(observedAt, nowMs) > staleSeconds : false;
+
+  const rollbackGuidance: MitigationGuidance = {
+    rollbackCommand: ROLLBACK_COMMAND,
+    rollbackRationale: `Returns ${MITIGATION_TARGET.resource} to the scenario's broken baseline. It is inside the same allowlist, so the rollback is itself gated and audited.`,
+    escalation: 'Leave the incident unresolved, capture the correlated ThreadId/CorrelationId timeline, and escalate to the platform owner before retrying.',
+  };
+
+  const result = (state: ReviewModeMitigationState, guidance: MitigationGuidance, extraLimitations: string[] = []): ReviewModeMitigationEvidence => ({
+    ...base,
+    state,
+    incidentResolved: state === 'verification-passed',
+    effectiveRunMode,
+    runModeBlocked: false,
+    approval: approvalEvidence,
+    execution: executionEvidence,
+    resourceState,
+    verification,
+    guidance,
+    observedAt,
+    stale,
+    securityFindings,
+    rejectedEvidence,
+    limitations: [...limitations, ...extraLimitations],
+  });
+
+  // --- Decision table -------------------------------------------------------------------------
+
+  if (executionPrecedesApproval) {
+    return result('execution-failed', rollbackGuidance, ['An execution was observed before its approval; the flow is not a valid Review-mode demonstration.']);
+  }
+
+  // Denial path. Requires BOTH an observed rejection AND proof of no mutation.
+  if (approvalEvidence?.outcome === 'rejected') {
+    if (resourceState.mutation === 'applied') {
+      securityFindings.push(
+        `DENY VIOLATION: the approval was rejected at ${approvalEvidence.observedAt}, but ${MITIGATION_TARGET.resource} still changed. ${resourceState.reason}`,
+      );
+      return result('deny-violation', rollbackGuidance, ['A rejected proposal must never mutate the resource. Investigate the tool access policy and RBAC boundary immediately.']);
+    }
+    if (resourceState.mutation !== 'unchanged' || approvalEvidence.stale) {
+      return result('denied-with-unverified-state', {
+        escalation: 'A rejection was observed, but the before/after resource state does not prove the resource was left untouched. Capture a fresh before/after pair before presenting the deny path.',
+      }, [
+        approvalEvidence.stale
+          ? 'The rejection event is stale, so it cannot describe the current state.'
+          : resourceState.reason,
+        'Mission Control will not report `denied` without proof of no mutation; it never rewrites `applied` or `unknown` into `unchanged`.',
+      ]);
+    }
+    return result('denied', {
+      escalation: 'No action was taken. Re-propose the mitigation to demonstrate the approve path.',
+    }, [resourceState.reason]);
+  }
+
+  // Blocked execution: an allowlisted call that the policy or API server refused.
+  if (executionEvidence?.blocked) {
+    return result('execution-blocked', rollbackGuidance, ['The execution was blocked at the enforcement boundary; no mitigation was applied.']);
+  }
+
+  // Approve path.
+  if (approvalEvidence?.outcome === 'approved') {
+    if (!executionEvidence) {
+      return result('approved', {
+        escalation: 'An approval was observed but no matching allowlisted execution telemetry has appeared yet. Do not report the mitigation as applied.',
+      }, ['Approval without correlated execution telemetry is reported as `approved`, never as executed or verified.']);
+    }
+    if (executionEvidence.failed) {
+      return result('execution-failed', rollbackGuidance, ['The approved action executed but reported a failure.']);
+    }
+    if (!executionEvidence.completedAt) {
+      return result('executing', {
+        escalation: 'Execution has started but no ToolEnd event has been observed. Wait for completion before verifying.',
+      }, ['No ToolEnd event was observed, so the execution is still in flight.']);
+    }
+    if (verification.probes.length === 0) {
+      return result('verification-failed', rollbackGuidance, ['No verification probes were collected, so recovery is unproven and the incident stays unresolved.']);
+    }
+    if (!verification.postDatesExecution) {
+      return result('verification-failed', rollbackGuidance, [
+        'At least one verification probe is missing a timestamp or does not post-date the execution. A probe collected before the fix cannot prove the fix worked.',
+      ]);
+    }
+    if (!verification.allProbesPassed) {
+      const failing = verification.probes.filter(probe => probe.status !== 'pass').map(probe => `${probe.probe}=${probe.status}`);
+      return result('verification-failed', rollbackGuidance, [
+        `Verification did not pass (${[...failing, ...verification.missingProbes.map(name => `${name}=missing`)].join(', ') || 'incomplete probe set'}). The incident remains unresolved.`,
+      ]);
+    }
+    if (resourceState.mutation === 'unchanged') {
+      return result('verification-failed', rollbackGuidance, [
+        'Verification probes passed, but the before/after resource state shows no change was applied. Refusing to report a mitigation that did not mutate the target.',
+      ]);
+    }
+    if (stale) {
+      return result('verification-failed', rollbackGuidance, ['The newest correlated evidence is stale; recovery cannot be claimed from it.']);
+    }
+
+    // Rollback is the same allowlisted command with --replicas=0.
+    const wasRollback = executionEvidence.command
+      ? normalizeMitigationCommand(executionEvidence.command) === ROLLBACK_COMMAND
+      : false;
+    if (wasRollback) {
+      return result('rolled-back', {
+        escalation: 'The rollback command executed and was verified. The scenario is back at its broken baseline.',
+      }, ['The executed command was the allowlisted rollback, not the restore.']);
+    }
+
+    return result('verification-passed', {}, [
+      'Recovery is evidenced by three structured probes (Kubernetes readiness, service endpoint health, and the synthetic golden transaction), each carrying source, observed value, timestamp and freshness.',
+    ]);
+  }
+
+  // An execution without any correlated approval is a governance failure.
+  if (executionEvidence) {
+    securityFindings.push(
+      `Execution observed at ${executionEvidence.completedAt ?? executionEvidence.startedAt ?? 'unknown time'} with no correlated ApprovalDecision. In Review mode every write must be preceded by a recorded approval.`,
+    );
+    return result('execution-failed', rollbackGuidance, ['Execution telemetry exists without a correlated approval; this is reported as a failure, not as a successful mitigation.']);
+  }
+
+  if (approvalEvidence && approvalEvidence.outcome === 'unknown') {
+    return result('proposed', {
+      escalation: 'An ApprovalDecision event was observed but its outcome could not be read from the documented schema. Confirm the decision in the SRE Agent portal before proceeding.',
+    }, ['ApprovalDecision outcome is SCHEMA_TBD; presence alone is never treated as approval.']);
+  }
+
+  if (input.incidentMitigatedByAgent) {
+    securityFindings.push(
+      'IncidentActivitySnapshot reports IncidentMitigatedByAgent=true, but no correlated ApprovalDecision or allowlisted execution was observed. Do not present this as an approved mitigation.',
+    );
+  }
+
+  return result('proposed', {
+    escalation: 'No approval decision has been recorded yet. The proposal is awaiting an operator decision in the SRE Agent portal.',
+  }, ['No ApprovalDecision row was correlated, so the mitigation is still awaiting a decision.']);
+}

--- a/mission-control/backend/src/services/sre-agent/mitigationProbes.test.ts
+++ b/mission-control/backend/src/services/sre-agent/mitigationProbes.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the structured verification probes (issue #80 §7).
+ *
+ * The contract these enforce: a probe never defaults to `pass`, always carries source/value/
+ * timestamp/freshness/pointer, and reports missing or stale data honestly.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { CustomerImpactResponse, InventoryResponse } from '../../types/index.js';
+import {
+  buildGoldenTransactionProbe,
+  buildKubernetesReadinessProbe,
+  buildServiceEndpointProbe,
+  buildVerificationProbes,
+  observeMitigationResourceState,
+} from './mitigationProbes.js';
+import { MITIGATION_TARGET, REQUIRED_VERIFICATION_PROBES } from './mitigationLifecycle.js';
+
+const NOW = new Date('2026-05-01T12:00:00.000Z');
+const FRESH = new Date(NOW.getTime() - 30_000).toISOString();
+const OLD = new Date(NOW.getTime() - 3_600_000).toISOString();
+
+function inventory(overrides: Partial<InventoryResponse['deployments'][number]> = {}, updatedAt = FRESH): InventoryResponse {
+  return {
+    namespace: 'energy',
+    updatedAt,
+    orphanPods: [],
+    services: [],
+    events: [],
+    deployments: [
+      {
+        name: MITIGATION_TARGET.name,
+        namespace: MITIGATION_TARGET.namespace,
+        desiredReplicas: 1,
+        readyPods: 1,
+        runningPods: 1,
+        replicas: 1,
+        updatedReplicas: 1,
+        availableReplicas: 1,
+        severity: 'healthy',
+        status: 'healthy',
+        reason: '',
+        restarts: 0,
+        age: '5m',
+        updatedAt,
+        labels: {},
+        annotations: {},
+        selectorLabels: {},
+        pods: [],
+        services: [],
+        endpointReadiness: [{ serviceName: MITIGATION_TARGET.name, ready: 1, notReady: 0, total: 1, addresses: [] }],
+        recentEvents: [],
+        ...overrides,
+      },
+    ],
+  } as InventoryResponse;
+}
+
+function impact(overrides: Partial<CustomerImpactResponse> = {}): CustomerImpactResponse {
+  return {
+    journey: 'meter-ingest',
+    status: 'healthy',
+    kubernetesDataStatus: 'available',
+    evidenceSources: ['synthetic'],
+    affectedStage: 'ingest',
+    recoveryCondition: 'success rate restored',
+    collectedAt: FRESH,
+    telemetry: {
+      dataStatus: 'available',
+      source: 'synthetic meter ingest',
+      runCount: 20,
+      successCount: 20,
+      failureCount: 0,
+      successRatePct: 100,
+      lastSuccess: FRESH,
+      lastSuccessAgeSeconds: 30,
+    },
+    ...overrides,
+  } as CustomerImpactResponse;
+}
+
+describe('kubernetes readiness probe', () => {
+  it('passes only when ready and available replicas are both at least one', () => {
+    const probe = buildKubernetesReadinessProbe(inventory(), NOW);
+    assert.equal(probe.status, 'pass');
+    assert.match(probe.observedValue, /readyReplicas=1/);
+    assert.ok(probe.source && probe.observedAt && probe.evidencePointer && probe.threshold);
+  });
+
+  it('fails when the deployment reports zero ready replicas', () => {
+    const probe = buildKubernetesReadinessProbe(inventory({ readyPods: 0, availableReplicas: 0, reason: 'ScaledToZero' }), NOW);
+    assert.equal(probe.status, 'fail');
+    assert.match(probe.detail ?? '', /ScaledToZero/);
+  });
+
+  it('reports no-data rather than pass when inventory is unavailable', () => {
+    assert.equal(buildKubernetesReadinessProbe(undefined, NOW).status, 'no-data');
+  });
+
+  it('reports no-data when the target deployment is absent', () => {
+    const empty = { ...inventory(), deployments: [] } as InventoryResponse;
+    assert.equal(buildKubernetesReadinessProbe(empty, NOW).status, 'no-data');
+  });
+
+  it('downgrades an otherwise-passing probe to stale when the observation is old', () => {
+    const probe = buildKubernetesReadinessProbe(inventory({}, OLD), NOW);
+    assert.equal(probe.status, 'stale');
+  });
+});
+
+describe('service endpoint probe', () => {
+  it('passes with at least one ready endpoint', () => {
+    assert.equal(buildServiceEndpointProbe(inventory(), NOW).status, 'pass');
+  });
+
+  it('fails when no endpoint is ready even though the pod exists', () => {
+    const probe = buildServiceEndpointProbe(
+      inventory({ endpointReadiness: [{ serviceName: MITIGATION_TARGET.name, ready: 0, notReady: 1, total: 1, addresses: [] }] }),
+      NOW,
+    );
+    assert.equal(probe.status, 'fail');
+  });
+
+  it('reports no-data when endpoint readiness is missing', () => {
+    assert.equal(buildServiceEndpointProbe(inventory({ endpointReadiness: [] }), NOW).status, 'no-data');
+    assert.equal(buildServiceEndpointProbe(undefined, NOW).status, 'no-data');
+  });
+});
+
+describe('golden transaction probe', () => {
+  it('passes when the synthetic journey has recovered', () => {
+    const probe = buildGoldenTransactionProbe(impact(), NOW);
+    assert.equal(probe.status, 'pass');
+    assert.match(probe.observedValue, /successRatePct=100/);
+  });
+
+  it('fails when the success rate is below the SLO threshold', () => {
+    const probe = buildGoldenTransactionProbe(
+      impact({ telemetry: { ...impact().telemetry, successRatePct: 40 } }),
+      NOW,
+    );
+    assert.equal(probe.status, 'fail');
+    assert.match(probe.detail ?? '', /successRatePct=40/);
+  });
+
+  it('fails when the journey status is critical even with a good rate', () => {
+    const probe = buildGoldenTransactionProbe(impact({ status: 'critical' }), NOW);
+    assert.equal(probe.status, 'fail');
+  });
+
+  it('fails when the last success is outside the freshness budget', () => {
+    const probe = buildGoldenTransactionProbe(
+      impact({ telemetry: { ...impact().telemetry, lastSuccessAgeSeconds: 4_000, lastSuccess: OLD } }),
+      NOW,
+    );
+    assert.notEqual(probe.status, 'pass');
+  });
+
+  it('reports no-data, never pass, when telemetry is empty', () => {
+    const probe = buildGoldenTransactionProbe(
+      impact({ telemetry: { dataStatus: 'no-data', source: 'synthetic' } }),
+      NOW,
+    );
+    assert.equal(probe.status, 'no-data');
+  });
+
+  it('reports error when the query itself was unavailable', () => {
+    const probe = buildGoldenTransactionProbe(
+      impact({ telemetry: { dataStatus: 'unavailable', source: 'synthetic', error: 'workspace not configured' } }),
+      NOW,
+    );
+    assert.equal(probe.status, 'error');
+    assert.match(probe.detail ?? '', /workspace not configured/);
+  });
+
+  it('reports no-data when the whole impact response is missing', () => {
+    assert.equal(buildGoldenTransactionProbe(undefined, NOW).status, 'no-data');
+  });
+});
+
+describe('probe set and resource observation', () => {
+  it('always returns exactly the three required probes', () => {
+    const probes = buildVerificationProbes(inventory(), impact(), NOW);
+    assert.deepEqual(probes.map(item => item.probe).sort(), [...REQUIRED_VERIFICATION_PROBES].sort());
+  });
+
+  it('still returns all three probes when every source is unavailable', () => {
+    const probes = buildVerificationProbes(undefined, undefined, NOW);
+    assert.equal(probes.length, 3);
+    assert.ok(probes.every(item => item.status !== 'pass'));
+  });
+
+  it('observes resource state for the deny proof', () => {
+    const observation = observeMitigationResourceState(inventory({ desiredReplicas: 0, readyPods: 0 }), 'before');
+    assert.equal(observation?.resource, MITIGATION_TARGET.resource);
+    assert.equal(observation?.specReplicas, 0);
+    assert.ok(observation?.evidencePointer.includes('before'));
+  });
+
+  it('returns undefined rather than inventing an observation', () => {
+    assert.equal(observeMitigationResourceState(undefined, 'after'), undefined);
+    const empty = { ...inventory(), deployments: [] } as InventoryResponse;
+    assert.equal(observeMitigationResourceState(empty, 'after'), undefined);
+  });
+});

--- a/mission-control/backend/src/services/sre-agent/mitigationProbes.ts
+++ b/mission-control/backend/src/services/sre-agent/mitigationProbes.ts
@@ -1,0 +1,274 @@
+/**
+ * Builds the three structured verification probes required by issue #80 before a Review-mode
+ * mitigation may be reported as recovered.
+ *
+ * Every probe carries source, observed value, timestamp, freshness and an evidence pointer.
+ * A boolean is never sufficient, and a probe that cannot be observed is reported as `no-data`
+ * or `stale` -- never silently omitted and never defaulted to `pass`.
+ *
+ * Contract: docs/REVIEW-MODE-MITIGATION.md §7
+ */
+
+import type { CustomerImpactResponse, InventoryResponse } from '../../types/index.js';
+import { SLO_METER_INGEST_DEMO_THRESHOLDS } from '../CustomerImpactService.js';
+import {
+  MITIGATION_TARGET,
+  type ResourceStateObservation,
+  type VerificationProbeEvidence,
+} from './mitigationLifecycle.js';
+
+/** A probe observed longer ago than this cannot prove the current state. */
+export const DEFAULT_PROBE_STALE_SECONDS = 5 * 60;
+
+function freshnessSeconds(observedAt: string, now: Date): number | undefined {
+  const parsed = Date.parse(observedAt);
+  if (Number.isNaN(parsed)) return undefined;
+  return Math.max(0, Math.round((now.getTime() - parsed) / 1_000));
+}
+
+function withStaleness(probe: VerificationProbeEvidence, staleSeconds: number): VerificationProbeEvidence {
+  if (probe.status !== 'pass') return probe;
+  if (probe.freshnessSeconds === undefined) {
+    return { ...probe, status: 'stale', detail: 'The probe has no usable timestamp, so its freshness cannot be established.' };
+  }
+  if (probe.freshnessSeconds > staleSeconds) {
+    return {
+      ...probe,
+      status: 'stale',
+      detail: `Observed ${probe.freshnessSeconds}s ago, beyond the ${staleSeconds}s freshness budget.`,
+    };
+  }
+  return probe;
+}
+
+/**
+ * Probe 1 -- Kubernetes readiness for the mitigation target.
+ * Passes only when the Deployment reports at least one ready AND one available replica.
+ */
+export function buildKubernetesReadinessProbe(
+  inventory: InventoryResponse | undefined,
+  now: Date,
+  staleSeconds = DEFAULT_PROBE_STALE_SECONDS,
+): VerificationProbeEvidence {
+  const source = `kubectl get deployment ${MITIGATION_TARGET.name} -n ${MITIGATION_TARGET.namespace}`;
+  const evidencePointer = `GET /api/inventory#deployments.${MITIGATION_TARGET.name}`;
+
+  if (!inventory) {
+    return {
+      probe: 'kubernetes-readiness',
+      status: 'no-data',
+      source,
+      observedValue: 'unavailable',
+      evidencePointer,
+      detail: 'Kubernetes inventory could not be read; readiness is unknown, not healthy.',
+    };
+  }
+
+  const deployment = inventory.deployments.find(
+    item => item.name === MITIGATION_TARGET.name && item.namespace === MITIGATION_TARGET.namespace,
+  );
+
+  if (!deployment) {
+    return {
+      probe: 'kubernetes-readiness',
+      status: 'no-data',
+      source,
+      observedValue: `deployment ${MITIGATION_TARGET.resource} not found`,
+      observedAt: inventory.updatedAt,
+      freshnessSeconds: freshnessSeconds(inventory.updatedAt, now),
+      evidencePointer,
+      detail: 'The target Deployment was not present in the inventory snapshot.',
+    };
+  }
+
+  const ready = deployment.readyPods ?? 0;
+  const available = deployment.availableReplicas ?? 0;
+  const passed = ready >= 1 && available >= 1;
+
+  return withStaleness(
+    {
+      probe: 'kubernetes-readiness',
+      status: passed ? 'pass' : 'fail',
+      source,
+      observedValue: `readyReplicas=${ready}, availableReplicas=${available}, desiredReplicas=${deployment.desiredReplicas}`,
+      observedAt: deployment.updatedAt ?? inventory.updatedAt,
+      freshnessSeconds: freshnessSeconds(deployment.updatedAt ?? inventory.updatedAt, now),
+      threshold: 'readyReplicas >= 1 and availableReplicas >= 1',
+      evidencePointer,
+      detail: passed ? undefined : `Deployment reason: ${deployment.reason || 'not reported'}`,
+    },
+    staleSeconds,
+  );
+}
+
+/**
+ * Probe 2 -- Service endpoint health.
+ * Passes only when the `mongodb` Service has at least one READY endpoint address, which is what
+ * actually proves dependent services can reach the database again.
+ */
+export function buildServiceEndpointProbe(
+  inventory: InventoryResponse | undefined,
+  now: Date,
+  staleSeconds = DEFAULT_PROBE_STALE_SECONDS,
+): VerificationProbeEvidence {
+  const source = `kubectl get endpoints ${MITIGATION_TARGET.name} -n ${MITIGATION_TARGET.namespace}`;
+  const evidencePointer = `GET /api/inventory#deployments.${MITIGATION_TARGET.name}.endpointReadiness`;
+
+  if (!inventory) {
+    return {
+      probe: 'service-endpoint-health',
+      status: 'no-data',
+      source,
+      observedValue: 'unavailable',
+      evidencePointer,
+      detail: 'Kubernetes inventory could not be read; endpoint health is unknown, not healthy.',
+    };
+  }
+
+  const deployment = inventory.deployments.find(
+    item => item.name === MITIGATION_TARGET.name && item.namespace === MITIGATION_TARGET.namespace,
+  );
+  const summaries = deployment?.endpointReadiness ?? [];
+  const summary = summaries.find(entry => entry.serviceName === MITIGATION_TARGET.name) ?? summaries[0];
+
+  if (!summary) {
+    return {
+      probe: 'service-endpoint-health',
+      status: 'no-data',
+      source,
+      observedValue: `no endpoint summary for service ${MITIGATION_TARGET.name}`,
+      observedAt: inventory.updatedAt,
+      freshnessSeconds: freshnessSeconds(inventory.updatedAt, now),
+      evidencePointer,
+      detail: 'No endpoint readiness data was observed for the target Service.',
+    };
+  }
+
+  const passed = summary.ready >= 1;
+  return withStaleness(
+    {
+      probe: 'service-endpoint-health',
+      status: passed ? 'pass' : 'fail',
+      source,
+      observedValue: `readyEndpoints=${summary.ready}, notReady=${summary.notReady}, total=${summary.total}`,
+      observedAt: deployment?.updatedAt ?? inventory.updatedAt,
+      freshnessSeconds: freshnessSeconds(deployment?.updatedAt ?? inventory.updatedAt, now),
+      threshold: 'readyEndpoints >= 1',
+      evidencePointer,
+      detail: passed ? undefined : 'No ready endpoint address; dependent services still cannot reach the database.',
+    },
+    staleSeconds,
+  );
+}
+
+/**
+ * Probe 3 -- the PR #84 synthetic golden transaction / customer-impact recovery signal.
+ * This is the scenario-relevant functional check: Kubernetes can report a healthy pod while the
+ * customer journey is still broken, so readiness alone is never accepted as recovery.
+ */
+export function buildGoldenTransactionProbe(
+  impact: CustomerImpactResponse | undefined,
+  now: Date,
+  staleSeconds = DEFAULT_PROBE_STALE_SECONDS,
+): VerificationProbeEvidence {
+  const source = 'Synthetic meter-ingest golden transaction (customer-impact SLO, PR #84)';
+  const evidencePointer = 'GET /api/customer-impact';
+  const threshold = `successRatePct >= ${SLO_METER_INGEST_DEMO_THRESHOLDS.successRatePct}, freshness <= ${SLO_METER_INGEST_DEMO_THRESHOLDS.freshnessMs / 1000}s, journey status not critical`;
+
+  if (!impact) {
+    return {
+      probe: 'golden-transaction',
+      status: 'no-data',
+      source,
+      observedValue: 'unavailable',
+      threshold,
+      evidencePointer,
+      detail: 'The customer-impact journey could not be evaluated; functional recovery is unproven.',
+    };
+  }
+
+  const telemetry = impact.telemetry;
+
+  if (telemetry.dataStatus !== 'available') {
+    return {
+      probe: 'golden-transaction',
+      status: telemetry.dataStatus === 'no-data' ? 'no-data' : 'error',
+      source: telemetry.source || source,
+      observedValue: `dataStatus=${telemetry.dataStatus}`,
+      observedAt: impact.collectedAt,
+      freshnessSeconds: freshnessSeconds(impact.collectedAt, now),
+      threshold,
+      evidencePointer,
+      detail: telemetry.error
+        ? `Golden-transaction telemetry is unavailable: ${telemetry.error}`
+        : 'No synthetic transaction runs were observed in the query window, so recovery is unproven.',
+    };
+  }
+
+  const successRate = telemetry.successRatePct;
+  const lastSuccessAge = telemetry.lastSuccessAgeSeconds;
+  const meetsRate = successRate !== undefined && successRate >= SLO_METER_INGEST_DEMO_THRESHOLDS.successRatePct;
+  const meetsFreshness =
+    lastSuccessAge !== undefined && lastSuccessAge <= SLO_METER_INGEST_DEMO_THRESHOLDS.freshnessMs / 1_000;
+  const journeyHealthy = impact.status === 'healthy' || impact.status === 'degraded';
+  const passed = meetsRate && meetsFreshness && journeyHealthy && impact.status !== 'critical';
+
+  const failureDetail: string[] = [];
+  if (!meetsRate) failureDetail.push(`successRatePct=${successRate ?? 'unknown'}`);
+  if (!meetsFreshness) failureDetail.push(`lastSuccessAgeSeconds=${lastSuccessAge ?? 'unknown'}`);
+  if (!journeyHealthy || impact.status === 'critical') failureDetail.push(`journeyStatus=${impact.status}`);
+
+  return withStaleness(
+    {
+      probe: 'golden-transaction',
+      status: passed ? 'pass' : 'fail',
+      source: telemetry.source || source,
+      observedValue: `journey=${impact.journey}, status=${impact.status}, successRatePct=${successRate ?? 'unknown'}, runs=${telemetry.runCount ?? 0}, lastSuccessAgeSeconds=${lastSuccessAge ?? 'unknown'}`,
+      observedAt: telemetry.lastSuccess ?? impact.collectedAt,
+      freshnessSeconds: freshnessSeconds(telemetry.lastSuccess ?? impact.collectedAt, now),
+      threshold,
+      evidencePointer,
+      detail: passed ? undefined : `Golden transaction has not recovered (${failureDetail.join(', ')}).`,
+    },
+    staleSeconds,
+  );
+}
+
+/**
+ * Observes the mitigation target's resource state for the deny / no-mutation proof.
+ * Returns `undefined` when the Deployment cannot be observed, so the caller reports `unknown`
+ * mutation rather than inventing an "unchanged" reading.
+ */
+export function observeMitigationResourceState(
+  inventory: InventoryResponse | undefined,
+  label: 'before' | 'after',
+): ResourceStateObservation | undefined {
+  if (!inventory) return undefined;
+  const deployment = inventory.deployments.find(
+    item => item.name === MITIGATION_TARGET.name && item.namespace === MITIGATION_TARGET.namespace,
+  );
+  if (!deployment) return undefined;
+
+  return {
+    source: `kubectl get deployment ${MITIGATION_TARGET.name} -n ${MITIGATION_TARGET.namespace} (${label})`,
+    resource: MITIGATION_TARGET.resource,
+    observedAt: deployment.updatedAt ?? inventory.updatedAt,
+    specReplicas: deployment.desiredReplicas,
+    readyReplicas: deployment.readyPods,
+    observedGeneration: undefined,
+    evidencePointer: `GET /api/inventory#deployments.${MITIGATION_TARGET.name} (${label})`,
+  };
+}
+
+export function buildVerificationProbes(
+  inventory: InventoryResponse | undefined,
+  impact: CustomerImpactResponse | undefined,
+  now: Date,
+  staleSeconds = DEFAULT_PROBE_STALE_SECONDS,
+): VerificationProbeEvidence[] {
+  return [
+    buildKubernetesReadinessProbe(inventory, now, staleSeconds),
+    buildServiceEndpointProbe(inventory, now, staleSeconds),
+    buildGoldenTransactionProbe(impact, now, staleSeconds),
+  ];
+}

--- a/mission-control/backend/src/services/sre-agent/redaction.ts
+++ b/mission-control/backend/src/services/sre-agent/redaction.ts
@@ -9,7 +9,10 @@
  */
 
 /** Ordered so that broader patterns cannot mask narrower, higher-value ones. */
-const REDACTION_RULES: ReadonlyArray<{ pattern: RegExp; replacement: string }> = Object.freeze([
+const REDACTION_RULES: ReadonlyArray<{
+  pattern: RegExp;
+  replacement: string | ((substring: string, ...args: string[]) => string);
+}> = Object.freeze([
   // Bearer / auth headers
   { pattern: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, replacement: '$1 [REDACTED]' },
   // JWTs anywhere in free text
@@ -19,6 +22,19 @@ const REDACTION_RULES: ReadonlyArray<{ pattern: RegExp; replacement: string }> =
     pattern:
       /\b(password|passwd|pwd|token|access[_-]?token|id[_-]?token|refresh[_-]?token|secret|client[_-]?secret|api[_-]?key|apikey|subscription[_-]?key|sas[_-]?token|authorization|connectionstring)(\s*[:=]\s*)(["']?)[^\s"',;}]+/gi,
     replacement: '$1$2$3[REDACTED]',
+  },
+  // Space-separated CLI secret flags, e.g. `az login --password hunter2` or `--client-secret abc`.
+  // The key=value rule above cannot see these because there is no `:` or `=` separator, and agent
+  // telemetry (AgentAzCliExecution / AgentToolExecution ToolInput) carries exactly this shape.
+  // A quoted value is consumed to its matching closing quote, so a secret containing spaces
+  // (`--password "Winter 2026 Grid!"`) is redacted whole rather than only up to the first space.
+  {
+    pattern:
+      /(--?(?:password|passwd|pwd|token|access[_-]?token|id[_-]?token|refresh[_-]?token|secret|client[_-]?secret|api[_-]?key|apikey|subscription[_-]?key|sas[_-]?token|account[_-]?key|admin[_-]?password|certificate[_-]?password|connection[_-]?string)\b)(\s+)("[^"]*"|'[^']*'|[^\s"']+)/gi,
+    replacement: (_match: string, flag: string, gap: string, value: string) => {
+      const quote = value.startsWith('"') ? '"' : value.startsWith("'") ? "'" : '';
+      return `${flag}${gap}${quote}[REDACTED]${quote}`;
+    },
   },
   // Storage / service connection string fragments
   { pattern: /\b(AccountKey|SharedAccessSignature|SharedAccessKey)=[^;\s"']+/gi, replacement: '$1=[REDACTED]' },
@@ -35,7 +51,9 @@ const REDACTION_RULES: ReadonlyArray<{ pattern: RegExp; replacement: string }> =
 export function redactSensitiveText(value: string): string {
   let output = value;
   for (const { pattern, replacement } of REDACTION_RULES) {
-    output = output.replace(pattern, replacement);
+    output = typeof replacement === 'string'
+      ? output.replace(pattern, replacement)
+      : output.replace(pattern, replacement);
   }
   return output;
 }

--- a/mission-control/backend/src/types/index.ts
+++ b/mission-control/backend/src/types/index.ts
@@ -1,3 +1,30 @@
+// Review-mode mitigation lifecycle contracts (issue #80).
+// The canonical definitions live next to the runtime parsers that enforce them, in
+// services/sre-agent/mitigationLifecycle.ts, so the types and their validation cannot drift apart.
+// They are re-exported here because this module is Mission Control's shared API contract surface,
+// and mission-control/frontend/src/types/api.ts mirrors it (parity is asserted by
+// frontend/src/utils/reviewModeMitigation.test.ts).
+export type {
+  MitigationApprovalEvidence,
+  MitigationApprovalOutcome,
+  MitigationCorrelationKey,
+  MitigationExecutionEvidence,
+  MitigationGuidance,
+  MitigationMutationState,
+  MitigationResourceStateEvidence,
+  MitigationRunMode,
+  MitigationVerificationEvidence,
+  ResourceStateObservation,
+  ReviewModeMitigationEvidence,
+  ReviewModeMitigationState,
+  VerificationProbeEvidence,
+  VerificationProbeName,
+  VerificationProbeStatus,
+} from '../services/sre-agent/mitigationLifecycle.js';
+
+// Also imported locally because a re-export does not bring the name into this module's scope.
+import type { ReviewModeMitigationEvidence } from '../services/sre-agent/mitigationLifecycle.js';
+
 export type KubeSeverity = 'healthy' | 'warning' | 'critical' | 'unknown';
 
 export interface KubeObjectRef {
@@ -355,6 +382,7 @@ export type SreAgentEvidenceTemplateName =
   | 'agent-execution-lifecycle'
   | 'agent-tool-execution'
   | 'approval-decisions'
+  | 'agent-az-cli-execution'
   | 'incident-thread-timeline';
 
 export interface SreAgentEvidenceQueryRequest {
@@ -805,6 +833,13 @@ export interface RehearsalRun {
   };
   incidentHandoffId?: string;
   notes?: string;
+  /**
+   * Review-mode mitigation evidence (issue #80), captured by RE-DERIVING it from observed audit
+   * telemetry at attach time. It is never accepted from a request body, so a rehearsal package can
+   * not be made to claim an approval, execution, or recovery that was not observed.
+   */
+  mitigationEvidence?: ReviewModeMitigationEvidence;
+  mitigationEvidenceCapturedAt?: string;
 }
 
 export interface RehearsalState {

--- a/mission-control/frontend/src/components/MissionWallboard.vue
+++ b/mission-control/frontend/src/components/MissionWallboard.vue
@@ -233,6 +233,11 @@
 
       <aside class="ops-panel" aria-label="Active incidents and pod board">
         <CustomerImpactPanel :impact="customerImpact" :error="customerImpactError" />
+        <ReviewModeMitigationPanel
+          :evidence="mitigationEvidence"
+          :guardrails="mitigationGuardrails"
+          :error="mitigationError"
+        />
         <section class="wallboard-card incident-handoff-card">
         <div class="wallboard-panel__heading">
           <div>
@@ -538,12 +543,15 @@ import SreAgentPanel from './SreAgentPanel.vue';
 import ScenarioNarrationPanel from './ScenarioNarrationPanel.vue';
 import Terminal from './Terminal.vue';
 import CustomerImpactPanel from './CustomerImpactPanel.vue';
+import ReviewModeMitigationPanel from './ReviewModeMitigationPanel.vue';
 import type {
   Deployment,
   AssistantAskResponse,
   AssistantClientContext,
   AssistantConversationMessage,
   CustomerImpactResponse,
+  ReviewModeMitigationEvidence,
+  ReviewModeMitigationGuardrails,
   IncidentHandoff,
   InventoryItem,
   InventorySeverity,
@@ -588,6 +596,7 @@ const {
   fixAll,
   getDeployments,
   getCustomerImpact,
+  getMitigationEvidence,
   getEvents,
   getIncidentHandoffs,
   getInventory,
@@ -612,6 +621,9 @@ const preflightChecks = ref<PreflightCheck[]>([]);
 const incidentHandoffs = ref<IncidentHandoff[]>([]);
 const customerImpact = ref<CustomerImpactResponse>();
 const customerImpactError = ref('');
+const mitigationEvidence = ref<ReviewModeMitigationEvidence>();
+const mitigationGuardrails = ref<ReviewModeMitigationGuardrails>();
+const mitigationError = ref('');
 
 const inventoryLoading = ref(false);
 const inventoryError = ref('');
@@ -772,6 +784,7 @@ const analystTranscriptStatus = computed(() => {
 async function refreshAll() {
   inventoryLoading.value = true;
   await Promise.all([loadInventory(), loadRuntime(), loadScenarios(), loadIncidentHandoffs(), loadCustomerImpact()]);
+  await loadMitigationEvidence();
   inventoryLoading.value = false;
 }
 
@@ -832,6 +845,24 @@ async function loadCustomerImpact() {
   } catch (error) {
     customerImpact.value = undefined;
     customerImpactError.value = `Customer-impact API unavailable: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+async function loadMitigationEvidence() {
+  mitigationError.value = '';
+  // Correlate with the newest observed native thread/incident, if Mission Control has one.
+  // Never invent an identifier: with none, the backend reports `ambiguous` rather than guessing.
+  const correlated = incidentHandoffs.value.find(incident => incident.nativeEvidence?.threadId || incident.nativeEvidence?.incidentId);
+  try {
+    const response = await getMitigationEvidence({
+      threadId: correlated?.nativeEvidence?.threadId,
+      incidentId: correlated?.nativeEvidence?.incidentId,
+    });
+    mitigationEvidence.value = response.evidence;
+    mitigationGuardrails.value = response.guardrails;
+  } catch (error) {
+    mitigationEvidence.value = undefined;
+    mitigationError.value = `Mitigation evidence API unavailable: ${error instanceof Error ? error.message : String(error)}`;
   }
 }
 

--- a/mission-control/frontend/src/components/ReviewModeMitigationPanel.vue
+++ b/mission-control/frontend/src/components/ReviewModeMitigationPanel.vue
@@ -1,0 +1,295 @@
+<template>
+  <section class="mitigation" :class="`mitigation--${presentation.tone}`" aria-labelledby="mitigation-heading">
+    <div class="mitigation__heading">
+      <div>
+        <p class="mitigation__kicker">Review-mode mitigation</p>
+        <h2 id="mitigation-heading">MongoDBDown · {{ evidence?.targetResource || 'energy/mongodb' }}</h2>
+      </div>
+      <span class="mitigation__badge" role="status">{{ presentation.label }}</span>
+    </div>
+
+    <p v-if="!evidence" class="mitigation__notice">
+      {{ error || 'Mitigation evidence has not been queried yet. This is not a claim that the agent is idle.' }}
+    </p>
+
+    <template v-else>
+      <p class="mitigation__meaning">{{ presentation.meaning }}</p>
+
+      <p v-if="loud" class="mitigation__banner" role="alert">
+        <strong>Attention:</strong>
+        <span v-if="evidence.runModeBlocked">
+          Effective run mode is <strong>{{ runMode.label }}</strong>. {{ runMode.meaning }}
+        </span>
+        <span v-else-if="evidence.schemaMismatch">
+          The audit telemetry schema no longer matches the documented event/field names.
+        </span>
+        <span v-else>{{ presentation.meaning }}</span>
+      </p>
+
+      <dl class="mitigation__facts">
+        <div>
+          <dt>Effective run mode</dt>
+          <dd :class="`mitigation__tone--${runMode.tone}`">{{ runMode.label }}</dd>
+        </div>
+        <div>
+          <dt>Incident resolved</dt>
+          <dd>{{ evidence.incidentResolved ? 'Yes — verified' : 'No' }}</dd>
+        </div>
+        <div>
+          <dt>Proposed action</dt>
+          <dd><code>{{ evidence.proposedCommand }}</code></dd>
+        </div>
+        <div v-if="evidence.approval">
+          <dt>Approval decision</dt>
+          <dd>
+            {{ evidence.approval.outcome }}
+            <small>observed {{ formatFreshness(evidence.approval.freshnessSeconds) }}</small>
+          </dd>
+        </div>
+        <div v-if="evidence.execution">
+          <dt>Execution</dt>
+          <dd>
+            <code>{{ evidence.execution.command || evidence.execution.toolName }}</code>
+            <small>
+              allowlisted: {{ evidence.execution.allowlisted ? 'yes' : 'no' }} ·
+              observed {{ formatFreshness(evidence.execution.freshnessSeconds) }}
+            </small>
+          </dd>
+        </div>
+        <div v-if="evidence.resourceState">
+          <dt>Resource mutation</dt>
+          <dd :class="`mitigation__tone--${mutation.tone}`">
+            {{ mutation.label }}
+            <small>{{ evidence.resourceState.reason }}</small>
+          </dd>
+        </div>
+      </dl>
+
+      <h3 class="mitigation__subheading">Verification evidence</h3>
+      <ul v-if="evidence.verification.probes.length" class="mitigation__probes">
+        <li v-for="probe in evidence.verification.probes" :key="probe.probe" class="mitigation__probe">
+          <span class="mitigation__probe-name">{{ probeLabels[probe.probe] }}</span>
+          <span class="mitigation__probe-status" :class="`mitigation__tone--${probeStatus(probe.status).tone}`">
+            {{ probeStatus(probe.status).label }}
+          </span>
+          <span class="mitigation__probe-value">{{ probe.observedValue }}</span>
+          <small class="mitigation__probe-meta">
+            source: {{ probe.source }} ·
+            observed {{ formatFreshness(probe.freshnessSeconds) }}
+            <template v-if="probe.threshold"> · threshold: {{ probe.threshold }}</template>
+            · evidence: {{ probe.evidencePointer }}
+          </small>
+          <small v-if="probe.detail" class="mitigation__probe-detail">{{ probe.detail }}</small>
+        </li>
+      </ul>
+      <p v-else class="mitigation__notice">
+        No verification probes were collected. Recovery is unproven; the incident stays unresolved.
+      </p>
+      <p v-if="evidence.verification.missingProbes.length" class="mitigation__notice">
+        Missing probes: {{ evidence.verification.missingProbes.join(', ') }}
+      </p>
+      <p v-if="evidence.execution?.completedAt && !evidence.verification.postDatesExecution" class="mitigation__notice">
+        At least one probe does not post-date the execution, so it cannot prove the fix worked.
+      </p>
+
+      <template v-if="correlation.length">
+        <h3 class="mitigation__subheading">Correlated identifiers</h3>
+        <dl class="mitigation__facts">
+          <div v-for="row in correlation" :key="row.label">
+            <dt>{{ row.label }}</dt>
+            <dd><code>{{ row.value }}</code></dd>
+          </div>
+        </dl>
+      </template>
+
+      <template v-if="evidence.securityFindings.length">
+        <h3 class="mitigation__subheading mitigation__subheading--danger">Security findings</h3>
+        <ul class="mitigation__list mitigation__list--danger">
+          <li v-for="(finding, index) in evidence.securityFindings" :key="index">{{ finding }}</li>
+        </ul>
+      </template>
+
+      <template v-if="evidence.guidance.rollbackCommand || evidence.guidance.escalation">
+        <h3 class="mitigation__subheading">Rollback &amp; escalation</h3>
+        <p v-if="evidence.guidance.rollbackCommand" class="mitigation__detail">
+          <strong>Rollback:</strong> <code>{{ evidence.guidance.rollbackCommand }}</code>
+          <small v-if="evidence.guidance.rollbackRationale">{{ evidence.guidance.rollbackRationale }}</small>
+        </p>
+        <p v-if="evidence.guidance.escalation" class="mitigation__detail">
+          <strong>Escalation:</strong> {{ evidence.guidance.escalation }}
+        </p>
+      </template>
+
+      <template v-if="evidence.rejectedEvidence.length">
+        <h3 class="mitigation__subheading">Rejected evidence</h3>
+        <ul class="mitigation__list">
+          <li v-for="(reason, index) in evidence.rejectedEvidence" :key="index">{{ reason }}</li>
+        </ul>
+      </template>
+
+      <template v-if="guardrails">
+        <h3 class="mitigation__subheading">Guardrails</h3>
+        <ul class="mitigation__list mitigation__list--warning">
+          <li v-for="(disclosure, index) in guardrails.disclosures" :key="index">{{ disclosure }}</li>
+        </ul>
+        <p class="mitigation__detail">
+          <strong>Allowlist:</strong>
+          <code v-for="command in guardrails.allowlistedCommands" :key="command">{{ command }}</code>
+        </p>
+        <p class="mitigation__detail">
+          <strong>Policy:</strong> {{ guardrails.policyDocument }}
+        </p>
+      </template>
+
+      <ul class="mitigation__list mitigation__list--muted">
+        <li v-for="(limitation, index) in evidence.limitations" :key="index">{{ limitation }}</li>
+      </ul>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ReviewModeMitigationEvidence, ReviewModeMitigationGuardrails, VerificationProbeStatus } from '@/types/api';
+import {
+  PROBE_LABELS,
+  correlationRows,
+  describeMitigationState,
+  describeMutation,
+  describeProbeStatus,
+  describeRunMode,
+  formatFreshness,
+  requiresLoudBanner,
+} from '@/utils/reviewModeMitigation';
+
+const props = defineProps<{
+  evidence?: ReviewModeMitigationEvidence;
+  guardrails?: ReviewModeMitigationGuardrails;
+  error?: string;
+}>();
+
+const probeLabels = PROBE_LABELS;
+
+const presentation = computed(() =>
+  props.evidence
+    ? describeMitigationState(props.evidence.state)
+    : { label: 'Not queried', tone: 'neutral' as const, meaning: '', loud: false },
+);
+const runMode = computed(() => describeRunMode(props.evidence?.effectiveRunMode ?? 'unknown'));
+const mutation = computed(() => describeMutation(props.evidence?.resourceState?.mutation ?? 'unknown'));
+const loud = computed(() => (props.evidence ? requiresLoudBanner(props.evidence) : false));
+const correlation = computed(() => (props.evidence ? correlationRows(props.evidence) : []));
+
+function probeStatus(status: VerificationProbeStatus) {
+  return describeProbeStatus(status);
+}
+</script>
+
+<style scoped>
+.mitigation {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.mitigation--success { border-color: rgba(34, 197, 94, 0.55); }
+.mitigation--warning { border-color: rgba(234, 179, 8, 0.6); }
+.mitigation--danger { border-color: rgba(239, 68, 68, 0.7); }
+.mitigation--pending { border-color: rgba(59, 130, 246, 0.55); }
+
+.mitigation__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.mitigation__kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  opacity: 0.7;
+  margin: 0;
+}
+
+.mitigation__badge {
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  white-space: nowrap;
+}
+
+.mitigation__banner {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: rgba(239, 68, 68, 0.12);
+  outline: 1px solid rgba(239, 68, 68, 0.4);
+  margin: 0;
+}
+
+.mitigation__meaning { margin: 0; opacity: 0.9; }
+.mitigation__notice { margin: 0; opacity: 0.8; font-style: italic; }
+.mitigation__detail { margin: 0; }
+
+.mitigation__subheading {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0.35rem 0 0;
+  opacity: 0.8;
+}
+
+.mitigation__subheading--danger { color: rgb(248, 113, 113); opacity: 1; }
+
+.mitigation__facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.mitigation__facts dt { font-size: 0.75rem; opacity: 0.7; }
+.mitigation__facts dd { margin: 0; font-weight: 600; }
+.mitigation__facts dd small { display: block; font-weight: 400; opacity: 0.7; }
+
+.mitigation__probes { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+
+.mitigation__probe {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.5rem;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.mitigation__probe-name { font-weight: 600; }
+.mitigation__probe-status { font-weight: 600; }
+.mitigation__probe-value { font-family: ui-monospace, monospace; font-size: 0.8rem; }
+.mitigation__probe-meta,
+.mitigation__probe-detail { opacity: 0.7; }
+
+.mitigation__tone--success { color: rgb(74, 222, 128); }
+.mitigation__tone--warning { color: rgb(250, 204, 21); }
+.mitigation__tone--danger { color: rgb(248, 113, 113); }
+.mitigation__tone--pending { color: rgb(96, 165, 250); }
+.mitigation__tone--neutral { color: inherit; }
+
+.mitigation__list { margin: 0; padding-left: 1.1rem; display: flex; flex-direction: column; gap: 0.25rem; }
+.mitigation__list--danger { color: rgb(248, 113, 113); }
+.mitigation__list--warning { color: rgb(250, 204, 21); }
+.mitigation__list--muted { opacity: 0.65; font-size: 0.8rem; }
+
+.mitigation code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.3rem;
+  margin-right: 0.35rem;
+}
+</style>

--- a/mission-control/frontend/src/composables/useApi.ts
+++ b/mission-control/frontend/src/composables/useApi.ts
@@ -5,6 +5,7 @@ import type {
   AssistantClientContext,
   AssistantConversationMessage,
   CustomerImpactResponse,
+  ReviewModeMitigationResponse,
   CreateRehearsalRunRequest,
   Deployment,
   DestroyParams,
@@ -96,6 +97,15 @@ export function useApi() {
   return {
     getHealth: () => api<{ status: string }>('/api/health'),
     getCustomerImpact: () => api<CustomerImpactResponse>('/api/customer-impact'),
+    // Read-only. Mission Control observes the Review-mode mitigation lifecycle; it never approves.
+    getMitigationEvidence: (params: { threadId?: string; incidentId?: string; correlationId?: string; traceId?: string } = {}) => {
+      const query = new URLSearchParams();
+      for (const [key, value] of Object.entries(params)) {
+        if (value) query.set(key, value);
+      }
+      const suffix = query.toString();
+      return api<ReviewModeMitigationResponse>(`/api/mitigation/evidence${suffix ? `?${suffix}` : ''}`);
+    },
     getPreflight: () => api<{ checks: PreflightCheck[] }>('/api/preflight'),
     getPods: () => api<{ pods: Pod[] }>('/api/pods'),
     getServices: () => api<{ services: Service[] }>('/api/services'),

--- a/mission-control/frontend/src/types/api.ts
+++ b/mission-control/frontend/src/types/api.ts
@@ -667,6 +667,9 @@ export interface RehearsalRun {
   };
   incidentHandoffId?: string;
   notes?: string;
+  // Issue #80: re-derived from observed audit telemetry at attach time, never caller-asserted.
+  mitigationEvidence?: ReviewModeMitigationEvidence;
+  mitigationEvidenceCapturedAt?: string;
 }
 
 export interface RehearsalReplayStep {
@@ -884,4 +887,152 @@ export interface SreAgentActiveThreadRecord {
   updatedAt: string;
   lastStatus: SreAgentInvestigationStatus;
   correlationId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Review-mode mitigation lifecycle (issue #80)
+//
+// This union MUST stay in lock-step with `ReviewModeMitigationState` in
+// mission-control/backend/src/services/sre-agent/mitigationLifecycle.ts.
+// `mission-control/frontend/src/utils/reviewModeMitigation.test.ts` fails the build if the two
+// drift apart, so an unhandled backend state can never fall through to a silent default label.
+// ---------------------------------------------------------------------------
+
+export type ReviewModeMitigationState =
+  | 'no-evidence'
+  | 'blocked-run-mode'
+  | 'ambiguous'
+  | 'proposed'
+  | 'denied'
+  | 'denied-with-unverified-state'
+  | 'deny-violation'
+  | 'approved'
+  | 'executing'
+  | 'execution-blocked'
+  | 'execution-failed'
+  | 'verification-passed'
+  | 'verification-failed'
+  | 'rolled-back';
+
+export type MitigationRunMode = 'review' | 'autonomous' | 'unknown';
+export type MitigationApprovalOutcome = 'approved' | 'rejected' | 'unknown';
+export type MitigationMutationState = 'unchanged' | 'applied' | 'unknown';
+export type VerificationProbeName = 'kubernetes-readiness' | 'service-endpoint-health' | 'golden-transaction';
+export type VerificationProbeStatus = 'pass' | 'fail' | 'no-data' | 'stale' | 'error';
+
+export interface VerificationProbeEvidence {
+  probe: VerificationProbeName;
+  status: VerificationProbeStatus;
+  source: string;
+  observedValue: string;
+  observedAt?: string;
+  freshnessSeconds?: number;
+  threshold?: string;
+  evidencePointer: string;
+  correlationId?: string;
+  detail?: string;
+}
+
+export interface ResourceStateObservation {
+  source: string;
+  resource: string;
+  observedAt: string;
+  specReplicas?: number;
+  readyReplicas?: number;
+  observedGeneration?: number;
+  evidencePointer: string;
+}
+
+export interface MitigationApprovalEvidence {
+  outcome: MitigationApprovalOutcome;
+  observedAt: string;
+  outcomeSource?: string;
+  threadId?: string;
+  correlationId?: string;
+  incidentId?: string;
+  traceId?: string;
+  freshnessSeconds: number;
+  stale: boolean;
+}
+
+export interface MitigationExecutionEvidence {
+  toolName: string;
+  command?: string;
+  startedAt?: string;
+  completedAt?: string;
+  callId?: string;
+  threadId?: string;
+  correlationId?: string;
+  traceId?: string;
+  allowlisted: boolean;
+  blocked: boolean;
+  failed: boolean;
+  azCliCorrelated: boolean;
+  freshnessSeconds: number;
+  stale: boolean;
+}
+
+export interface MitigationResourceStateEvidence {
+  before?: ResourceStateObservation;
+  after?: ResourceStateObservation;
+  mutation: MitigationMutationState;
+  reason: string;
+}
+
+export interface MitigationVerificationEvidence {
+  probes: VerificationProbeEvidence[];
+  missingProbes: VerificationProbeName[];
+  allProbesPassed: boolean;
+  earliestProbeAt?: string;
+  postDatesExecution: boolean;
+}
+
+export interface MitigationGuidance {
+  rollbackCommand?: string;
+  rollbackRationale?: string;
+  escalation?: string;
+}
+
+export interface ReviewModeMitigationEvidence {
+  state: ReviewModeMitigationState;
+  incidentResolved: boolean;
+  effectiveRunMode: MitigationRunMode;
+  runModeBlocked: boolean;
+  scenario: 'MongoDBDown';
+  targetResource: string;
+  proposedCommand: string;
+  correlation: {
+    threadId?: string;
+    correlationId?: string;
+    incidentId?: string;
+    traceId?: string;
+  };
+  approval?: MitigationApprovalEvidence;
+  execution?: MitigationExecutionEvidence;
+  resourceState?: MitigationResourceStateEvidence;
+  verification: MitigationVerificationEvidence;
+  guidance: MitigationGuidance;
+  observedAt?: string;
+  stale: boolean;
+  schemaMismatch: boolean;
+  securityFindings: string[];
+  rejectedEvidence: string[];
+  limitations: string[];
+}
+
+export interface ReviewModeMitigationGuardrails {
+  policyDocument: string;
+  allowlistedCommands: string[];
+  rollbackCommand: string;
+  targetResource: string;
+  disclosures: string[];
+  references: string[];
+}
+
+export interface ReviewModeMitigationResponse {
+  scenario: 'MongoDBDown';
+  evidence: ReviewModeMitigationEvidence;
+  guardrails: ReviewModeMitigationGuardrails;
+  evidenceSources: string[];
+  collectedAt: string;
 }

--- a/mission-control/frontend/src/utils/reviewModeMitigation.test.ts
+++ b/mission-control/frontend/src/utils/reviewModeMitigation.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Frontend/backend union parity and presentation tests for the Review-mode mitigation lifecycle
+ * (issue #80).
+ *
+ * The parity test reads the backend and frontend source files directly. If a backend state is added
+ * without a matching frontend union member and label, this test fails -- which is what stops an
+ * unhandled lifecycle state from silently rendering as a default badge.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import {
+  PROBE_LABELS,
+  REVIEW_MODE_MITIGATION_STATES,
+  correlationRows,
+  describeMitigationState,
+  describeMutation,
+  describeProbeStatus,
+  describeRunMode,
+  formatFreshness,
+  requiresLoudBanner,
+} from './reviewModeMitigation.js';
+import type { ReviewModeMitigationEvidence, ReviewModeMitigationState } from '../types/api';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BACKEND_LIFECYCLE = resolve(HERE, '../../../backend/src/services/sre-agent/mitigationLifecycle.ts');
+const FRONTEND_TYPES = resolve(HERE, '../types/api.ts');
+
+/** Extracts the string-literal members of a named exported union from TypeScript source. */
+function extractUnion(source: string, typeName: string): string[] {
+  const pattern = new RegExp(`export type ${typeName}\\s*=([\\s\\S]*?);`, 'm');
+  const match = pattern.exec(source);
+  assert.ok(match, `could not find 'export type ${typeName}' in source`);
+  return [...match![1]!.matchAll(/'([^']+)'/g)].map(item => item[1]!);
+}
+
+test('backend and frontend ReviewModeMitigationState unions are identical', () => {
+  const backend = extractUnion(readFileSync(BACKEND_LIFECYCLE, 'utf8'), 'ReviewModeMitigationState');
+  const frontend = extractUnion(readFileSync(FRONTEND_TYPES, 'utf8'), 'ReviewModeMitigationState');
+
+  assert.ok(backend.length >= 14, `expected the backend union to be non-trivial, got ${backend.length}`);
+  assert.deepEqual(
+    [...frontend].sort(),
+    [...backend].sort(),
+    'frontend ReviewModeMitigationState drifted from the backend union',
+  );
+});
+
+test('every backend state has an explicit presentation with no default fallthrough', () => {
+  const backend = extractUnion(readFileSync(BACKEND_LIFECYCLE, 'utf8'), 'ReviewModeMitigationState');
+
+  assert.deepEqual(
+    [...REVIEW_MODE_MITIGATION_STATES].sort(),
+    [...backend].sort(),
+    'REVIEW_MODE_MITIGATION_STATES drifted from the backend union',
+  );
+
+  for (const state of backend as ReviewModeMitigationState[]) {
+    const presentation = describeMitigationState(state);
+    assert.ok(presentation.label.length > 0, `${state} has no label`);
+    assert.ok(presentation.meaning.length > 0, `${state} has no operator meaning`);
+    assert.ok(['neutral', 'pending', 'success', 'warning', 'danger'].includes(presentation.tone), `${state} has an invalid tone`);
+  }
+});
+
+test('describeMitigationState throws instead of guessing for an unknown state', () => {
+  assert.throws(
+    () => describeMitigationState('totally-new-state' as ReviewModeMitigationState),
+    /Unhandled Review-mode mitigation state/,
+  );
+});
+
+test('only verification-passed is presented as success', () => {
+  const successStates = REVIEW_MODE_MITIGATION_STATES.filter(state => describeMitigationState(state).tone === 'success');
+  assert.deepEqual(successStates, ['verification-passed']);
+});
+
+test('security-critical states are marked loud', () => {
+  for (const state of ['blocked-run-mode', 'deny-violation', 'execution-failed', 'verification-failed', 'denied-with-unverified-state'] as const) {
+    assert.equal(describeMitigationState(state).loud, true, `${state} must be loud`);
+  }
+});
+
+test('run mode presentation blocks anything that is not review', () => {
+  assert.equal(describeRunMode('review').tone, 'success');
+  assert.equal(describeRunMode('autonomous').loud, true);
+  assert.equal(describeRunMode('unknown').loud, true);
+});
+
+test('mutation presentation never renders unknown as unchanged', () => {
+  assert.equal(describeMutation('unchanged').tone, 'success');
+  assert.equal(describeMutation('applied').tone, 'warning');
+  assert.equal(describeMutation('unknown').loud, true);
+  assert.notEqual(describeMutation('unknown').label, describeMutation('unchanged').label);
+});
+
+test('probe statuses other than pass are never presented as success', () => {
+  assert.equal(describeProbeStatus('pass').tone, 'success');
+  for (const status of ['fail', 'no-data', 'stale', 'error'] as const) {
+    assert.notEqual(describeProbeStatus(status).tone, 'success');
+    assert.equal(describeProbeStatus(status).loud, true);
+  }
+});
+
+test('every probe name has a human label', () => {
+  const backendProbes = extractUnion(readFileSync(BACKEND_LIFECYCLE, 'utf8'), 'VerificationProbeName');
+  assert.deepEqual(Object.keys(PROBE_LABELS).sort(), [...backendProbes].sort());
+});
+
+test('freshness never renders an unknown age as a number', () => {
+  assert.equal(formatFreshness(undefined), 'unknown');
+  assert.equal(formatFreshness(30), '30s ago');
+  assert.equal(formatFreshness(120), '2m ago');
+  assert.equal(formatFreshness(7200), '2h ago');
+});
+
+function evidence(overrides: Partial<ReviewModeMitigationEvidence> = {}): ReviewModeMitigationEvidence {
+  return {
+    state: 'proposed',
+    incidentResolved: false,
+    effectiveRunMode: 'review',
+    runModeBlocked: false,
+    scenario: 'MongoDBDown',
+    targetResource: 'energy/mongodb',
+    proposedCommand: 'kubectl scale deployment/mongodb -n energy --replicas=1',
+    correlation: { threadId: 'thread-1' },
+    verification: { probes: [], missingProbes: [], allProbesPassed: false, postDatesExecution: false },
+    guidance: {},
+    stale: false,
+    schemaMismatch: false,
+    securityFindings: [],
+    rejectedEvidence: [],
+    limitations: [],
+    ...overrides,
+  };
+}
+
+test('a loud banner is required for security findings, blocked run mode and schema drift', () => {
+  assert.equal(requiresLoudBanner(evidence()), false);
+  assert.equal(requiresLoudBanner(evidence({ securityFindings: ['something'] })), true);
+  assert.equal(requiresLoudBanner(evidence({ runModeBlocked: true })), true);
+  assert.equal(requiresLoudBanner(evidence({ schemaMismatch: true })), true);
+  assert.equal(requiresLoudBanner(evidence({ state: 'deny-violation' })), true);
+});
+
+test('correlation rows only include identifiers that were actually observed', () => {
+  assert.deepEqual(correlationRows(evidence()), [{ label: 'ThreadId', value: 'thread-1' }]);
+  assert.deepEqual(correlationRows(evidence({ correlation: {} })), []);
+  assert.equal(correlationRows(evidence({ correlation: { threadId: 't', correlationId: 'c', incidentId: 'i', traceId: 'r' } })).length, 4);
+});

--- a/mission-control/frontend/src/utils/reviewModeMitigation.ts
+++ b/mission-control/frontend/src/utils/reviewModeMitigation.ts
@@ -1,0 +1,234 @@
+/**
+ * Presentation helpers for the Review-mode mitigation lifecycle (issue #80).
+ *
+ * Every backend state has an explicit label, tone and operator meaning. The mapping is exhaustive:
+ * `assertNever` makes an unhandled state a compile-time error, and the accompanying test asserts
+ * union parity with the backend so a new state can never silently render as "unknown".
+ *
+ * Nothing here infers state. It only formats what the backend derived from observed telemetry.
+ */
+
+import type {
+  MitigationMutationState,
+  MitigationRunMode,
+  ReviewModeMitigationEvidence,
+  ReviewModeMitigationState,
+  VerificationProbeEvidence,
+  VerificationProbeStatus,
+} from '../types/api';
+
+export type MitigationTone = 'neutral' | 'pending' | 'success' | 'warning' | 'danger';
+
+export interface MitigationStatePresentation {
+  label: string;
+  tone: MitigationTone;
+  /** What the operator should understand from this state -- never a claim beyond the evidence. */
+  meaning: string;
+  /** True when the state must be visually loud (blocked demo, security finding, deny violation). */
+  loud: boolean;
+}
+
+/** Full, ordered list of states the UI must handle. Kept in sync with the backend by test. */
+export const REVIEW_MODE_MITIGATION_STATES: readonly ReviewModeMitigationState[] = Object.freeze([
+  'no-evidence',
+  'blocked-run-mode',
+  'ambiguous',
+  'proposed',
+  'denied',
+  'denied-with-unverified-state',
+  'deny-violation',
+  'approved',
+  'executing',
+  'execution-blocked',
+  'execution-failed',
+  'verification-passed',
+  'verification-failed',
+  'rolled-back',
+]);
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled Review-mode mitigation state: ${String(value)}`);
+}
+
+export function describeMitigationState(state: ReviewModeMitigationState): MitigationStatePresentation {
+  switch (state) {
+    case 'no-evidence':
+      return {
+        label: 'No evidence',
+        tone: 'neutral',
+        loud: false,
+        meaning: 'No usable audit telemetry was observed. This is not a claim that the agent is idle or the system is healthy.',
+      };
+    case 'blocked-run-mode':
+      return {
+        label: 'Blocked — run mode',
+        tone: 'danger',
+        loud: true,
+        meaning: 'The effective agent autonomy level is not Review. The demonstration is blocked because the approval gate did not apply.',
+      };
+    case 'ambiguous':
+      return {
+        label: 'Ambiguous correlation',
+        tone: 'warning',
+        loud: true,
+        meaning: 'No precise identifier was available, so no mitigation evidence was attached to this incident.',
+      };
+    case 'proposed':
+      return {
+        label: 'Proposed',
+        tone: 'pending',
+        loud: false,
+        meaning: 'A mitigation is awaiting an operator decision in the Azure SRE Agent portal. No decision has been observed.',
+      };
+    case 'denied':
+      return {
+        label: 'Denied — no change',
+        tone: 'neutral',
+        loud: false,
+        meaning: 'A rejection was observed and before/after resource state proves the target was not mutated.',
+      };
+    case 'denied-with-unverified-state':
+      return {
+        label: 'Denied — state unverified',
+        tone: 'warning',
+        loud: true,
+        meaning: 'A rejection was observed, but there is no fresh before/after pair proving the resource was left untouched.',
+      };
+    case 'deny-violation':
+      return {
+        label: 'DENY VIOLATION',
+        tone: 'danger',
+        loud: true,
+        meaning: 'The proposal was rejected but the resource changed anyway. Investigate the policy and RBAC boundary immediately.',
+      };
+    case 'approved':
+      return {
+        label: 'Approved',
+        tone: 'pending',
+        loud: false,
+        meaning: 'An approval was observed. No correlated allowlisted execution telemetry has appeared yet.',
+      };
+    case 'executing':
+      return {
+        label: 'Executing',
+        tone: 'pending',
+        loud: false,
+        meaning: 'The approved action has started. No completion event has been observed yet.',
+      };
+    case 'execution-blocked':
+      return {
+        label: 'Execution blocked',
+        tone: 'warning',
+        loud: true,
+        meaning: 'The enforcement boundary refused the call. No mitigation was applied — this is the guardrail working.',
+      };
+    case 'execution-failed':
+      return {
+        label: 'Execution failed',
+        tone: 'danger',
+        loud: true,
+        meaning: 'The action did not complete successfully, or executed outside the expected approval order. The incident stays unresolved.',
+      };
+    case 'verification-passed':
+      return {
+        label: 'Verified recovery',
+        tone: 'success',
+        loud: false,
+        meaning: 'Approval, execution and all three post-execution probes were observed and correlated. The incident is resolved.',
+      };
+    case 'verification-failed':
+      return {
+        label: 'Verification failed',
+        tone: 'danger',
+        loud: true,
+        meaning: 'Recovery is unproven. The incident remains unresolved and rollback/escalation guidance applies.',
+      };
+    case 'rolled-back':
+      return {
+        label: 'Rolled back',
+        tone: 'warning',
+        loud: false,
+        meaning: 'The allowlisted rollback was executed and verified. The scenario is back at its broken baseline.',
+      };
+    default:
+      return assertNever(state);
+  }
+}
+
+export function describeRunMode(mode: MitigationRunMode): MitigationStatePresentation {
+  switch (mode) {
+    case 'review':
+      return { label: 'Review', tone: 'success', loud: false, meaning: 'Observed agent autonomy level is Review; every Azure write requires an approval.' };
+    case 'autonomous':
+      return { label: 'Autonomous', tone: 'danger', loud: true, meaning: 'Observed agent autonomy level is Autonomous. This demonstration must not proceed.' };
+    case 'unknown':
+      return { label: 'Unknown', tone: 'danger', loud: true, meaning: 'The effective run mode could not be observed, so the approval gate cannot be proven.' };
+    default:
+      return assertNever(mode);
+  }
+}
+
+export function describeMutation(mutation: MitigationMutationState): MitigationStatePresentation {
+  switch (mutation) {
+    case 'unchanged':
+      return { label: 'Unchanged', tone: 'success', loud: false, meaning: 'Before/after observations are equal; the resource was not mutated.' };
+    case 'applied':
+      return { label: 'Changed', tone: 'warning', loud: false, meaning: 'The resource changed between the before and after observations.' };
+    case 'unknown':
+      return { label: 'Unknown', tone: 'warning', loud: true, meaning: 'Mutation cannot be determined; the before/after pair is missing, stale, or out of order.' };
+    default:
+      return assertNever(mutation);
+  }
+}
+
+export function describeProbeStatus(status: VerificationProbeStatus): MitigationStatePresentation {
+  switch (status) {
+    case 'pass':
+      return { label: 'Pass', tone: 'success', loud: false, meaning: 'The probe met its threshold within the freshness budget.' };
+    case 'fail':
+      return { label: 'Fail', tone: 'danger', loud: true, meaning: 'The probe was observed and did not meet its threshold.' };
+    case 'no-data':
+      return { label: 'No data', tone: 'warning', loud: true, meaning: 'The probe could not be observed. Absence is never treated as success.' };
+    case 'stale':
+      return { label: 'Stale', tone: 'warning', loud: true, meaning: 'The observation is outside the freshness budget and cannot prove the current state.' };
+    case 'error':
+      return { label: 'Error', tone: 'danger', loud: true, meaning: 'The probe query itself failed.' };
+    default:
+      return assertNever(status);
+  }
+}
+
+export const PROBE_LABELS: Record<VerificationProbeEvidence['probe'], string> = {
+  'kubernetes-readiness': 'Kubernetes readiness',
+  'service-endpoint-health': 'Service endpoint health',
+  'golden-transaction': 'Golden transaction (customer impact)',
+};
+
+/** Formats freshness for display without ever rendering an unknown age as "0s". */
+export function formatFreshness(seconds: number | undefined): string {
+  if (seconds === undefined) return 'unknown';
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3_600) return `${Math.round(seconds / 60)}m ago`;
+  return `${Math.round(seconds / 3_600)}h ago`;
+}
+
+/** True when the panel must render a loud banner rather than a quiet badge. */
+export function requiresLoudBanner(evidence: ReviewModeMitigationEvidence): boolean {
+  return (
+    describeMitigationState(evidence.state).loud ||
+    evidence.runModeBlocked ||
+    evidence.securityFindings.length > 0 ||
+    evidence.schemaMismatch
+  );
+}
+
+/** Ordered rows for the correlation timeline; only identifiers that were actually observed. */
+export function correlationRows(evidence: ReviewModeMitigationEvidence): { label: string; value: string }[] {
+  const rows: { label: string; value: string }[] = [];
+  const { threadId, correlationId, incidentId, traceId } = evidence.correlation;
+  if (threadId) rows.push({ label: 'ThreadId', value: threadId });
+  if (correlationId) rows.push({ label: 'CorrelationId', value: correlationId });
+  if (incidentId) rows.push({ label: 'IncidentId', value: incidentId });
+  if (traceId) rows.push({ label: 'TraceId', value: traceId });
+  return rows;
+}

--- a/scripts/configure-sre-agent-mitigation-guardrails.ps1
+++ b/scripts/configure-sre-agent-mitigation-guardrails.ps1
@@ -1,0 +1,236 @@
+<#
+.SYNOPSIS
+    Applies and verifies the Review-mode mitigation guardrails for the Energy Grid lab (issue #80).
+
+.DESCRIPTION
+    Implements the enforcement boundary described in docs/REVIEW-MODE-MITIGATION.md §3:
+
+      Layer 1  Global Tool Access Policy (infra/sre-agent/tool-access-policy.json), PUT to the
+               documented endpoint /api/v2/agent/settings/global
+               (https://learn.microsoft.com/azure/sre-agent/tool-access-policies#global-policies).
+      Layer 3  Azure control-plane custom role instead of Contributor.
+
+    The script is deliberately conservative:
+      * -WhatIf is supported and no write happens without an explicit -Apply.
+      * It NEVER creates, deletes, or modifies any Azure resource other than PUTting the tool
+        access policy for the named agent.
+      * Every check reports what was actually observed. A check that cannot be performed is
+        reported as UNKNOWN, never as PASS.
+
+.PARAMETER ResourceGroupName
+    Resource group containing the SRE Agent.
+
+.PARAMETER AgentName
+    Name of the Microsoft.App/agents resource. Discovered from the resource group when omitted.
+
+.PARAMETER Apply
+    Actually PUT the tool access policy. Without this, the script only reports what it would do.
+
+.EXAMPLE
+    ./scripts/configure-sre-agent-mitigation-guardrails.ps1 -ResourceGroupName rg-srelab-eastus2
+
+.EXAMPLE
+    ./scripts/configure-sre-agent-mitigation-guardrails.ps1 -ResourceGroupName rg-srelab-eastus2 -Apply
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResourceGroupName,
+
+    [string]$AgentName,
+
+    [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$policyPath = Join-Path $repoRoot 'infra/sre-agent/tool-access-policy.json'
+
+if (-not (Test-Path $policyPath)) {
+    throw "Tool access policy not found: $policyPath"
+}
+
+function Write-Result {
+    param([string]$Status, [string]$Message)
+    $colour = switch ($Status) {
+        'PASS'    { 'Green' }
+        'FAIL'    { 'Red' }
+        'WARN'    { 'Yellow' }
+        'UNKNOWN' { 'DarkYellow' }
+        default   { 'Gray' }
+    }
+    Write-Host ("[{0,-7}] {1}" -f $Status, $Message) -ForegroundColor $colour
+}
+
+Write-Host ''
+Write-Host 'Review-mode mitigation guardrails (issue #80)' -ForegroundColor Cyan
+Write-Host '=============================================' -ForegroundColor Cyan
+Write-Host "Design document: docs/REVIEW-MODE-MITIGATION.md"
+Write-Host ''
+
+# -----------------------------------------------------------------------------
+# 1. Validate the policy document itself, before touching Azure.
+# -----------------------------------------------------------------------------
+
+$policyRaw = Get-Content -Path $policyPath -Raw
+try {
+    $policy = $policyRaw | ConvertFrom-Json
+} catch {
+    throw "Tool access policy is not valid JSON: $($_.Exception.Message)"
+}
+
+if (-not $policy.permissions) {
+    throw 'Tool access policy is missing the required `permissions` object.'
+}
+
+$askRules = @($policy.permissions.ask)
+$denyRules = @($policy.permissions.deny)
+$allowRules = @($policy.permissions.allow)
+
+$expectedAsk = @(
+    'RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=1)',
+    'RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=0)'
+)
+
+$failures = 0
+
+if (($askRules.Count -eq $expectedAsk.Count) -and (-not (Compare-Object $askRules $expectedAsk))) {
+    Write-Result 'PASS' "Ask rules are exactly the two allowlisted scale commands."
+} else {
+    Write-Result 'FAIL' "Ask rules drifted from the documented allowlist. Expected: $($expectedAsk -join ', ')"
+    $failures++
+}
+
+# The deny list must block the categories issue #80 forbids outright.
+$requiredDenyPatterns = @(
+    'kubectl delete', 'kubectl exec', 'RunAzCliWriteCommands', 'az keyvault',
+    'az aks command invoke', 'ExecutePythonCode', 'RunShellCommand', 'RunInTerminal'
+)
+foreach ($pattern in $requiredDenyPatterns) {
+    if ($denyRules -match [regex]::Escape($pattern)) {
+        Write-Result 'PASS' "Deny rule present for '$pattern'."
+    } else {
+        Write-Result 'FAIL' "Deny rule MISSING for '$pattern'. Issue #80 forbids this category."
+        $failures++
+    }
+}
+
+# An allow rule that matches a write tool would bypass the ask gate entirely.
+foreach ($rule in $allowRules) {
+    if ($rule -match 'Write|delete|exec|Terminal|Shell|Python') {
+        Write-Result 'FAIL' "Allow rule '$rule' would bypass the approval gate. Allow must be read-only."
+        $failures++
+    }
+}
+if ($allowRules.Count -gt 0 -and $failures -eq 0) {
+    Write-Result 'PASS' "Allow rules are read-only ($($allowRules.Count) rule(s))."
+}
+
+if ($failures -gt 0) {
+    throw "Tool access policy failed static validation with $failures error(s). Refusing to apply it."
+}
+
+# -----------------------------------------------------------------------------
+# 2. Discover the agent and report its Azure RBAC posture.
+# -----------------------------------------------------------------------------
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Write-Result 'UNKNOWN' 'Azure CLI is not on PATH; skipping all live checks. Static policy validation passed.'
+    Write-Host ''
+    Write-Host 'Static validation only. Live guardrail state was NOT verified.' -ForegroundColor Yellow
+    exit 0
+}
+
+if (-not $AgentName) {
+    $AgentName = az resource list --resource-group $ResourceGroupName --resource-type 'Microsoft.App/agents' --query '[0].name' -o tsv 2>$null
+}
+
+if (-not $AgentName) {
+    Write-Result 'UNKNOWN' "No Microsoft.App/agents resource found in '$ResourceGroupName'. Live checks skipped."
+    Write-Host ''
+    Write-Host 'Static validation only. Live guardrail state was NOT verified.' -ForegroundColor Yellow
+    exit 0
+}
+
+Write-Result 'INFO' "Agent: $AgentName (resource group $ResourceGroupName)"
+
+$principalId = az resource show --resource-group $ResourceGroupName --name $AgentName --resource-type 'Microsoft.App/agents' --query 'properties.actionConfiguration.identity' -o tsv 2>$null
+
+$identityPrincipal = $null
+if ($principalId) {
+    $identityPrincipal = az identity show --ids $principalId --query 'principalId' -o tsv 2>$null
+}
+
+if ($identityPrincipal) {
+    $assignments = az role assignment list --assignee $identityPrincipal --all -o json 2>$null | ConvertFrom-Json
+    $contributor = @($assignments | Where-Object { $_.roleDefinitionName -eq 'Contributor' })
+
+    if ($contributor.Count -gt 0) {
+        # Loud, non-suppressible: issue #80 requires Contributor to be replaced on this path.
+        Write-Result 'FAIL' "The agent identity holds Contributor at: $((($contributor | ForEach-Object { $_.scope }) -join ', ')). Issue #80 requires the Review-mode mitigation path to use the narrow custom role instead. Redeploy with sreAgentAccessLevel = 'Mitigation'."
+        $failures++
+    } else {
+        Write-Result 'PASS' 'The agent identity does NOT hold Contributor.'
+    }
+
+    $customRole = @($assignments | Where-Object { $_.roleDefinitionName -like 'SRE Agent Energy Grid Mitigation Operator*' })
+    if ($customRole.Count -gt 0) {
+        Write-Result 'PASS' "Narrow mitigation custom role assigned at: $((($customRole | ForEach-Object { $_.scope }) -join ', '))"
+    } else {
+        Write-Result 'WARN' "The narrow mitigation custom role is not assigned. Deploy with enableReviewModeMitigation = true."
+    }
+
+    $k8sRole = @($assignments | Where-Object { $_.roleDefinitionName -like 'SRE Agent Energy Grid Deployment Scaler*' })
+    if ($k8sRole.Count -gt 0) {
+        Write-Result 'PASS' 'Layer 2 active: the Kubernetes boundary is enforced by the API server at namespace scope.'
+    } else {
+        Write-Result 'WARN' 'DEMO-ONLY PERMISSION BREADTH: Layer 2 (Azure RBAC for Kubernetes) is inactive, so the cluster-user credential is broader than this action needs. The tool access policy still constrains what the agent will run. See docs/REVIEW-MODE-MITIGATION.md section 4. Deploy with enableAgentKubernetesRbac = true to remove this breadth.'
+    }
+} else {
+    Write-Result 'UNKNOWN' 'Could not resolve the agent managed identity principal; RBAC posture NOT verified.'
+}
+
+# -----------------------------------------------------------------------------
+# 3. Apply the tool access policy.
+# -----------------------------------------------------------------------------
+
+$permissionsBody = ($policy | Select-Object -Property permissions | ConvertTo-Json -Depth 10 -Compress)
+
+if (-not $Apply) {
+    Write-Host ''
+    Write-Result 'INFO' 'Dry run. Re-run with -Apply to PUT the tool access policy.'
+    Write-Host "Would PUT to: https://<agent-endpoint>/api/v2/agent/settings/global"
+    Write-Host "Body: $permissionsBody"
+} elseif ($PSCmdlet.ShouldProcess("$AgentName global tool access policy", 'PUT permissions')) {
+    $endpoint = az resource show --resource-group $ResourceGroupName --name $AgentName --resource-type 'Microsoft.App/agents' --query 'properties.endpoint' -o tsv 2>$null
+    if (-not $endpoint) {
+        Write-Result 'UNKNOWN' 'The agent endpoint could not be resolved from ARM. Apply the policy from the portal: Settings > Permissions.'
+    } else {
+        $token = az account get-access-token --resource 'https://management.azure.com/' --query accessToken -o tsv 2>$null
+        if (-not $token) {
+            Write-Result 'FAIL' 'Could not acquire an access token; the policy was NOT applied.'
+            $failures++
+        } else {
+            try {
+                Invoke-RestMethod -Method Put `
+                    -Uri "$endpoint/api/v2/agent/settings/global" `
+                    -Headers @{ Authorization = "Bearer $token"; 'Content-Type' = 'application/json' } `
+                    -Body $permissionsBody | Out-Null
+                Write-Result 'PASS' 'Global tool access policy applied.'
+            } catch {
+                Write-Result 'FAIL' "Failed to apply the tool access policy: $($_.Exception.Message)"
+                $failures++
+            }
+        }
+    }
+}
+
+Write-Host ''
+if ($failures -gt 0) {
+    throw "Review-mode mitigation guardrails FAILED with $failures error(s). Do not run the demonstration until these are resolved."
+}
+
+Write-Host 'Guardrail checks completed. Review any WARN/UNKNOWN lines above before demonstrating.' -ForegroundColor Green
+Write-Host 'Live deny/approve proof is captured separately -- see docs/REVIEW-MODE-MITIGATION.md section 10.' -ForegroundColor Yellow

--- a/scripts/configure-sre-agent-mitigation-guardrails.ps1
+++ b/scripts/configure-sre-agent-mitigation-guardrails.ps1
@@ -24,7 +24,13 @@
     Name of the Microsoft.App/agents resource. Discovered from the resource group when omitted.
 
 .PARAMETER Apply
-    Actually PUT the tool access policy. Without this, the script only reports what it would do.
+    Actually PUT the tool access policy, and create the namespace-scoped Layer 2 role assignment
+    when its custom role definition exists. Without this, the script only reports what it would do.
+
+.PARAMETER KubernetesNamespace
+    The single Kubernetes namespace the Layer 2 assignment may target. Any assignment found at a
+    different scope -- including the bare cluster scope -- is reported as a FAILURE, never as
+    namespace enforcement.
 
 .EXAMPLE
     ./scripts/configure-sre-agent-mitigation-guardrails.ps1 -ResourceGroupName rg-srelab-eastus2
@@ -39,6 +45,9 @@ param(
     [string]$ResourceGroupName,
 
     [string]$AgentName,
+
+    [ValidatePattern('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')]
+    [string]$KubernetesNamespace = 'energy',
 
     [switch]$Apply
 )
@@ -183,10 +192,73 @@ if ($identityPrincipal) {
     }
 
     $k8sRole = @($assignments | Where-Object { $_.roleDefinitionName -like 'SRE Agent Energy Grid Deployment Scaler*' })
-    if ($k8sRole.Count -gt 0) {
-        Write-Result 'PASS' 'Layer 2 active: the Kubernetes boundary is enforced by the API server at namespace scope.'
+
+    # Resolve the ONE scope at which the Layer 2 assignment is permitted to exist. Azure RBAC for
+    # Kubernetes Authorization scopes a namespace grant to <aksResourceId>/namespaces/<namespace>
+    # (https://learn.microsoft.com/azure/aks/manage-azure-rbac). Anything else -- notably the bare
+    # cluster id -- is a cluster-wide grant and must never be reported as namespace enforcement.
+    $aksId = az resource list --resource-group $ResourceGroupName --resource-type 'Microsoft.ContainerService/managedClusters' --query '[0].id' -o tsv 2>$null
+    $expectedNamespaceScope = if ($aksId) { "$aksId/namespaces/$KubernetesNamespace" } else { $null }
+
+    if ($k8sRole.Count -eq 0) {
+        Write-Result 'WARN' 'DEMO-ONLY PERMISSION BREADTH: Layer 2 (Azure RBAC for Kubernetes) is inactive, so the cluster-user credential is broader than this action needs. The tool access policy still constrains what the agent will run. See docs/REVIEW-MODE-MITIGATION.md section 4. Deploy with enableAgentKubernetesRbac = true and re-run this script with -Apply to create the namespace-scoped assignment.'
+    } elseif (-not $expectedNamespaceScope) {
+        Write-Result 'UNKNOWN' 'A Deployment Scaler assignment exists but the AKS resource id could not be resolved, so its scope could NOT be verified. Not reporting namespace enforcement.'
     } else {
-        Write-Result 'WARN' 'DEMO-ONLY PERMISSION BREADTH: Layer 2 (Azure RBAC for Kubernetes) is inactive, so the cluster-user credential is broader than this action needs. The tool access policy still constrains what the agent will run. See docs/REVIEW-MODE-MITIGATION.md section 4. Deploy with enableAgentKubernetesRbac = true to remove this breadth.'
+        # Compare exactly. A trailing-slash or casing difference is still a different scope, so
+        # normalise only trailing slashes and compare case-insensitively (ARM ids are
+        # case-insensitive but case-preserving).
+        $normalizedExpected = $expectedNamespaceScope.TrimEnd('/')
+        $correctlyScoped = @($k8sRole | Where-Object { $_.scope.TrimEnd('/') -ieq $normalizedExpected })
+        $wronglyScoped = @($k8sRole | Where-Object { $_.scope.TrimEnd('/') -ine $normalizedExpected })
+
+        foreach ($bad in $wronglyScoped) {
+            if ($bad.scope.TrimEnd('/') -ieq $aksId.TrimEnd('/')) {
+                Write-Result 'FAIL' "CLUSTER-WIDE GRANT: the Deployment Scaler role is assigned at the cluster scope '$($bad.scope)'. This is NOT namespace enforcement. Delete it with: az role assignment delete --ids $($bad.id)"
+            } else {
+                Write-Result 'FAIL' "OUT-OF-SCOPE GRANT: the Deployment Scaler role is assigned at '$($bad.scope)', which is not the expected '$normalizedExpected'. Delete it with: az role assignment delete --ids $($bad.id)"
+            }
+            $failures++
+        }
+
+        if ($correctlyScoped.Count -gt 0) {
+            Write-Result 'PASS' "Layer 2 active: Deployment Scaler assigned at exactly '$($correctlyScoped[0].scope)' -- the Kubernetes boundary is enforced by the API server for namespace '$KubernetesNamespace'."
+        } elseif ($wronglyScoped.Count -gt 0) {
+            Write-Result 'FAIL' "No Deployment Scaler assignment exists at the required namespace scope '$normalizedExpected'. Layer 2 is NOT enforcing a namespace boundary."
+            $failures++
+        }
+    }
+
+    # Create the namespace-scoped assignment when asked. Bicep cannot express this scope (see
+    # infra/bicep/modules/sre-agent-mitigation-role.bicep), so it is created here -- idempotently,
+    # and only ever at the exact namespace path.
+    if ($Apply -and $expectedNamespaceScope) {
+        $scalerRoleName = az role definition list --custom-role-only true --query "[?starts_with(roleName, 'SRE Agent Energy Grid Deployment Scaler')].roleName | [0]" -o tsv 2>$null
+        if (-not $scalerRoleName) {
+            Write-Result 'WARN' 'The Deployment Scaler custom role definition does not exist. Deploy with enableAgentKubernetesRbac = true before creating the namespace assignment.'
+        } elseif ($PSCmdlet.ShouldProcess($expectedNamespaceScope, "Assign '$scalerRoleName'")) {
+            $normalizedExpected = $expectedNamespaceScope.TrimEnd('/')
+            $already = @($k8sRole | Where-Object { $_.scope.TrimEnd('/') -ieq $normalizedExpected })
+            if ($already.Count -gt 0) {
+                Write-Result 'INFO' "Namespace-scoped assignment already exists at '$normalizedExpected'; nothing to do (idempotent)."
+            } else {
+                $created = az role assignment create --assignee-object-id $identityPrincipal --assignee-principal-type ServicePrincipal --role "$scalerRoleName" --scope $normalizedExpected -o json 2>$null | ConvertFrom-Json
+                if (-not $created) {
+                    Write-Result 'FAIL' "Failed to create the namespace-scoped assignment at '$normalizedExpected'."
+                    $failures++
+                } else {
+                    # Read back and assert the scope the SERVICE returned, not the one requested.
+                    $readBack = az role assignment show --scope $normalizedExpected --assignee $identityPrincipal --role "$scalerRoleName" -o json 2>$null | ConvertFrom-Json
+                    $actualScope = if ($readBack) { @($readBack)[0].scope } else { $created.scope }
+                    if ($actualScope -and $actualScope.TrimEnd('/') -ieq $normalizedExpected) {
+                        Write-Result 'PASS' "Created and verified namespace-scoped assignment. Returned scope: '$actualScope'"
+                    } else {
+                        Write-Result 'FAIL' "Assignment was created but its returned scope '$actualScope' does not match the required '$normalizedExpected'. Treating Layer 2 as NOT enforced."
+                        $failures++
+                    }
+                }
+            }
+        }
     }
 } else {
     Write-Result 'UNKNOWN' 'Could not resolve the agent managed identity principal; RBAC posture NOT verified.'

--- a/scripts/validate-sre-agent-mitigation-guardrails.ps1
+++ b/scripts/validate-sre-agent-mitigation-guardrails.ps1
@@ -1,0 +1,181 @@
+<#
+.SYNOPSIS
+    Static regression guard for the Review-mode mitigation guardrails (issue #80).
+
+.DESCRIPTION
+    Runs entirely offline. It proves that the enforcement boundary described in
+    docs/REVIEW-MODE-MITIGATION.md has not silently drifted in source:
+
+      1. The tool access policy allowlist is exactly the two documented scale commands, the deny
+         list covers every category issue #80 forbids, and no allow rule can bypass the ask gate.
+      2. The backend allowlist constant matches the policy document, so Mission Control's own
+         re-check cannot diverge from what the agent is configured to permit.
+      3. The Bicep 'Mitigation' access level grants NO Contributor.
+      4. The custom role grants no admin credential, no runCommand, and no write action.
+      5. The lifecycle module still refuses to accept caller-asserted lifecycle state.
+
+    This is intentionally narrow. It does not attempt to be a general linter, and it never
+    contacts Azure -- live posture is checked by configure-sre-agent-mitigation-guardrails.ps1.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$policyPath = Join-Path $repoRoot 'infra/sre-agent/tool-access-policy.json'
+$rolePath = Join-Path $repoRoot 'infra/bicep/modules/sre-agent-mitigation-role.bicep'
+$agentBicepPath = Join-Path $repoRoot 'infra/bicep/modules/sre-agent.bicep'
+$lifecyclePath = Join-Path $repoRoot 'mission-control/backend/src/services/sre-agent/mitigationLifecycle.ts'
+$servicePath = Join-Path $repoRoot 'mission-control/backend/src/services/ReviewModeMitigationService.ts'
+$docPath = Join-Path $repoRoot 'docs/REVIEW-MODE-MITIGATION.md'
+
+$failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) {
+        Write-Host "[PASS   ] $Message" -ForegroundColor Green
+    } else {
+        Write-Host "[FAIL   ] $Message" -ForegroundColor Red
+        $script:failures.Add($Message)
+    }
+}
+
+Write-Host ''
+Write-Host 'Review-mode mitigation guardrails - static validation (issue #80)' -ForegroundColor Cyan
+Write-Host '=================================================================' -ForegroundColor Cyan
+Write-Host ''
+
+foreach ($required in @($policyPath, $rolePath, $agentBicepPath, $lifecyclePath, $servicePath, $docPath)) {
+    if (-not (Test-Path $required)) {
+        throw "Required guardrail artifact is missing: $required"
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 1. Tool access policy
+# -----------------------------------------------------------------------------
+
+$policy = Get-Content -Path $policyPath -Raw | ConvertFrom-Json
+$askRules = @($policy.permissions.ask)
+$denyRules = @($policy.permissions.deny)
+$allowRules = @($policy.permissions.allow)
+
+$expectedAsk = @(
+    'RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=1)',
+    'RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=0)'
+)
+
+Assert-True (($askRules.Count -eq 2) -and (-not (Compare-Object $askRules $expectedAsk))) `
+    'Tool access policy ask rules are exactly the two documented scale commands.'
+
+foreach ($pattern in @('kubectl delete', 'kubectl exec', 'kubectl port-forward', 'RunAzCliWriteCommands',
+                       'az keyvault', 'az aks command invoke', 'ExecutePythonCode', 'RunShellCommand',
+                       'RunInTerminal', '--all-namespaces')) {
+    Assert-True ([bool]($denyRules -match [regex]::Escape($pattern))) "Deny rule present for '$pattern'."
+}
+
+$bypassing = @($allowRules | Where-Object { $_ -match 'Write|delete|exec|Terminal|Shell|Python' })
+Assert-True ($bypassing.Count -eq 0) 'No allow rule can bypass the ask approval gate (allow is read-only).'
+
+# -----------------------------------------------------------------------------
+# 2. Backend allowlist matches the policy document
+# -----------------------------------------------------------------------------
+
+$lifecycle = Get-Content -Path $lifecyclePath -Raw
+
+foreach ($command in @('kubectl scale deployment/mongodb -n energy --replicas=1',
+                       'kubectl scale deployment/mongodb -n energy --replicas=0')) {
+    Assert-True ($lifecycle -match [regex]::Escape($command)) `
+        "Backend allowlist contains '$command', matching the tool access policy."
+}
+
+Assert-True ($lifecycle -match 'ALLOWLISTED_MITIGATION_TOOLS[^\n]*\n?[^\n]*RunKubectlWriteCommand') `
+    'Backend restricts the mitigation tool to RunKubectlWriteCommand.'
+
+Assert-True ($lifecycle -match 'SHELL_METACHARACTERS') `
+    'Backend rejects shell metacharacters before normalising a command.'
+
+# The guarantees that PR #85 lacked. These are asserted in source so a refactor cannot quietly
+# reintroduce caller-asserted lifecycle state.
+Assert-True ($lifecycle -match "state = 'verification-passed'|'verification-passed'") `
+    'Backend defines the verification-passed state.'
+Assert-True ($lifecycle -match 'deny-violation') `
+    'Backend distinguishes a deny violation from a clean denial.'
+Assert-True ($lifecycle -match 'denied-with-unverified-state') `
+    'Backend cannot report `denied` without before/after no-mutation proof.'
+Assert-True ($lifecycle -match 'blocked-run-mode') `
+    'Backend blocks the flow when the effective run mode is not Review.'
+
+$service = Get-Content -Path $servicePath -Raw
+Assert-True ($service -match 'Unknown request field') `
+    'The API rejects unknown request keys instead of silently dropping them.'
+Assert-True ($service -notmatch "MITIGATION_REQUEST_KEYS[\s\S]{0,400}'state'") `
+    'The API never accepts a caller-supplied lifecycle state.'
+
+# -----------------------------------------------------------------------------
+# 3. Bicep: Mitigation access level must not grant Contributor
+# -----------------------------------------------------------------------------
+
+$agentBicep = Get-Content -Path $agentBicepPath -Raw
+$contributorId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
+if ($agentBicep -match '(?s)Mitigation:\s*\[(.*?)\]') {
+    $mitigationBlock = $Matches[1]
+    Assert-True ($mitigationBlock -notmatch [regex]::Escape($contributorId)) `
+        "The 'Mitigation' access level does NOT grant Contributor."
+} else {
+    Assert-True $false "The 'Mitigation' access level block was not found in sre-agent.bicep."
+}
+
+Assert-True ($agentBicep -match "mode: 'Review'") `
+    "The agent's actionConfiguration mode remains 'Review'."
+Assert-True ($agentBicep -notmatch "mode: 'Autonomous'") `
+    'No Autonomous mode is configured anywhere in the agent module.'
+
+# -----------------------------------------------------------------------------
+# 4. Custom role stays narrow
+# -----------------------------------------------------------------------------
+
+$role = Get-Content -Path $rolePath -Raw
+
+# Only inspect the actual ARM action strings, not comments or the human-readable description --
+# both legitimately mention what the role does NOT grant.
+$roleActions = @([regex]::Matches($role, "'(Microsoft\.[A-Za-z0-9./_-]+)'") | ForEach-Object { $_.Groups[1].Value })
+
+Assert-True ($roleActions -contains 'Microsoft.ContainerService/managedClusters/listClusterUserCredential/action') `
+    'Custom role grants the cluster-USER credential.'
+Assert-True (-not ($roleActions -match 'listClusterAdminCredential')) `
+    'Custom role does NOT grant the cluster-ADMIN credential.'
+Assert-True (-not ($roleActions -match 'runCommand')) `
+    'Custom role does NOT grant runCommand (which would be arbitrary in-cluster shell).'
+Assert-True (-not ($roleActions -match 'managedClusters/write|managedClusters/delete')) `
+    'Custom role grants no cluster write or delete action.'
+Assert-True ($roleActions.Count -gt 0 -and -not ($roleActions -match '\*')) `
+    'Custom role contains no wildcard action.'
+Assert-True ($role -match 'notDataActions') `
+    'Custom role explicitly excludes secrets and pod exec via notDataActions.'
+
+# -----------------------------------------------------------------------------
+# 5. Documentation honesty
+# -----------------------------------------------------------------------------
+
+$doc = Get-Content -Path $docPath -Raw
+Assert-True ($doc -match 'PENDING') `
+    'The design document still records the live deny/approve proof as pending rather than claiming it.'
+Assert-True ($doc -match 'DEMO-ONLY PERMISSION BREADTH|demo-only permission') `
+    'The design document discloses the demo-only permission breadth.'
+
+# -----------------------------------------------------------------------------
+
+Write-Host ''
+if ($failures.Count -gt 0) {
+    Write-Host "FAILED: $($failures.Count) guardrail check(s) did not pass." -ForegroundColor Red
+    foreach ($failure in $failures) { Write-Host "  - $failure" -ForegroundColor Red }
+    throw "Review-mode mitigation guardrail validation failed with $($failures.Count) error(s)."
+}
+
+Write-Host 'All Review-mode mitigation guardrail checks passed (static).' -ForegroundColor Green
+Write-Host 'Live posture is verified separately by scripts/configure-sre-agent-mitigation-guardrails.ps1.' -ForegroundColor Yellow

--- a/scripts/validate-sre-agent-mitigation-guardrails.ps1
+++ b/scripts/validate-sre-agent-mitigation-guardrails.ps1
@@ -159,6 +159,61 @@ Assert-True ($role -match 'notDataActions') `
     'Custom role explicitly excludes secrets and pod exec via notDataActions.'
 
 # -----------------------------------------------------------------------------
+# 4b. Layer 2 must never be granted cluster-wide while being called namespace-scoped.
+#
+# Azure RBAC for Kubernetes scopes a namespace grant to <aksResourceId>/namespaces/<namespace>.
+# Bicep cannot target that extension-resource path, so an assignment written as `scope: aks`
+# silently becomes a CLUSTER-WIDE grant. That is strictly worse than no Layer 2, because the
+# operator is told a boundary exists that does not. These checks fail the build if such an
+# assignment reappears in the template.
+# -----------------------------------------------------------------------------
+
+$assignmentBlocks = [regex]::Matches(
+    $role,
+    "resource\s+(\w+)\s+'Microsoft\.Authorization/roleAssignments@[^']+'\s*=(?s).*?\n}"
+)
+
+$dataActionAssignmentAtClusterScope = $false
+foreach ($match in $assignmentBlocks) {
+    $block = $match.Value
+    # An assignment that references the Kubernetes dataActions role definition.
+    if ($block -match 'namespaceRole') {
+        $dataActionAssignmentAtClusterScope = $true
+    }
+}
+
+Assert-True (-not $dataActionAssignmentAtClusterScope) `
+    'Bicep does NOT create a role assignment for the Kubernetes dataActions role (it cannot express the namespace scope; the configure script creates it at <aksId>/namespaces/energy).'
+
+Assert-True ($role -match 'namespaceAssignmentScope') `
+    'Bicep emits the exact required namespace assignment scope as an output.'
+Assert-True ($role -match '\$\{aks\.id\}/namespaces/\$\{namespaceName\}') `
+    'The emitted namespace assignment scope is the documented <aksResourceId>/namespaces/<namespace> path.'
+Assert-True ($role -match 'namespaceRoleAssignmentCreatedByTemplate bool = false') `
+    'Bicep explicitly declares that it does not create the Layer 2 assignment.'
+
+# The configure script must create AND verify the exact scope, and must fail on a cluster-wide one.
+$configureScriptPath = Join-Path $repoRoot 'scripts/configure-sre-agent-mitigation-guardrails.ps1'
+if (-not (Test-Path $configureScriptPath)) {
+    Assert-True $false 'configure-sre-agent-mitigation-guardrails.ps1 is missing.'
+} else {
+    $configure = Get-Content -Path $configureScriptPath -Raw
+    Assert-True ($configure -match '\$aksId/namespaces/\$KubernetesNamespace') `
+        'The configure script builds the assignment scope as <aksId>/namespaces/<namespace>.'
+    Assert-True ($configure -match 'az role assignment create[^\n]*--scope \$normalizedExpected') `
+        'The configure script creates the Layer 2 assignment at the exact namespace scope.'
+    Assert-True ($configure -match 'az role assignment show') `
+        'The configure script reads the assignment back to verify the scope the service returned.'
+    Assert-True ($configure -match 'CLUSTER-WIDE GRANT') `
+        'The configure script fails loudly when the Layer 2 role is assigned at cluster scope.'
+    Assert-True ($configure -match 'OUT-OF-SCOPE GRANT') `
+        'The configure script fails loudly when the Layer 2 role is assigned to another namespace.'
+    # The regression being guarded: any assignment used to print "namespace scope" unconditionally.
+    Assert-True ($configure -notmatch "Write-Result 'PASS' 'Layer 2 active: the Kubernetes boundary is enforced by the API server at namespace scope\.'") `
+        'The configure script no longer claims namespace enforcement without verifying the scope.'
+}
+
+# -----------------------------------------------------------------------------
 # 5. Documentation honesty
 # -----------------------------------------------------------------------------
 

--- a/tests/static/test_review_mode_mitigation_rbac.py
+++ b/tests/static/test_review_mode_mitigation_rbac.py
@@ -1,0 +1,159 @@
+"""Static safety tests for the Review-mode mitigation RBAC boundary (issue #80).
+
+These guard the HIGH-severity defect found in review of PR #86: the Kubernetes dataActions role
+assignment was written at ``scope: aks`` -- a CLUSTER-WIDE grant -- while the code, docs, and
+configure script all claimed it was narrowed to ``<aksId>/namespaces/energy``.
+
+Azure RBAC for Kubernetes Authorization scopes a namespace grant to the extension-resource path
+``<aksResourceId>/namespaces/<namespace>``. Bicep cannot target that path, so the assignment must be
+created by the configure script -- never by the template at cluster scope.
+
+These tests run offline and are intentionally narrow.
+"""
+
+import json
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+ROLE_MODULE = ROOT / 'infra/bicep/modules/sre-agent-mitigation-role.bicep'
+CONFIGURE_SCRIPT = ROOT / 'scripts/configure-sre-agent-mitigation-guardrails.ps1'
+VALIDATE_SCRIPT = ROOT / 'scripts/validate-sre-agent-mitigation-guardrails.ps1'
+POLICY = ROOT / 'infra/sre-agent/tool-access-policy.json'
+DESIGN_DOC = ROOT / 'docs/REVIEW-MODE-MITIGATION.md'
+
+ROLE_ASSIGNMENT_RE = re.compile(
+    r"resource\s+(?P<symbol>\w+)\s+'Microsoft\.Authorization/roleAssignments@[^']+'\s*="
+    r"(?P<body>.*?)\n}",
+    re.DOTALL,
+)
+
+
+class MitigationRbacScopeTests(unittest.TestCase):
+    def setUp(self):
+        self.role_module = ROLE_MODULE.read_text(encoding='utf-8')
+        self.configure = CONFIGURE_SCRIPT.read_text(encoding='utf-8')
+        self.validate = VALIDATE_SCRIPT.read_text(encoding='utf-8')
+
+    def test_template_creates_no_assignment_for_the_kubernetes_dataactions_role(self):
+        """A `scope: aks` assignment of the dataActions role is a cluster-wide grant."""
+        for match in ROLE_ASSIGNMENT_RE.finditer(self.role_module):
+            body = match.group('body')
+            self.assertNotIn(
+                'namespaceRole',
+                body,
+                msg=(
+                    f"Role assignment '{match.group('symbol')}' references the Kubernetes "
+                    'dataActions role. Bicep cannot express the '
+                    '<aksId>/namespaces/<namespace> scope, so any assignment it creates is '
+                    'CLUSTER-WIDE. Create it in configure-sre-agent-mitigation-guardrails.ps1 '
+                    'instead.'
+                ),
+            )
+
+    def test_template_declares_it_does_not_create_the_layer2_assignment(self):
+        self.assertIn('namespaceRoleAssignmentCreatedByTemplate bool = false', self.role_module)
+
+    def test_template_emits_the_exact_namespace_scope(self):
+        self.assertIn('output namespaceAssignmentScope string', self.role_module)
+        self.assertIn('${aks.id}/namespaces/${namespaceName}', self.role_module)
+
+    def test_dataactions_role_excludes_secrets_and_exec(self):
+        self.assertIn('Microsoft.ContainerService/managedClusters/secrets/read', self.role_module)
+        self.assertIn('Microsoft.ContainerService/managedClusters/pods/exec/action', self.role_module)
+        not_data = self.role_module.split('notDataActions:', 1)[1]
+        self.assertIn('secrets/read', not_data)
+        self.assertIn('pods/exec/action', not_data)
+
+    def test_control_plane_role_grants_no_admin_credential_or_run_command(self):
+        actions = re.findall(r"'(Microsoft\.[A-Za-z0-9./_-]+)'", self.role_module)
+        self.assertIn('Microsoft.ContainerService/managedClusters/listClusterUserCredential/action', actions)
+        for forbidden in ('listClusterAdminCredential', 'runCommand', 'managedClusters/write', 'managedClusters/delete'):
+            self.assertFalse(
+                any(forbidden in action for action in actions),
+                msg=f"custom role must not grant '{forbidden}'",
+            )
+        self.assertFalse(any('*' in action for action in actions), msg='no wildcard actions')
+
+    def test_layer2_remains_opt_in_and_off_by_default(self):
+        self.assertIn('param enableKubernetesDataActions bool = false', self.role_module)
+        main = (ROOT / 'infra/bicep/main.bicep').read_text(encoding='utf-8')
+        self.assertIn('param enableReviewModeMitigation bool = false', main)
+        self.assertIn('param enableAgentKubernetesRbac bool = false', main)
+
+
+class ConfigureScriptScopeTests(unittest.TestCase):
+    def setUp(self):
+        self.configure = CONFIGURE_SCRIPT.read_text(encoding='utf-8')
+
+    def test_builds_the_documented_namespace_scope(self):
+        self.assertIn('"$aksId/namespaces/$KubernetesNamespace"', self.configure)
+
+    def test_creates_assignment_only_at_the_exact_namespace_scope(self):
+        self.assertIn('az role assignment create', self.configure)
+        self.assertIn('--scope $normalizedExpected', self.configure)
+
+    def test_verifies_the_scope_the_service_returned(self):
+        self.assertIn('az role assignment show', self.configure)
+        self.assertIn('does not match the required', self.configure)
+
+    def test_fails_loudly_on_cluster_wide_or_foreign_namespace_grants(self):
+        self.assertIn('CLUSTER-WIDE GRANT', self.configure)
+        self.assertIn('OUT-OF-SCOPE GRANT', self.configure)
+
+    def test_is_idempotent(self):
+        self.assertIn('nothing to do (idempotent)', self.configure)
+
+    def test_no_longer_claims_namespace_enforcement_without_verifying(self):
+        """The exact regression: any assignment used to print 'namespace scope'."""
+        self.assertNotIn(
+            "Write-Result 'PASS' 'Layer 2 active: the Kubernetes boundary is enforced by "
+            "the API server at namespace scope.'",
+            self.configure,
+        )
+
+
+class ValidatorGuardTests(unittest.TestCase):
+    def setUp(self):
+        self.validate = VALIDATE_SCRIPT.read_text(encoding='utf-8')
+
+    def test_validator_guards_against_a_reintroduced_cluster_scoped_assignment(self):
+        self.assertIn('roleAssignments@', self.validate)
+        self.assertIn('does NOT create a role assignment for the Kubernetes dataActions role', self.validate)
+
+    def test_validator_checks_the_configure_script_scope_logic(self):
+        self.assertIn('CLUSTER-WIDE GRANT', self.validate)
+        self.assertIn('OUT-OF-SCOPE GRANT', self.validate)
+
+
+class ToolAccessPolicyTests(unittest.TestCase):
+    def test_ask_rules_are_exactly_the_two_documented_scale_commands(self):
+        policy = json.loads(POLICY.read_text(encoding='utf-8'))
+        self.assertEqual(
+            sorted(policy['permissions']['ask']),
+            sorted([
+                'RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=1)',
+                'RunKubectlWriteCommand(kubectl scale deployment/mongodb -n energy --replicas=0)',
+            ]),
+        )
+
+    def test_allow_rules_cannot_bypass_the_ask_gate(self):
+        policy = json.loads(POLICY.read_text(encoding='utf-8'))
+        for rule in policy['permissions']['allow']:
+            self.assertNotRegex(rule, r'Write|delete|exec|Terminal|Shell|Python')
+
+
+class DesignDocHonestyTests(unittest.TestCase):
+    def test_doc_does_not_claim_the_template_creates_a_namespace_assignment(self):
+        doc = DESIGN_DOC.read_text(encoding='utf-8')
+        self.assertIn('PENDING', doc)
+        self.assertIn('namespaces/energy', doc)
+        # The doc must explain that Bicep cannot express the namespace scope.
+        self.assertRegex(doc, r'Bicep cannot|cannot express')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements #80: one reversible scenario with a documented, guardrailed Review-mode mitigation path whose lifecycle is **derived from observed Azure SRE Agent audit telemetry**, never asserted by a caller.

This is a reimplementation from latest `main` (includes #82 MCP, #83 native incidents, #84 customer-impact SLO). The prior attempt (closed #85) is treated only as negative evidence — none of its design is reused.

## 1 · Action-design gate — the blocking question, resolved

**Does a Kubernetes fix trigger the native Review-mode approval gate? No, not on its own.**

[Run modes](https://learn.microsoft.com/azure/sre-agent/run-modes) scopes Approve/Deny to *Azure infrastructure operations* and directs everything else to Hooks or Tool Access Policies. So:

| Candidate | Verdict |
| --- | --- |
| An ARM operation that scales a Kubernetes Deployment | **Does not exist** |
| `az aks command invoke` | ARM write and *would* gate — but is arbitrary in-cluster shell, forbidden by #80 non-goals. **Rejected** |
| `az aks nodepool scale` | Doesn't fix MongoDB; also invalid — both pools set `enableAutoScaling: true`. **Rejected** |

All ten repo scenarios are Kubernetes data-plane faults, so the supported approval contract is a global Tool Access Policy **`ask`** rule (documented: *"pauses for approval in Review mode"*) **plus** response-plan run mode Review. Because `ask` auto-approves under Autonomous, an observed effective mode of `review` is a hard precondition.

**Chosen action:** `kubectl scale deployment/mongodb -n energy --replicas=1` · **Rollback:** same command with `--replicas=0`, inside the same allowlist so rollback is itself gated and audited.

Full preconditions, blast radius, permissions, timeout, rollback and verification: [`docs/REVIEW-MODE-MITIGATION.md`](docs/REVIEW-MODE-MITIGATION.md).

## 2 · Enforcement boundary

- **Tool access policy** (`infra/sre-agent/tool-access-policy.json`) — exactly two `ask` rules; `deny` covers deletes, exec, port-forward, `az keyvault`, all `RunAzCliWriteCommands`, `az aks command invoke`, Python, shell, `--all-namespaces`; `allow` is read-only only.
- **Contributor replaced.** New `Mitigation` access level grants **no** Contributor. A custom role scoped to the AKS *resource* grants only `managedClusters/read` + `listClusterUserCredential/action` — no admin credential, no `runCommand`, no wildcard.
- **Opt-in Azure RBAC for Kubernetes** moves the boundary into the API server at namespace scope. Off by default (it changes how operators get a kubeconfig, and there's no live env to validate that); the residual breadth is disclosed **loudly** in the API, the UI and the validator rather than hidden.

## 3 · Evidence contract

Joins `IncidentActivitySnapshot`, `ApprovalDecision`, `AgentToolExecution` and `AgentAzCliExecution` on **exact string equality** of ThreadId/CorrelationId/IncidentId/TraceId. Mismatched, ambiguous, replayed, duplicated, future-dated, out-of-order, stale and schema-drifted rows are rejected with a stated reason.

- Autonomous or unobservable run mode **blocks** the flow loudly.
- `denied` requires an observed rejection **and** before/after state proving no mutation. `applied`/`unknown` is never rewritten into `unchanged`; a mutation after a rejection is `deny-violation`, a security finding.
- `verification-passed` requires observed approval, matching execution, and three structured probes — Kubernetes readiness, service endpoint health, and the #84 golden transaction — that all **post-date** execution. Each probe carries source, observed value, timestamp, freshness and an evidence pointer. No boolean-only success.
- Verification failure / stale / partial / no-data leaves the incident **unresolved** with rollback and escalation guidance.
- Mission Control stays **read-only** for approval. No local Approve button, because Microsoft documents no supported external approval operation.

## 4 · Review findings — all found and fixed before merge

Each has a named regression test.

| Severity | Finding | Fix |
| --- | --- | --- |
| **High** | Lookahead-based command normalisation discarded extra arguments, so `...deployment/mongodb deployment/grid-api -n energy --replicas=1 --server https://evil --as system:masters` normalised into an allowlisted command and reached `verification-passed` | Replaced with a strict tokeniser; any unrecognised flag or second positional resource rejects the whole string |
| **High** | Layer 2's Kubernetes `dataActions` role was assigned at `scope: aks` — a **cluster-wide grant** — while code, docs and the configure script all claimed `<aksId>/namespaces/energy`. `namespaceName` only affected the assignment GUID/description, and the script printed "enforced by the API server at namespace scope" for *any* assignment at *any* scope | See §4a below |
| **Medium** | The run-mode gate selected its snapshot row with an OR over IncidentId/ThreadId, so autonomy level could be read from a *different* agent thread — presenting an ungated autonomous write as human-approved | `correlateRawRow()` applies the same strict equality as everywhere else |
| **Medium** | `agent-tool-execution` filtered only on `threadId`. The primary UI path can have an `incidentId` without a `threadId`, degrading the query to a workspace-wide top-50 whose `take` could silently drop the incident's tool rows | Template and allowed params now accept `incidentId`; `ReviewModeMitigationService` passes it. Exact post-query correlation is unchanged, so a foreign row from a looser filter is still rejected |
| **Medium** | Out-of-scope `ToolEnd` rows were excluded from the security scan, so a disallowed operation that **succeeded** produced no finding — completing a forbidden action was quieter than attempting one | All non-allowlisted rows are flagged regardless of event type, deduped per call by CallId → SpanId → command text, preferring the ToolEnd row because it carries the outcome |
| **Medium** | Redaction of space-separated CLI secret flags stopped at the first space inside quotes, leaking multi-word secrets into response bodies | Value pattern consumes to the matching closing quote |

Self-review additionally caught a **sliding before/after window**: once a mutation had settled, two successive later polls would compare equal and report a rejected-but-mutated resource as a clean `denied`. The "before" reading is now anchored at or before the decision timestamp.

### 4a · The namespace-scope fix, in detail

Azure RBAC for Kubernetes scopes a namespace grant to the extension-resource path `<aksResourceId>/namespaces/<namespace>`. That is **not a deployable ARM resource type**, so Bicep has no symbolic reference to target and `scope:` cannot name it — writing `scope: aks` silently produces a cluster-wide grant. A cluster-wide `dataActions` grant labelled "namespace-scoped" is worse than no Layer 2 at all, because the operator is told a boundary exists that does not.

Fixed honestly rather than papered over:

- **The template creates only the role definition.** The cluster-scoped assignment is gone. The module outputs the exact required `namespaceAssignmentScope` and `namespaceRoleAssignmentCreatedByTemplate = false`.
- **The configure script creates the assignment** idempotently at `--scope <aksId>/namespaces/energy`, then **reads it back and asserts the scope the service returned** — not the one requested.
- **Wrong scopes fail loudly.** A bare-cluster assignment is `CLUSTER-WIDE GRANT`; another namespace is `OUT-OF-SCOPE GRANT`. Each prints the exact `az role assignment delete --ids …` remedy. Namespace enforcement is never inferred from an assignment merely existing.
- **New `-KubernetesNamespace` parameter** (pattern-validated, defaults to `energy`).
- **Two independent guards.** `validate-sre-agent-mitigation-guardrails.ps1` fails if a `roleAssignments` resource referencing the dataActions role reappears in the template; new `tests/static/test_review_mode_mitigation_rbac.py` (17 offline tests) parses the Bicep assignment blocks and both scripts. Verified by temporarily reintroducing a `scope: aks` assignment — the validator failed as intended.

Layer 2 remains opt-in and off by default.

## 5 · Validation

| Check | Result |
| --- | --- |
| Backend tests | **266 pass** |
| Frontend tests | **17 pass** (incl. backend/frontend union parity read from source) |
| Python tests | **56 pass** (incl. 17 new RBAC-scope static tests) |
| Backend + frontend lint & build | pass |
| `validate-sre-agent-mitigation-guardrails.ps1` | **43 static checks pass** |
| Other repo validators | pass |
| `az bicep build` — all 13 files | pass, no lint warnings |
| CodeQL (actions, go, javascript-typescript, python, rust) | pass on `7f16ddb` |

Test coverage includes runtime parsers, effective autonomous mode, exact/mismatched IDs, request forgery, deny with applied mutation, missing rejection event, before/after drift, stale/future/out-of-order/replayed events, duplicates, approval without execution, execution without approval, probe missing/no-data/stale/failing, verification before execution, verification pass, rollback, redaction, frontend/backend parity, persistence, concurrency, allowlist bypass, incident-only correlation with concurrent-thread noise, ToolEnd-only out-of-scope detection, and Start/End dedupe.

Also fixed: `.gitignore`'s blanket `*.json` would have silently dropped the tool access policy — added an explicit negation following the repo's existing convention.

## 6 · Live-proof status — explicitly PENDING

No Energy Grid environment exists in this subscription, and `rg-srelab-northcentralus` (AmeriGas) was not touched. No paid or destructive Azure operation was performed.

**Pending:**
- One live **Deny** run and one live **Approve → Execute → Verify** run.
- Confirmation that a Tool Access Policy `ask` approval emits an `ApprovalDecision` customEvent. Microsoft documents the event but not which approval mechanisms emit it; the code treats a missing event as `pending`/`unknown`, never as approved.

Capture procedure: [`docs/DEMO-RUNBOOK.md#review-mode-mitigation-mongodbdown`](docs/DEMO-RUNBOOK.md).

Because the enforceable action path cannot be exercised outside tests here, this **does not use `Closes #80`**.

Refs #80. Preserves all #82/#83/#84 functionality and contracts.

