### PR TITLE
Prevent overlapping Mission Control wallboard refreshes

### DIFF
--- a/mission-control/frontend/src/components/MissionWallboard.vue
+++ b/mission-control/frontend/src/components/MissionWallboard.vue
@@ -36,7 +36,7 @@
           :aria-busy="inventoryLoading"
           :disabled="inventoryLoading"
           :title="inventoryLoading ? 'Refreshing Mission Control data' : 'Refresh Mission Control data'"
-          @click="refreshAll"
+          @click="refreshPoller.poll"
         >
           Refresh
         </button>
@@ -536,6 +536,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useApi } from '@/composables/useApi';
+import { usePolling } from '@/composables/usePolling';
 import { useWebSocket } from '@/composables/useWebSocket';
 import { buildMitigationEvidenceRequest } from '@/utils/reviewModeMitigation';
 import PortalValidation from './PortalValidation.vue';
@@ -684,7 +685,6 @@ const MAX_CONTEXT_RESOURCES = 6;
 const MAX_CONTEXT_ENDPOINTS = 6;
 const MAX_CONTEXT_PUBLIC_LINKS = 4;
 
-let refreshTimer: ReturnType<typeof setInterval> | null = null;
 let destroyCountdownTimer: ReturnType<typeof setInterval> | null = null;
 
 const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -794,6 +794,8 @@ async function refreshAll() {
   await loadMitigationEvidence();
   inventoryLoading.value = false;
 }
+
+const refreshPoller = usePolling(refreshAll, 5000);
 
 async function loadInventory(): Promise<boolean> {
   inventoryError.value = '';
@@ -1737,14 +1739,13 @@ function writeStoredBoolean(key: string, value: boolean) {
 }
 
 onMounted(() => {
-  refreshAll();
+  refreshPoller.start();
   runPreflight();
-  refreshTimer = setInterval(refreshAll, 5000);
   document.addEventListener('keydown', handleAnalystDocumentKeydown);
 });
 
 onUnmounted(() => {
-  if (refreshTimer) clearInterval(refreshTimer);
+  refreshPoller.stop();
   clearDestroyCountdown();
   document.removeEventListener('keydown', handleAnalystDocumentKeydown);
 });

--- a/mission-control/frontend/src/composables/usePolling.test.ts
+++ b/mission-control/frontend/src/composables/usePolling.test.ts
@@ -30,3 +30,28 @@ test('scheduled polling waits for the current request to finish', async () => {
   assert.equal(calls, 1);
   scope.stop();
 });
+
+test('manual polls reuse the request already in flight', async () => {
+  let calls = 0;
+  let resolveRequest: (() => void) | undefined;
+  const request = new Promise<void>((resolve) => {
+    resolveRequest = resolve;
+  });
+  const scope = effectScope();
+  const poller = scope.run(() => usePolling(async () => {
+    calls += 1;
+    await request;
+    return calls;
+  }));
+
+  assert.ok(poller);
+  const first = poller.poll();
+  const second = poller.poll();
+
+  assert.equal(first, second);
+  assert.equal(calls, 1);
+
+  resolveRequest?.();
+  await Promise.all([first, second]);
+  scope.stop();
+});

--- a/mission-control/frontend/src/composables/usePolling.ts
+++ b/mission-control/frontend/src/composables/usePolling.ts
@@ -5,35 +5,48 @@ export function usePolling<T>(fetcher: () => Promise<T>, intervalMs = 5000) {
   const error = ref<Error | null>(null);
   const loading = ref(false);
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight: Promise<void> | null = null;
   let active = false;
+  let runId = 0;
 
-  async function poll() {
-    loading.value = true;
-    try {
-      data.value = await fetcher();
-      error.value = null;
-    } catch (e) {
-      error.value = e instanceof Error ? e : new Error(String(e));
-    } finally {
-      loading.value = false;
-    }
+  function poll(): Promise<void> {
+    if (inFlight) return inFlight;
+
+    const request = (async () => {
+      loading.value = true;
+      try {
+        data.value = await fetcher();
+        error.value = null;
+      } catch (e) {
+        error.value = e instanceof Error ? e : new Error(String(e));
+      } finally {
+        loading.value = false;
+      }
+    })();
+    inFlight = request;
+    void request.finally(() => {
+      if (inFlight === request) inFlight = null;
+    });
+    return request;
   }
 
-  async function runScheduledPoll() {
+  async function runScheduledPoll(expectedRunId: number) {
     await poll();
-    if (active) {
-      timer = setTimeout(runScheduledPoll, intervalMs);
+    if (active && runId === expectedRunId) {
+      timer = setTimeout(() => runScheduledPoll(expectedRunId), intervalMs);
     }
   }
 
   function start() {
     if (active) return;
     active = true;
-    void runScheduledPoll();
+    const expectedRunId = ++runId;
+    void runScheduledPoll(expectedRunId);
   }
 
   function stop() {
     active = false;
+    runId += 1;
     if (timer) {
       clearTimeout(timer);
       timer = null;


### PR DESCRIPTION
## Summary

Replace the main wallboard's fixed `setInterval` refresh with the existing completion-aware polling composable, and deduplicate manual refreshes against any request already in flight.

A wallboard refresh includes Kubernetes inventory plus Azure-backed customer-impact and mitigation evidence calls. Those calls can exceed the five-second interval, so the previous timer could start additional refresh batches before the first completed. The new behavior waits five seconds after completion before scheduling the next batch.

## Ranked performance opportunities

| Rank | Improvement | Impact | Effort | Rationale |
|---|---|---|---|---|
| 1 | Prevent overlapping wallboard refresh batches | High | Low | Stops duplicated Kubernetes/Azure requests whenever refresh latency exceeds five seconds. Implemented here. |
| 2 | Add a shared short-lived Kubernetes inventory cache with in-flight deduplication | High | Medium | `/api/inventory`, customer-impact evaluation, and diagnostics can independently collect the same cluster resources. |
| 3 | Pause periodic refresh while the browser tab is hidden | Medium-High | Low | Avoids continuous backend and Azure work when Mission Control is not visible. |
| 4 | Add bounded exponential backoff after repeated refresh failures | Medium-High | Low | Prevents a disconnected or unauthenticated client from retrying expensive commands every five seconds. |
| 5 | Consolidate inventory collection into fewer `kubectl` invocations | High | Medium | Each inventory refresh currently spawns separate processes for deployments, pods, services, events, and endpoints. |
| 6 | Use a persistent Kubernetes API client instead of spawning `kubectl` | High | High | Removes process startup and repeated kubeconfig loading from every request. |
| 7 | Pre-index pods, services, endpoints, and events during inventory assembly | Medium | Low | Avoids repeatedly scanning full arrays for every deployment as the namespace grows. |
| 8 | Lazy-load control-dock panels that are closed by default | Medium | Low | Reduces initial JavaScript parsing and component setup for the primary wallboard view. |
| 9 | Bound or virtualize streamed job output | Medium | Low | Prevents long deploy/destroy sessions from growing `jobLines` and DOM rendering cost indefinitely. |
| 10 | Cancel stale diagnostics requests when the selected resource changes | Medium | Medium | Avoids unnecessary log/endpoint calls and stale rendering during rapid operator navigation. |

## Validation

- Frontend tests: 20 passed
- Frontend type-check: passed
- Frontend production build: passed