### PR TITLE
Reduce duplicate Kubernetes polling

### DIFF
--- a/mission-control/backend/src/routes/mitigation.test.ts
+++ b/mission-control/backend/src/routes/mitigation.test.ts
@@ -32,6 +32,7 @@ function inventoryFixture(desiredReplicas: number, readyPods: number): Inventory
   return {
     namespace: 'energy',
     updatedAt: T(-20),
+    pods: [],
     orphanPods: [],
     services: [],
     events: [],

--- a/mission-control/backend/src/services/CustomerImpactService.test.ts
+++ b/mission-control/backend/src/services/CustomerImpactService.test.ts
@@ -357,6 +357,7 @@ function inventoryWith(options: { mongoDown?: boolean; serviceMismatch?: boolean
         recentEvents: [],
       },
     ],
+    pods: [],
     orphanPods: [],
     services: [meterService],
     events: [],

--- a/mission-control/backend/src/services/KubeClient.ts
+++ b/mission-control/backend/src/services/KubeClient.ts
@@ -98,6 +98,7 @@ export class KubeClient {
       namespace: ENERGY_NAMESPACE,
       updatedAt: new Date().toISOString(),
       deployments: deploymentItems,
+      pods,
       orphanPods: pods.filter((pod) => !claimedPods.has(pod.name)).map(toInventoryPodSummary),
       services,
       events: events.slice(0, 50),

--- a/mission-control/backend/src/services/sre-agent/mitigationProbes.test.ts
+++ b/mission-control/backend/src/services/sre-agent/mitigationProbes.test.ts
@@ -26,6 +26,7 @@ function inventory(overrides: Partial<InventoryResponse['deployments'][number]> 
   return {
     namespace: 'energy',
     updatedAt,
+    pods: [],
     orphanPods: [],
     services: [],
     events: [],

--- a/mission-control/backend/src/types/index.ts
+++ b/mission-control/backend/src/types/index.ts
@@ -183,6 +183,7 @@ export interface InventoryResponse {
   namespace: 'energy';
   updatedAt: string;
   deployments: DeploymentInventoryItem[];
+  pods: Pod[];
   orphanPods: InventoryPodSummary[];
   services: Service[];
   events: KubeEvent[];

--- a/mission-control/frontend/src/components/MissionWallboard.vue
+++ b/mission-control/frontend/src/components/MissionWallboard.vue
@@ -784,20 +784,27 @@ const analystTranscriptStatus = computed(() => {
 
 async function refreshAll() {
   inventoryLoading.value = true;
-  await Promise.all([loadInventory(), loadRuntime(), loadScenarios(), loadIncidentHandoffs(), loadCustomerImpact()]);
+  const [hasBundledRuntime] = await Promise.all([
+    loadInventory(),
+    loadScenarios(),
+    loadIncidentHandoffs(),
+    loadCustomerImpact(),
+  ]);
+  if (!hasBundledRuntime) await loadRuntime();
   await loadMitigationEvidence();
   inventoryLoading.value = false;
 }
 
-async function loadInventory() {
+async function loadInventory(): Promise<boolean> {
   inventoryError.value = '';
   try {
     const response = await getInventory();
     inventory.value = normalizeInventory(inventoryItemsFromResponse(response), response.namespace);
+    if (Array.isArray(response.pods)) pods.value = response.pods;
     if (Array.isArray(response.services)) services.value = response.services;
     if (Array.isArray(response.events)) events.value = response.events;
     inventorySource.value = 'inventory-api';
-    return;
+    return Array.isArray(response.pods);
   } catch (error) {
     inventoryError.value = `Inventory API unavailable: ${error instanceof Error ? error.message : String(error)}. Showing explicit fallback from older endpoints if available.`;
   }
@@ -817,6 +824,7 @@ async function loadInventory() {
     inventory.value = [];
     inventorySource.value = 'unavailable';
   }
+  return false;
 }
 
 async function loadRuntime() {

--- a/mission-control/frontend/src/types/api.ts
+++ b/mission-control/frontend/src/types/api.ts
@@ -172,6 +172,7 @@ export interface InventoryResponse {
   updatedAt?: string;
   inventory?: InventoryItem[];
   deployments: InventoryItem[];
+  pods?: Pod[];
   orphanPods: InventoryPodSummary[];
   services: Service[];
   events: KubeEvent[];


### PR DESCRIPTION
## Summary

- include the already-collected pod list in the Kubernetes inventory response
- reuse bundled pods, services, and events in Mission Control
- retain legacy endpoint polling only for mixed-version or unavailable inventory responses

The wallboard previously launched 8 `kubectl` subprocesses per 5-second refresh: 5 for `/api/inventory`, then 3 redundant calls for pods, services, and events. The normal path now launches 5, reducing that polling load by 37.5% (36 fewer subprocesses per minute).

## Performance audit

| Rank | Improvement | Impact | Effort | Status |
|---:|---|---|---|---|
| 1 | Reuse pods/services/events already collected by `/api/inventory` instead of polling three legacy endpoints every 5 seconds | High | Low | Implemented |
| 2 | Add a shared short-TTL, in-flight-deduplicated inventory cache across inventory, customer-impact, mitigation, and mission-state services | High | Low | Candidate |
| 3 | Replace fixed `setInterval` polling with completion-scheduled polling and pause it while the tab is hidden | High | Low | Candidate |
| 4 | Replace repeated `kubectl` child processes with a long-lived Kubernetes API client and watches | High | Medium | Candidate |
| 5 | Reuse wallboard inventory state for Header service links instead of polling `/api/services` separately | Medium | Low | Candidate |
| 6 | Pre-index pods, services, and events by labels/object names before building deployment inventory instead of filtering every collection per deployment | Medium | Low | Candidate |
| 7 | Add bounded RabbitMQ consumer concurrency and QoS/prefetch in dispatch-service; it currently persists messages serially | High | Medium | Candidate |
| 8 | Avoid synchronous stdout span exporting when OTLP is unavailable; batch or disable fallback tracing in production | Medium | Low | Candidate |
| 9 | Add response compression and immutable caching headers for the production frontend assets | Medium | Low | Candidate |
| 10 | Lazy-load infrequently used Mission Wallboard drawers/panels to reduce initial Vue parse and render work | Medium | Medium | Candidate |

## Validation

- `npm run lint`
- `npm test -w backend`
- `npm test -w frontend`
- `npm run build`