### PR TITLE
Add PowerShell parser and analyzer gate

### DIFF
--- a/.github/workflows/validate-powershell.yml
+++ b/.github/workflows/validate-powershell.yml
@@ -56,7 +56,7 @@ jobs:
 
           Write-Host "PowerShell AST parser passed for $($scriptFiles.Count) file(s)."
 
-      - name: Install and load exact PSScriptAnalyzer version
+      - name: Install, import, and run exact PSScriptAnalyzer version
         shell: pwsh
         run: |
           $moduleVersion = '1.23.0'
@@ -88,16 +88,13 @@ jobs:
           Get-Module -Name PSScriptAnalyzer -All | Remove-Module -Force -ErrorAction SilentlyContinue
           Import-Module $installedModule.Path -Force -RequiredVersion $moduleVersion -ErrorAction Stop
 
-          $loadedModule = Get-Module PSScriptAnalyzer | Select-Object -First 1
+          $loadedModule = Get-Module -Name PSScriptAnalyzer | Select-Object -First 1
           if (-not $loadedModule -or $loadedModule.Version.ToString() -ne $moduleVersion) {
             throw "Expected PSScriptAnalyzer version $moduleVersion to be loaded, but got $($loadedModule.Version.ToString())."
           }
 
           Write-Host "Loaded PSScriptAnalyzer $($loadedModule.Version) from $($loadedModule.Path)"
 
-      - name: Run PSScriptAnalyzer
-        shell: pwsh
-        run: |
           $results = Invoke-ScriptAnalyzer -Path scripts -Recurse -Severity Error
 
           if ($results) {

--- a/.github/workflows/validate-powershell.yml
+++ b/.github/workflows/validate-powershell.yml
@@ -1,0 +1,78 @@
+name: Validate PowerShell
+
+on:
+  push:
+    paths:
+      - 'scripts/**/*.ps1'
+      - '.github/workflows/validate-powershell.yml'
+  pull_request:
+    paths:
+      - 'scripts/**/*.ps1'
+      - '.github/workflows/validate-powershell.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-powershell:
+    name: Parse and analyze PowerShell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Parse PowerShell syntax
+        shell: pwsh
+        run: |
+          $scriptFiles = Get-ChildItem scripts -Filter *.ps1 -Recurse
+          if (-not $scriptFiles) {
+            throw "No PowerShell scripts were found under scripts/."
+          }
+
+          $errorCount = 0
+          foreach ($file in $scriptFiles) {
+            $parseErrors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile(
+              $file.FullName,
+              [ref]$null,
+              [ref]$parseErrors
+            )
+
+            if ($parseErrors) {
+              foreach ($error in $parseErrors) {
+                $line = $error.Extent.StartLineNumber
+                $column = $error.Extent.StartColumnNumber
+                Write-Host "::error file=$($file.FullName),line=$line,col=$column::$($error.Message)"
+                $errorCount++
+              }
+            }
+          }
+
+          if ($errorCount -gt 0) {
+            throw "PowerShell syntax parsed with $errorCount error(s)."
+          }
+
+          Write-Host "PowerShell AST parser passed for $($scriptFiles.Count) file(s)."
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck -RequiredVersion '1.23.0'
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $results = Invoke-ScriptAnalyzer -Path scripts -Recurse -Severity Error
+
+          if ($results) {
+            foreach ($result in $results) {
+              Write-Host "::error file=$($result.ScriptPath),line=$($result.Line),col=$($result.Column),title=$($result.RuleName)::$($result.Message)"
+            }
+
+            throw "PSScriptAnalyzer found $($results.Count) Error-severity issue(s)."
+          }
+
+          Write-Host "PSScriptAnalyzer returned no Error-severity issues."

--- a/.github/workflows/validate-powershell.yml
+++ b/.github/workflows/validate-powershell.yml
@@ -56,11 +56,44 @@ jobs:
 
           Write-Host "PowerShell AST parser passed for $($scriptFiles.Count) file(s)."
 
-      - name: Install PSScriptAnalyzer
+      - name: Install and load exact PSScriptAnalyzer version
         shell: pwsh
         run: |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck -RequiredVersion '1.23.0'
+          $moduleVersion = '1.23.0'
+          $repositoryName = 'PSGallery'
+
+          $psGallery = Get-PSRepository -Name $repositoryName -ErrorAction Stop
+          if ($psGallery.InstallationPolicy -ne 'Trusted') {
+            Set-PSRepository -Name $repositoryName -InstallationPolicy Trusted -ErrorAction Stop
+          }
+
+          Install-Module `
+            -Name PSScriptAnalyzer `
+            -Repository $repositoryName `
+            -Scope CurrentUser `
+            -RequiredVersion $moduleVersion `
+            -Force `
+            -AcceptLicense `
+            -ErrorAction Stop
+
+          $installedModule = Get-Module -ListAvailable -Name PSScriptAnalyzer |
+            Where-Object { $_.Version -eq [version]$moduleVersion } |
+            Sort-Object Version -Descending |
+            Select-Object -First 1
+
+          if (-not $installedModule) {
+            throw "PSScriptAnalyzer $moduleVersion is not installed from $repositoryName."
+          }
+
+          Get-Module -Name PSScriptAnalyzer -All | Remove-Module -Force -ErrorAction SilentlyContinue
+          Import-Module $installedModule.Path -Force -RequiredVersion $moduleVersion -ErrorAction Stop
+
+          $loadedModule = Get-Module PSScriptAnalyzer | Select-Object -First 1
+          if (-not $loadedModule -or $loadedModule.Version.ToString() -ne $moduleVersion) {
+            throw "Expected PSScriptAnalyzer version $moduleVersion to be loaded, but got $($loadedModule.Version.ToString())."
+          }
+
+          Write-Host "Loaded PSScriptAnalyzer $($loadedModule.Version) from $($loadedModule.Path)"
 
       - name: Run PSScriptAnalyzer
         shell: pwsh


### PR DESCRIPTION
## Summary

This PR adds a dedicated PowerShell validation workflow for the repo's deployment and support scripts.

- Parse every `scripts/**/*.ps1` file with the PowerShell AST parser and fail on syntax errors with file/line/column diagnostics.
- Install the exact PSScriptAnalyzer 1.23.0 module from `PSGallery`, set `PSGallery` trust explicitly, remove any prior analyzer module, import the exact installed module path, assert the loaded version is `1.23.0`, and invoke `Invoke-ScriptAnalyzer` in the same `pwsh` process.
- Preserve trust: `PSGallery` is set to `Trusted`, and the workflow does not bypass publisher validation.
- Keep analysis limited to `Error` severity so this PR does not broaden unrelated cleanup.

## Changed files

- `.github/workflows/validate-powershell.yml`

## Validation performed

The workflow does the following after checkout:

- AST parsing is done in a separate `Parse PowerShell syntax` `pwsh` step. This enumerates `scripts/**/*.ps1`, calls `Parser::ParseFile(...)`, emits `::error` annotations with file/line/column, and fails on parse errors.
- The analyzer work is done in a separate `Install, import, and run exact PSScriptAnalyzer version` `pwsh` step, but the install, exact-path import, version assertion, and `Invoke-ScriptAnalyzer -Path scripts -Recurse -Severity Error` execution all occur in the same `pwsh` process.
- `Set-PSRepository -Name PSGallery -InstallationPolicy Trusted`
- `Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -RequiredVersion '1.23.0' -Force -AcceptLicense`
- `Get-Module -Name PSScriptAnalyzer -All | Remove-Module -Force`
- `Import-Module $installedModule.Path -Force -RequiredVersion '1.23.0'`
- `Get-Module -Name PSScriptAnalyzer` version assertion before analysis
- `Invoke-ScriptAnalyzer -Path scripts -Recurse -Severity Error`

This is the exact implementation now enforced in CI.

## Checks actually run

Current GitHub checks for PR #105 are passing:

- `Parse and analyze PowerShell scripts` — pass
- `CodeQL` — pass

## Risks / scope

- This gate is static-only; it does not execute Azure, kubectl, or other deployment commands.
- It intentionally does not require interactive auth or mutate infrastructure.
- Error-only analyzer severity keeps the PR scoped to actionable issues while preserving the repo's existing warnings.

Closes #90
