### PR TITLE
Validate Kubernetes manifests in CI

### DIFF
--- a/.github/workflows/validate-kubernetes.yml
+++ b/.github/workflows/validate-kubernetes.yml
@@ -22,10 +22,6 @@ jobs:
     env:
       KUBECONFORM_VERSION: v0.6.7
       KUBERNETES_VERSION: '1.30.0'
-      # SecretProviderClass is an Azure Key Vault CSI custom resource that is intentionally
-      # outside this issue's scope. We skip only this explicit custom kind instead of
-      # ignoring all unknown kinds silently.
-      KUBE_SKIP_TYPES: 'SecretProviderClass'
 
     steps:
       - name: Checkout repository
@@ -56,5 +52,4 @@ jobs:
             -strict \
             -summary \
             -kubernetes-version "${KUBERNETES_VERSION}" \
-            -skip "${KUBE_SKIP_TYPES}" \
             $MANIFESTS

--- a/.github/workflows/validate-kubernetes.yml
+++ b/.github/workflows/validate-kubernetes.yml
@@ -1,0 +1,60 @@
+name: Validate Kubernetes Manifests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/validate-kubernetes.yml'
+      - 'k8s/**'
+  pull_request:
+    paths:
+      - '.github/workflows/validate-kubernetes.yml'
+      - 'k8s/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-kubernetes:
+    name: kubeconform
+    runs-on: ubuntu-latest
+
+    env:
+      KUBECONFORM_VERSION: v0.6.7
+      KUBERNETES_VERSION: '1.30.0'
+      # SecretProviderClass is an Azure Key Vault CSI custom resource that is intentionally
+      # outside this issue's scope. We skip only this explicit custom kind instead of
+      # ignoring all unknown kinds silently.
+      KUBE_SKIP_TYPES: 'SecretProviderClass'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: List YAML manifests to validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Kubernetes YAML manifests under k8s/base and k8s/scenarios:"
+          find k8s/base k8s/scenarios -type f -name '*.yaml' -print | sort
+
+      - name: Validate Kubernetes schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          MANIFESTS=$(find k8s/base k8s/scenarios -type f -name '*.yaml' -print | sort | tr '\n' ' ')
+
+          if [ -z "$MANIFESTS" ]; then
+            echo "No Kubernetes YAML manifests found under k8s/base or k8s/scenarios." >&2
+            exit 1
+          fi
+
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/work" \
+            -w /work \
+            "ghcr.io/yannh/kubeconform:${KUBECONFORM_VERSION}" \
+            -strict \
+            -summary \
+            -kubernetes-version "${KUBERNETES_VERSION}" \
+            -skip "${KUBE_SKIP_TYPES}" \
+            $MANIFESTS


### PR DESCRIPTION
## Summary
- Add a dedicated CI workflow that validates every YAML manifest under `k8s/base/` and `k8s/scenarios/`.
- Use `kubeconform` in strict mode against Kubernetes `1.30.0` to catch schema regressions before deployment.
- Preserve the existing metadata validation workflow and avoid any cluster login or live AKS interaction.
- Handle the repo's explicit custom-resource exception by skipping only `SecretProviderClass`, instead of silently ignoring unknown kinds.

## Validation evidence
- `find k8s/base k8s/scenarios -type f -name '*.yaml' -print | sort`
- `docker run --rm -v .:/work -w /work ghcr.io/yannh/kubeconform:v0.6.7 -strict -summary -kubernetes-version 1.30.0 -skip SecretProviderClass k8s/base/application.yaml k8s/scenarios/complete-failure-bundle/scenario.yaml k8s/scenarios/crash-loop.yaml k8s/scenarios/high-cpu.yaml k8s/scenarios/image-pull-backoff.yaml k8s/scenarios/missing-config.yaml k8s/scenarios/mongodb-down.yaml k8s/scenarios/network-block.yaml k8s/scenarios/oom-killed.yaml k8s/scenarios/pending-pods.yaml k8s/scenarios/probe-failure.yaml k8s/scenarios/service-mismatch.yaml`

Result: `Summary: 45 resources found in 12 files - Valid: 45, Invalid: 0, Errors: 0, Skipped: 0`

Closes #89
