### PR TITLE
Prevent overlapping Mission Control polling requests

### DIFF
--- a/mission-control/frontend/src/composables/usePolling.test.ts
+++ b/mission-control/frontend/src/composables/usePolling.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { effectScope } from 'vue';
+import { usePolling } from './usePolling.js';
+
+test('scheduled polling waits for the current request to finish', async () => {
+  let calls = 0;
+  let resolveRequest: (() => void) | undefined;
+  const request = new Promise<void>((resolve) => {
+    resolveRequest = resolve;
+  });
+  const scope = effectScope();
+  const poller = scope.run(() => usePolling(async () => {
+    calls += 1;
+    await request;
+    return calls;
+  }, 1));
+
+  assert.ok(poller);
+  poller.start();
+  poller.start();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(calls, 1);
+
+  poller.stop();
+  resolveRequest?.();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(calls, 1);
+  scope.stop();
+});

--- a/mission-control/frontend/src/composables/usePolling.ts
+++ b/mission-control/frontend/src/composables/usePolling.ts
@@ -1,10 +1,11 @@
-import { ref, onUnmounted } from 'vue';
+import { onScopeDispose, ref } from 'vue';
 
 export function usePolling<T>(fetcher: () => Promise<T>, intervalMs = 5000) {
   const data = ref<T | null>(null) as { value: T | null };
   const error = ref<Error | null>(null);
   const loading = ref(false);
-  let timer: ReturnType<typeof setInterval> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let active = false;
 
   async function poll() {
     loading.value = true;
@@ -18,19 +19,28 @@ export function usePolling<T>(fetcher: () => Promise<T>, intervalMs = 5000) {
     }
   }
 
+  async function runScheduledPoll() {
+    await poll();
+    if (active) {
+      timer = setTimeout(runScheduledPoll, intervalMs);
+    }
+  }
+
   function start() {
-    poll();
-    timer = setInterval(poll, intervalMs);
+    if (active) return;
+    active = true;
+    void runScheduledPoll();
   }
 
   function stop() {
+    active = false;
     if (timer) {
-      clearInterval(timer);
+      clearTimeout(timer);
       timer = null;
     }
   }
 
-  onUnmounted(stop);
+  onScopeDispose(stop);
 
   return { data, error, loading, start, stop, poll };
 }


### PR DESCRIPTION
## Summary

- replace interval-based polling with completion-based scheduling so slow API calls cannot overlap and amplify backend/AKS load
- make repeated `start()` calls idempotent to prevent leaked timers
- dispose polling with the owning Vue effect scope
- add regression coverage for overlap and shutdown behavior

## Performance audit

| Rank | Improvement | Impact | Effort | Evidence |
|---:|---|---|---|---|
| 1 | Prevent overlapping and duplicate frontend polls (**implemented**) | High | Low | `mission-control/frontend/src/composables/usePolling.ts` |
| 2 | Add RabbitMQ QoS and bounded concurrent dispatch workers instead of serial message processing | High | Medium | `services/dispatch-service/internal/service/service.go:398-414` |
| 3 | Consolidate the five `kubectl` subprocess/API calls made per inventory request | High | Medium | `mission-control/backend/src/services/KubeClient.ts:73-80` |
| 4 | Add short-lived inventory caching and in-flight request coalescing for concurrent callers | High | Medium | `mission-control/backend/src/services/KubeClient.ts:73-105` and inventory consumers |
| 5 | Add HPA policies for meter and dispatch services rather than fixed replica counts | High | Medium | `k8s/base/application.yaml:362-364,487-489`; no HPA manifests present |
| 6 | Compress Mission Control JSON responses | Medium | Low | `mission-control/backend/src/server.ts:29-50` registers CORS/WebSockets but no compression |
| 7 | Consolidate PodGrid's separate pods/events requests into one snapshot poll | Medium | Low | `mission-control/frontend/src/components/PodGrid.vue:85-100` |
| 8 | Index pods/services/events once when building inventory instead of repeatedly filtering full arrays per deployment | Medium | Low | `mission-control/backend/src/services/KubeClient.ts:82-92` |
| 9 | Index pods by labels for endpoint health instead of filtering all pods for every service | Medium | Low | `mission-control/backend/src/services/AnalystKubeQueryService.ts:153-185` |
| 10 | Bound meter-service request bodies to prevent unbounded buffering and allocation under load | Medium | Low | `services/meter-service/src/index.js:120-132` |

Rank 1 was selected because it removes an unbounded load-amplification path in a shared utility with a small, isolated change and no dependency additions.

## Validation

- `npm test -w frontend`
- `npm run lint -w frontend`
- `npm run build -w frontend`